### PR TITLE
fix build: Remove pdf2md from packages/workflow pnpm-lock

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,9 +320,6 @@ importers:
       '@llumiverse/core':
         specifier: workspace:*
         version: link:../../llumiverse/core
-      '@opendocsg/pdf2md':
-        specifier: 0.2.0
-        version: 0.2.0
       '@temporalio/activity':
         specifier: ^1.11.5
         version: 1.11.5


### PR DESCRIPTION
* https://github.com/vertesia/composableai/commit/e8e6c10e804eceb58edad197711eb27990d0bce0

Above commit broke the build on github.

Removing pdf2md from matching location in pnpm-lock to fix build.

No functional change. If it builds, it is good to go.