### PR TITLE
feat: support parameter "site" in the Vertesia Client

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -10,7 +10,8 @@
     "scripts": {
         "eslint": "eslint './src/**/*.{jsx,js,tsx,ts}'",
         "build": "pnpm exec tsmod build",
-        "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
+        "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo",
+        "test": "vitest run"
     },
     "devDependencies": {
         "@types/eventsource": "^1.1.14",

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "vitest";
+import { VertesiaClient } from "./client";
+
+describe('Test Vertesia Client', () => {
+    test('Initialization with studio and zeno URLs', () => {
+        const client = new VertesiaClient({
+            serverUrl: 'https://api.vertesia.io',
+            storeUrl: 'https://api.vertesia.io',
+            apikey: '1234',
+        });
+        expect(client).toBeDefined();
+    });
+})

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -10,4 +10,22 @@ describe('Test Vertesia Client', () => {
         });
         expect(client).toBeDefined();
     });
-})
+
+    test('Initialization with studio URL only', () => {
+        expect(() => {
+            new VertesiaClient({
+                serverUrl: 'https://api.vertesia.io',
+                storeUrl: '',
+            });
+        }).toThrowError('storeUrl is required for VertesiaClient');
+    });
+
+    test('Initialization with zeno URL only', () => {
+        expect(() => {
+            new VertesiaClient({
+                serverUrl: '',
+                storeUrl: 'https://api.vertesia.io',
+            });
+        }).toThrowError('serverUrl is required for VertesiaClient');
+    });
+});

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -17,7 +17,7 @@ describe('Test Vertesia Client', () => {
                 serverUrl: 'https://api.vertesia.io',
                 storeUrl: '',
             });
-        }).toThrowError('storeUrl is required for VertesiaClient');
+        }).toThrowError("Parameter 'site' or 'storeUrl' is required for VertesiaClient");
     });
 
     test('Initialization with zeno URL only', () => {
@@ -26,10 +26,10 @@ describe('Test Vertesia Client', () => {
                 serverUrl: '',
                 storeUrl: 'https://api.vertesia.io',
             });
-        }).toThrowError('serverUrl is required for VertesiaClient');
+        }).toThrowError("Parameter 'site' or 'serverUrl' is required for VertesiaClient");
     });
 
-    test('Initialization with site', () => {
+    test('Initialization with same site', () => {
         const client = new VertesiaClient({
             serverUrl: 'https://api.vertesia.io',
             storeUrl: 'https://api.vertesia.io',
@@ -39,5 +39,17 @@ describe('Test Vertesia Client', () => {
         expect(client).toBeDefined();
         expect(client.storeUrl).toBe('https://api.vertesia.io');
         expect(client.baseUrl).toBe('https://api.vertesia.io');
+    });
+
+    test('Initialization with overrides', () => {
+        const client = new VertesiaClient({
+            serverUrl: 'https://studio-server-production.api.becomposable.com',
+            storeUrl: 'https://zeno-server-production.api.becomposable.com',
+            site: 'api.vertesia.io',
+        });
+
+        expect(client).toBeDefined();
+        expect(client.storeUrl).toBe('https://zeno-server-production.api.becomposable.com');
+        expect(client.baseUrl).toBe('https://studio-server-production.api.becomposable.com');
     });
 });

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -37,8 +37,27 @@ describe('Test Vertesia Client', () => {
         });
 
         expect(client).toBeDefined();
-        expect(client.storeUrl).toBe('https://api.vertesia.io');
         expect(client.baseUrl).toBe('https://api.vertesia.io');
+        expect(client.storeUrl).toBe('https://api.vertesia.io');
+    });
+
+    test('Initialization with default parameters', () => {
+        const client = new VertesiaClient();
+
+        expect(client).toBeDefined();
+        expect(client.baseUrl).toBe('https://api.vertesia.io');
+        expect(client.storeUrl).toBe('https://api.vertesia.io');
+    });
+
+    test('Initialization with site localhost', () => {
+        const client = new VertesiaClient({
+            serverUrl: 'http://localhost:8091',
+            storeUrl: 'http://localhost:8092',
+        });
+
+        expect(client).toBeDefined();
+        expect(client.baseUrl).toBe('http://localhost:8091');
+        expect(client.storeUrl).toBe('http://localhost:8092');
     });
 
     test('Initialization with overrides', () => {
@@ -49,7 +68,7 @@ describe('Test Vertesia Client', () => {
         });
 
         expect(client).toBeDefined();
-        expect(client.storeUrl).toBe('https://zeno-server-production.api.becomposable.com');
         expect(client.baseUrl).toBe('https://studio-server-production.api.becomposable.com');
+        expect(client.storeUrl).toBe('https://zeno-server-production.api.becomposable.com');
     });
 });

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -28,4 +28,16 @@ describe('Test Vertesia Client', () => {
             });
         }).toThrowError('serverUrl is required for VertesiaClient');
     });
+
+    test('Initialization with site', () => {
+        const client = new VertesiaClient({
+            serverUrl: 'https://api.vertesia.io',
+            storeUrl: 'https://api.vertesia.io',
+            site: 'api.vertesia.io',
+        });
+
+        expect(client).toBeDefined();
+        expect(client.storeUrl).toBe('https://api.vertesia.io');
+        expect(client.baseUrl).toBe('https://api.vertesia.io');
+    });
 });

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -49,6 +49,26 @@ describe('Test Vertesia Client', () => {
         expect(client.storeUrl).toBe('https://api.vertesia.io');
     });
 
+    test('Initialization with site api-preview.vertesia.io', () => {
+        const client = new VertesiaClient({
+            site: 'api-preview.vertesia.io',
+        });
+
+        expect(client).toBeDefined();
+        expect(client.baseUrl).toBe('https://api-preview.vertesia.io');
+        expect(client.storeUrl).toBe('https://api-preview.vertesia.io');
+    });
+
+    test('Initialization with site api-staging.vertesia.io', () => {
+        const client = new VertesiaClient({
+            site: 'api-staging.vertesia.io',
+        });
+
+        expect(client).toBeDefined();
+        expect(client.baseUrl).toBe('https://api-staging.vertesia.io');
+        expect(client.storeUrl).toBe('https://api-staging.vertesia.io');
+    });
+
     test('Initialization with site localhost', () => {
         const client = new VertesiaClient({
             serverUrl: 'http://localhost:8091',

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -21,9 +21,9 @@ import UsersApi from "./UsersApi.js";
  */
 const EXPIRATION_THRESHOLD = 60000;
 
-export interface VertesiaClientProps {
-    serverUrl: string;
-    storeUrl: string;
+export type VertesiaClientProps = {
+    serverUrl?: string;
+    storeUrl?: string;
     /**
      * The site name of Vertesia.
      *
@@ -60,15 +60,28 @@ export class VertesiaClient extends AbstractFetchClient<VertesiaClient> {
     sessionTags?: string | string[];
 
     constructor(
-        opts: VertesiaClientProps = {} as any
+        opts: VertesiaClientProps = {}
     ) {
-        super(opts.serverUrl);
-        if (!opts.serverUrl) {
-            throw new Error("serverUrl is required for VertesiaClient");
+        let studioServerUrl: string;
+        let zenoServerUrl: string;
+
+        if (opts.serverUrl) {
+            studioServerUrl = opts.serverUrl;
+        } else if (opts.site) {
+            studioServerUrl = `https://${opts.site}`;
+        } else {
+            throw new Error("Parameter 'site' or 'serverUrl' is required for VertesiaClient");
         }
-        if (!opts.storeUrl) {
-            throw new Error("storeUrl is required for VertesiaClient");
+
+        if (opts.storeUrl) {
+            zenoServerUrl = opts.storeUrl;
+        } else if (opts.site) {
+            zenoServerUrl = `https://${opts.site}`;
+        } else {
+            throw new Error("Parameter 'site' or 'storeUrl' is required for VertesiaClient");
         }
+
+        super(studioServerUrl);
         this.store = new ZenoClient({
             serverUrl: opts.storeUrl,
             apikey: opts.apikey,

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -139,10 +139,6 @@ export class VertesiaClient extends AbstractFetchClient<VertesiaClient> {
         return this.store.types;
     }
 
-    get serverUrl() {
-        return this.baseUrl;
-    }
-
     get storeUrl() {
         return this.store.baseUrl;
     }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -24,6 +24,17 @@ const EXPIRATION_THRESHOLD = 60000;
 export interface VertesiaClientProps {
     serverUrl: string;
     storeUrl: string;
+    /**
+     * The site name of Vertesia.
+     *
+     * This is used to determine the API backend. It should not include the protocol.
+     *
+     * @example api.vertesia.io
+     * @example api-preview.vertesia.io
+     * @example api-staging.vertesia.io
+     * @default api.vertesia.io
+     */
+    site?: string;
     apikey?: string;
     projectId?: string;
     sessionTags?: string | string[];
@@ -128,6 +139,13 @@ export class VertesiaClient extends AbstractFetchClient<VertesiaClient> {
         return this.store.types;
     }
 
+    get serverUrl() {
+        return this.baseUrl;
+    }
+
+    get storeUrl() {
+        return this.store.baseUrl;
+    }
 
     set project(projectId: string | null) {
         if (projectId) {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -53,7 +53,7 @@ export class VertesiaClient extends AbstractFetchClient<VertesiaClient> {
     ) {
         super(opts.serverUrl);
         if (!opts.serverUrl) {
-            throw new Error("storeUrl is required for VertesiaClient");
+            throw new Error("serverUrl is required for VertesiaClient");
         }
         if (!opts.storeUrl) {
             throw new Error("storeUrl is required for VertesiaClient");

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -32,6 +32,7 @@ export type VertesiaClientProps = {
      * @example api-preview.vertesia.io
      * @example api-staging.vertesia.io
      * @default api.vertesia.io
+     * @since 0.52.0
      */
     site?: 'api.vertesia.io' | 'api-preview.vertesia.io' | 'api-staging.vertesia.io';
     serverUrl?: string;

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -22,19 +22,20 @@ import UsersApi from "./UsersApi.js";
 const EXPIRATION_THRESHOLD = 60000;
 
 export type VertesiaClientProps = {
-    serverUrl?: string;
-    storeUrl?: string;
     /**
      * The site name of Vertesia.
      *
-     * This is used to determine the API backend. It should not include the protocol.
+     * This is used to determine the API backend. It should not include the protocol. For more
+     * advanced configurations, use `serverUrl` and `storeUrl` instead.
      *
      * @example api.vertesia.io
      * @example api-preview.vertesia.io
      * @example api-staging.vertesia.io
      * @default api.vertesia.io
      */
-    site?: string;
+    site?: 'api.vertesia.io' | 'api-preview.vertesia.io' | 'api-staging.vertesia.io';
+    serverUrl?: string;
+    storeUrl?: string;
     apikey?: string;
     projectId?: string;
     sessionTags?: string | string[];
@@ -60,7 +61,9 @@ export class VertesiaClient extends AbstractFetchClient<VertesiaClient> {
     sessionTags?: string | string[];
 
     constructor(
-        opts: VertesiaClientProps = {}
+        opts: VertesiaClientProps = {
+            site: 'api.vertesia.io',
+        }
     ) {
         let studioServerUrl: string;
         let zenoServerUrl: string;
@@ -82,8 +85,9 @@ export class VertesiaClient extends AbstractFetchClient<VertesiaClient> {
         }
 
         super(studioServerUrl);
+
         this.store = new ZenoClient({
-            serverUrl: opts.storeUrl,
+            serverUrl: zenoServerUrl,
             apikey: opts.apikey,
             onRequest: opts.onRequest,
             onResponse: opts.onResponse


### PR DESCRIPTION
This PR introduces a new parameter "site" for the Vertesia API Client. You can use this to specify which site you want to talk to, which is either for the production environment, preview, or staging. If the site is not specified, it defaults to the production site `api.vertesia.io`.

So in most cases, a developer will use it like this without any parameters:

```ts
const client = new VertesiaClient();
```

Or if he/she wants to switch to the preview or staging environment:

```ts
const client = new VertesiaClient({
    site: 'api-preview.vertesia.io',
});
```

This PR also makes the previous URL parameters optional. If defined, they will take precedence over the "site" parameter. This is mainly useful for local development or custom solutions.

```ts
const client = new VertesiaClient({
    serverUrl: 'http://localhost:8091',
    storeUrl: 'http://localhost:8092',
});
```

```ts
const client = new VertesiaClient({
    serverUrl: 'https://custom-domain.com/studio',
    storeUrl: 'https://custom-domain.com/zeno',
});
```