### PR TITLE
fix: log existing content types using .map

### DIFF
--- a/packages/workflow/src/activities/generateOrAssignContentType.ts
+++ b/packages/workflow/src/activities/generateOrAssignContentType.ts
@@ -77,7 +77,7 @@ export async function generateOrAssignContentType(payload: DSLActivityExecutionP
 
     const fileRef = await getImage();
 
-    log.info("Execute SelectDocumentType interaction on content with \nexisting types: " + existing_types.join(","));
+    log.info("Execute SelectDocumentType interaction on content with \nexisting types: " + existing_types.map(t => t.name).join(","));
 
     const res = await executeInteractionFromActivity(client, interactionName, params, {
         existing_types, content, image: fileRef


### PR DESCRIPTION
Currently existing content types are logging as:
```
Execute SelectDocumentType interaction on content with 
existing types: [object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]
```

Fixed using .map