### PR TITLE
feat: move Embeddings API to top-level

### DIFF
--- a/packages/client/src/store/CommandsApi.ts
+++ b/packages/client/src/store/CommandsApi.ts
@@ -11,5 +11,5 @@ export class CommandsApi extends ApiTopic {
         super(parent, "/api/v1/commands");
     }
 
-    embeddings = new EmbeddingsApi(this);
+    embeddings = new EmbeddingsApi(this, "/embeddings");
 }

--- a/packages/client/src/store/CommandsApi.ts
+++ b/packages/client/src/store/CommandsApi.ts
@@ -1,5 +1,5 @@
 import { ApiTopic, ClientBase } from "@vertesia/api-fetch-client";
-import { EmbeddingsApi } from "./EmbeddingsApi";
+import { EmbeddingsApi } from "./EmbeddingsApi.js";
 
 /**
  * @deprecated use EmbeddingsApi instead

--- a/packages/client/src/store/CommandsApi.ts
+++ b/packages/client/src/store/CommandsApi.ts
@@ -1,7 +1,10 @@
 import { ApiTopic, ClientBase } from "@vertesia/api-fetch-client";
-import { EmbeddingsStatusResponse, GenericCommandResponse, ProjectConfigurationEmbeddings, SupportedEmbeddingTypes } from "@vertesia/common";
+import { EmbeddingsApi } from "./EmbeddingsApi";
 
-
+/**
+ * @deprecated use EmbeddingsApi instead
+ * @see EmbeddingsApi
+ */
 export class CommandsApi extends ApiTopic {
 
     constructor(parent: ClientBase) {
@@ -9,34 +12,4 @@ export class CommandsApi extends ApiTopic {
     }
 
     embeddings = new EmbeddingsApi(this);
-
-}
-
-export class EmbeddingsApi extends ApiTopic {
-
-    constructor(parent: ClientBase) {
-        super(parent, "/embeddings");
-    }
-
-    async status(type: SupportedEmbeddingTypes): Promise<EmbeddingsStatusResponse> {
-        return this.get(type + "/status");
-    }
-
-    async activate(type: SupportedEmbeddingTypes, config: Partial<ProjectConfigurationEmbeddings>): Promise<GenericCommandResponse> {
-
-        if (!config.environment) {
-            throw new Error("Invalid configuration: select environment");
-        }
-
-        return this.post(type + "/enable", { payload: config });
-    }
-
-    async disable(type: SupportedEmbeddingTypes): Promise<GenericCommandResponse> {
-        return this.post(type + "/disable");
-    }
-
-    async recalculate(type: SupportedEmbeddingTypes): Promise<GenericCommandResponse> {
-        return this.post(type + "/recalculate");
-    }
-
 }

--- a/packages/client/src/store/EmbeddingsApi.ts
+++ b/packages/client/src/store/EmbeddingsApi.ts
@@ -11,8 +11,8 @@ import {
  */
 export class EmbeddingsApi extends ApiTopic {
 
-    constructor(parent: ClientBase) {
-        super(parent, "/embeddings");
+    constructor(parent: ClientBase, basePath: string = "/api/v1/embeddings") {
+        super(parent, basePath);
     }
 
     async status(type: SupportedEmbeddingTypes): Promise<EmbeddingsStatusResponse> {

--- a/packages/client/src/store/EmbeddingsApi.ts
+++ b/packages/client/src/store/EmbeddingsApi.ts
@@ -1,5 +1,10 @@
 import { ApiTopic, ClientBase } from "@vertesia/api-fetch-client";
-import { EmbeddingsStatusResponse, GenericCommandResponse, ProjectConfigurationEmbeddings, SupportedEmbeddingTypes } from "@vertesia/common";
+import {
+    EmbeddingsStatusResponse,
+    GenericCommandResponse,
+    ProjectConfigurationEmbeddings,
+    SupportedEmbeddingTypes,
+} from "@vertesia/common";
 
 /**
  * @since 0.52.0

--- a/packages/client/src/store/EmbeddingsApi.ts
+++ b/packages/client/src/store/EmbeddingsApi.ts
@@ -1,0 +1,34 @@
+import { ApiTopic, ClientBase } from "@vertesia/api-fetch-client";
+import { EmbeddingsStatusResponse, GenericCommandResponse, ProjectConfigurationEmbeddings, SupportedEmbeddingTypes } from "@vertesia/common";
+
+/**
+ * @since 0.52.0
+ */
+export class EmbeddingsApi extends ApiTopic {
+
+    constructor(parent: ClientBase) {
+        super(parent, "/embeddings");
+    }
+
+    async status(type: SupportedEmbeddingTypes): Promise<EmbeddingsStatusResponse> {
+        return this.get(type + "/status");
+    }
+
+    async activate(type: SupportedEmbeddingTypes, config: Partial<ProjectConfigurationEmbeddings>): Promise<GenericCommandResponse> {
+
+        if (!config.environment) {
+            throw new Error("Invalid configuration: select environment");
+        }
+
+        return this.post(type + "/enable", { payload: config });
+    }
+
+    async disable(type: SupportedEmbeddingTypes): Promise<GenericCommandResponse> {
+        return this.post(type + "/disable");
+    }
+
+    async recalculate(type: SupportedEmbeddingTypes): Promise<GenericCommandResponse> {
+        return this.post(type + "/recalculate");
+    }
+
+}

--- a/packages/client/src/store/client.ts
+++ b/packages/client/src/store/client.ts
@@ -2,6 +2,7 @@ import { AbstractFetchClient, RequestError } from "@vertesia/api-fetch-client";
 import { BulkOperationPayload, BulkOperationResult } from "@vertesia/common";
 import { AgentsApi } from "./AgentsApi.js";
 import { CommandsApi } from "./CommandsApi.js";
+import { EmbeddingsApi } from "./EmbeddingsApi.js";
 import { ZenoClientNotFoundError } from "./errors.js";
 import { FilesApi } from "./FilesApi.js";
 import { ObjectsApi } from "./ObjectsApi.js";
@@ -62,4 +63,5 @@ export class ZenoClient extends AbstractFetchClient<ZenoClient> {
     commands = new CommandsApi(this);
     agents = new AgentsApi(this);
     collections = new CollectionsApi(this);
+    embeddings = new EmbeddingsApi(this);
 }


### PR DESCRIPTION
Recently, we introduced the Unified API in our backend. We cannot have the same resource path in both Studio and Zeno anymore. Otherwise, it creates some conflicts for the API routes. This PR adds the Embeddings API to the top level to mitigate the problem. The old API is marked as deprecated but it is still present. It will be removed once we have the new endpoints in our production.