### PR TITLE
fix: Populate text field in generateDocumentProperties

### DIFF
--- a/packages/workflow/src/activities/generateDocumentProperties.ts
+++ b/packages/workflow/src/activities/generateDocumentProperties.ts
@@ -1,10 +1,8 @@
 import { log } from "@temporalio/activity";
-import { CreateContentObjectPayload, DSLActivityExecutionPayload, DSLActivitySpec } from "@vertesia/common";
+import { DSLActivityExecutionPayload, DSLActivitySpec } from "@vertesia/common";
 import { setupActivity } from "../dsl/setup/ActivityContext.js";
 import { TruncateSpec } from "../utils/tokens.js";
 import { InteractionExecutionParams, executeInteractionFromActivity } from "./executeInteraction.js";
-import { ContentObject } from "@vertesia/common";
-import { Create } from "sharp";
 
 const INT_EXTRACT_INFORMATION = "sys:ExtractInformation";
 export interface GenerateDocumentPropertiesParams extends InteractionExecutionParams {


### PR DESCRIPTION
* https://github.com/vertesia/studio/issues/1418

Previously the text field was being overwritten causing some issues, then a fix was added which stopped writing to it at all.
This fix writes to the field with fallbacks if there is no text already, solving the overwriting issue while giving some text.

This mostly applies to image content and natural language search of embeddings, so the issue can be more completely addressed by using image embeddings.
* https://github.com/vertesia/studio/issues/1624