### PR TITLE
feat: set search attributes for child workflows

### DIFF
--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -24,6 +24,7 @@
     "license": "Apache-2.0",
     "devDependencies": {
         "@smithy/types": "^3.7.2",
+        "@temporalio/proto": "^1.11.5",
         "@temporalio/testing": "^1.11.5",
         "@temporalio/worker": "^1.11.5",
         "@types/fluent-ffmpeg": "^2.1.27",

--- a/packages/workflow/src/dsl/dsl-workflow.ts
+++ b/packages/workflow/src/dsl/dsl-workflow.ts
@@ -108,7 +108,11 @@ async function startChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWorkfl
             ...payload,
             workflow: step.spec,
             vars: resolvedVars
-        }]
+        }],
+        searchAttributes: {
+            AccountId: [payload.account_id],
+            ProjectId: [payload.project_id],
+        },
     });
     if (step.output) {
         vars.setValue(step.output, handle.workflowId);
@@ -131,7 +135,11 @@ async function executeChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWork
             ...payload,
             workflow: step.spec,
             vars: resolvedVars,
-        }]
+        }],
+        searchAttributes: {
+            AccountId: [payload.account_id],
+            ProjectId: [payload.project_id],
+        },
     });
 
     if (step.output) {

--- a/packages/workflow/src/dsl/dsl-workflow.ts
+++ b/packages/workflow/src/dsl/dsl-workflow.ts
@@ -109,10 +109,10 @@ async function startChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWorkfl
             workflow: step.spec,
             vars: resolvedVars
         }],
-        // searchAttributes: {
-        //     AccountId: [payload.account_id],
-        //     ProjectId: [payload.project_id],
-        // },
+        searchAttributes: {
+            AccountId: [payload.account_id],
+            ProjectId: [payload.project_id],
+        },
     });
     if (step.output) {
         vars.setValue(step.output, handle.workflowId);
@@ -136,10 +136,10 @@ async function executeChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWork
             workflow: step.spec,
             vars: resolvedVars,
         }],
-        // searchAttributes: {
-        //     AccountId: [payload.account_id],
-        //     ProjectId: [payload.project_id],
-        // },
+        searchAttributes: {
+            AccountId: [payload.account_id],
+            ProjectId: [payload.project_id],
+        },
     });
 
     if (step.output) {

--- a/packages/workflow/src/dsl/dsl-workflow.ts
+++ b/packages/workflow/src/dsl/dsl-workflow.ts
@@ -109,10 +109,10 @@ async function startChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWorkfl
             workflow: step.spec,
             vars: resolvedVars
         }],
-        searchAttributes: {
-            AccountId: [payload.account_id],
-            ProjectId: [payload.project_id],
-        },
+        // searchAttributes: {
+        //     AccountId: [payload.account_id],
+        //     ProjectId: [payload.project_id],
+        // },
     });
     if (step.output) {
         vars.setValue(step.output, handle.workflowId);
@@ -136,10 +136,10 @@ async function executeChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWork
             workflow: step.spec,
             vars: resolvedVars,
         }],
-        searchAttributes: {
-            AccountId: [payload.account_id],
-            ProjectId: [payload.project_id],
-        },
+        // searchAttributes: {
+        //     AccountId: [payload.account_id],
+        //     ProjectId: [payload.project_id],
+        // },
     });
 
     if (step.output) {

--- a/packages/workflow/src/dsl/workflow-exec-child.test.ts
+++ b/packages/workflow/src/dsl/workflow-exec-child.test.ts
@@ -87,25 +87,25 @@ const steps2: DSLWorkflowStep[] = [
 // ========== test env setup ==========
 
 
-let testEnv: TestWorkflowEnvironment;
-
-beforeAll(async () => {
-    testEnv = await TestWorkflowEnvironment.createLocal();
-    const { connection } = testEnv;
-    await connection.operatorService.addSearchAttributes({
-        namespace: 'default',
-        searchAttributes: {
-            AccountId: protos.temporal.api.enums.v1.IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
-            ProjectId: protos.temporal.api.enums.v1.IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
-        },
-    });
-});
-
-afterAll(async () => {
-    await testEnv?.teardown();
-});
-
 describe('DSL Workflow with chld workflows', () => {
+
+    let testEnv: TestWorkflowEnvironment;
+
+    beforeAll(async () => {
+        testEnv = await TestWorkflowEnvironment.createLocal();
+        const { connection } = testEnv;
+        await connection.operatorService.addSearchAttributes({
+            namespace: 'default',
+            searchAttributes: {
+                AccountId: protos.temporal.api.enums.v1.IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
+                ProjectId: protos.temporal.api.enums.v1.IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
+            },
+        });
+    });
+
+    afterAll(async () => {
+        await testEnv?.teardown();
+    });
 
     test('execute child workflow', async () => {
         const { client, nativeConnection } = testEnv;

--- a/packages/workflow/src/dsl/workflow-exec-child.test.ts
+++ b/packages/workflow/src/dsl/workflow-exec-child.test.ts
@@ -1,10 +1,10 @@
-import { ContentEventName, DSLActivityExecutionPayload, DSLWorkflowExecutionPayload, DSLWorkflowStep } from '@vertesia/common';
+import * as protos from '@temporalio/proto';
 import { TestWorkflowEnvironment } from '@temporalio/testing';
 import { Worker } from '@temporalio/worker';
+import { ContentEventName, DSLActivityExecutionPayload, DSLWorkflowExecutionPayload, DSLWorkflowStep } from '@vertesia/common';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import { dslWorkflow } from './dsl-workflow.js';
 import { setupActivity } from './setup/ActivityContext.js';
-import * as protos from '@temporalio/proto';
 
 interface SayHelloParams {
     name: string;

--- a/packages/workflow/src/dsl/workflow-exec-child.test.ts
+++ b/packages/workflow/src/dsl/workflow-exec-child.test.ts
@@ -4,6 +4,7 @@ import { Worker } from '@temporalio/worker';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import { dslWorkflow } from './dsl-workflow.js';
 import { setupActivity } from './setup/ActivityContext.js';
+import * as protos from '@temporalio/proto';
 
 interface SayHelloParams {
     name: string;
@@ -90,6 +91,14 @@ let testEnv: TestWorkflowEnvironment;
 
 beforeAll(async () => {
     testEnv = await TestWorkflowEnvironment.createLocal();
+    const { connection } = testEnv;
+    await connection.operatorService.addSearchAttributes({
+        namespace: 'default',
+        searchAttributes: {
+            AccountId: protos.temporal.api.enums.v1.IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
+            ProjectId: protos.temporal.api.enums.v1.IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
+        },
+    });
 });
 
 afterAll(async () => {

--- a/packages/workflow/src/dsl/workflow-exec-child.test.ts
+++ b/packages/workflow/src/dsl/workflow-exec-child.test.ts
@@ -86,17 +86,17 @@ const steps2: DSLWorkflowStep[] = [
 // ========== test env setup ==========
 
 
+let testEnv: TestWorkflowEnvironment;
+
+beforeAll(async () => {
+    testEnv = await TestWorkflowEnvironment.createLocal();
+});
+
+afterAll(async () => {
+    await testEnv?.teardown();
+});
+
 describe('DSL Workflow with chld workflows', () => {
-
-    let testEnv: TestWorkflowEnvironment;
-
-    beforeAll(async () => {
-        testEnv = await TestWorkflowEnvironment.createLocal();
-    });
-
-    afterAll(async () => {
-        await testEnv?.teardown();
-    });
 
     test('execute child workflow', async () => {
         const { client, nativeConnection } = testEnv;

--- a/packages/workflow/src/dsl/workflow.test.ts
+++ b/packages/workflow/src/dsl/workflow.test.ts
@@ -45,18 +45,18 @@ const activities: DSLActivitySpec[] = [
 
 // ========== test env setup ==========
 
+let testEnv: TestWorkflowEnvironment;
+
+beforeAll(async () => {
+    testEnv = await TestWorkflowEnvironment.createLocal();
+});
+
+afterAll(async () => {
+    await testEnv?.teardown();
+});
 
 describe('DSL Workflow', () => {
 
-    let testEnv: TestWorkflowEnvironment;
-
-    beforeAll(async () => {
-        testEnv = await TestWorkflowEnvironment.createLocal();
-    });
-
-    afterAll(async () => {
-        await testEnv?.teardown();
-    });
 
     it('successfully completes a mock workflow', async () => {
         const { client, nativeConnection } = testEnv;

--- a/packages/workflow/src/dsl/workflow.test.ts
+++ b/packages/workflow/src/dsl/workflow.test.ts
@@ -46,26 +46,26 @@ const activities: DSLActivitySpec[] = [
 
 // ========== test env setup ==========
 
-let testEnv: TestWorkflowEnvironment;
-
-beforeAll(async () => {
-    testEnv = await TestWorkflowEnvironment.createLocal();
-    const { connection } = testEnv;
-    await connection.operatorService.addSearchAttributes({
-        namespace: 'default',
-        searchAttributes: {
-            AccountId: protos.temporal.api.enums.v1.IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
-            ProjectId: protos.temporal.api.enums.v1.IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
-        },
-    });
-});
-
-afterAll(async () => {
-    await testEnv?.teardown();
-});
 
 describe('DSL Workflow', () => {
 
+    let testEnv: TestWorkflowEnvironment;
+
+    beforeAll(async () => {
+        testEnv = await TestWorkflowEnvironment.createLocal();
+        const { connection } = testEnv;
+        await connection.operatorService.addSearchAttributes({
+            namespace: 'default',
+            searchAttributes: {
+                AccountId: protos.temporal.api.enums.v1.IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
+                ProjectId: protos.temporal.api.enums.v1.IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
+            },
+        });
+    });
+
+    afterAll(async () => {
+        await testEnv?.teardown();
+    });
 
     it('successfully completes a mock workflow', async () => {
         const { client, nativeConnection } = testEnv;

--- a/packages/workflow/src/dsl/workflow.test.ts
+++ b/packages/workflow/src/dsl/workflow.test.ts
@@ -51,13 +51,13 @@ let testEnv: TestWorkflowEnvironment;
 beforeAll(async () => {
     testEnv = await TestWorkflowEnvironment.createLocal();
     const { connection } = testEnv;
-        await connection.operatorService.addSearchAttributes({
-            namespace: 'default',
-            searchAttributes: {
-                AccountId: protos.temporal.api.enums.v1.IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
-                ProjectId: protos.temporal.api.enums.v1.IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
-            },
-        });
+    await connection.operatorService.addSearchAttributes({
+        namespace: 'default',
+        searchAttributes: {
+            AccountId: protos.temporal.api.enums.v1.IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
+            ProjectId: protos.temporal.api.enums.v1.IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
+        },
+    });
 });
 
 afterAll(async () => {

--- a/packages/workflow/src/dsl/workflow.test.ts
+++ b/packages/workflow/src/dsl/workflow.test.ts
@@ -1,6 +1,7 @@
-import { ContentEventName, DSLActivityExecutionPayload, DSLActivitySpec, DSLWorkflowExecutionPayload } from '@vertesia/common';
+import * as protos from '@temporalio/proto';
 import { TestWorkflowEnvironment } from '@temporalio/testing';
 import { Worker } from '@temporalio/worker';
+import { ContentEventName, DSLActivityExecutionPayload, DSLActivitySpec, DSLWorkflowExecutionPayload } from '@vertesia/common';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { dslWorkflow } from './dsl-workflow.js';
 import { setupActivity } from "./setup/ActivityContext.js";
@@ -49,6 +50,14 @@ let testEnv: TestWorkflowEnvironment;
 
 beforeAll(async () => {
     testEnv = await TestWorkflowEnvironment.createLocal();
+    const { connection } = testEnv;
+        await connection.operatorService.addSearchAttributes({
+            namespace: 'default',
+            searchAttributes: {
+                AccountId: protos.temporal.api.enums.v1.IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
+                ProjectId: protos.temporal.api.enums.v1.IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
+            },
+        });
 });
 
 afterAll(async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -395,6 +395,9 @@ importers:
       '@smithy/types':
         specifier: ^3.7.2
         version: 3.7.2
+      '@temporalio/proto':
+        specifier: ^1.11.5
+        version: 1.11.7
       '@temporalio/testing':
         specifier: ^1.11.5
         version: 1.11.7


### PR DESCRIPTION
## Description

This PR sets the search attributes "AccountId" and "ProjectId" to child workflows, allowing them to be searchable using these attributes.

## Additional Notes

https://community.temporal.io/t/how-to-define-custom-search-attribute-in-a-typescript-test-environment/10589