### PR TITLE
feat: adds matchInteractions property to prompt search query

### DIFF
--- a/packages/common/src/query.ts
+++ b/packages/common/src/query.ts
@@ -48,6 +48,7 @@ export interface ObjectTypeSearchQuery extends SimpleSearchQuery {
 
 export interface PromptSearchQuery extends SimpleSearchQuery {
     role?: string;
+    matchInteractions?: boolean;
 }
 
 export interface InteractionSearchQuery extends SimpleSearchQuery {


### PR DESCRIPTION
This is necessary to make matching prompts with interactions optional.

* https://github.com/vertesia/studio/pull/1768