### PR TITLE
feat: allow interaction to be an array in run listing query

### DIFF
--- a/packages/common/src/query.ts
+++ b/packages/common/src/query.ts
@@ -3,14 +3,14 @@ import { SupportedEmbeddingTypes } from './project.js';
 
 export interface RunListingQueryOptions {
     project?: string;
-    interaction?: string;
+    interaction?: string | string[];
     limit?: number;
     offset?: number;
     filters?: RunListingFilters;
 }
 
 export interface RunListingFilters {
-    interaction?: string,
+    interaction?: string | string[],
     status?: ExecutionRunStatus,
     model?: string,
     environment?: string,


### PR DESCRIPTION
Used to pass multiple interaction to the endpoint at once.

We are using this to list multiple versions of an interaction at once.

* https://github.com/vertesia/studio/pull/1819