### PR TITLE
chore: spell check

### DIFF
--- a/packages/api-fetch-client/src/base.ts
+++ b/packages/api-fetch-client/src/base.ts
@@ -9,13 +9,13 @@ export interface IRequestParams {
     query?: Record<string, IPrimitives> | null;
     headers?: Record<string, string> | null;
     /*
-     * custom response reader. The default is to read a JSON objectusing the jsonParse method
+     * custom response reader. The default is to read a JSON object using the jsonParse method
      * The reader function is called with the client as the `this` context
      * This can be an async function (i.e. return a promise). If a promise is returned
      * it will wait for the promise to resolve before returning the result
      *
      * If set to 'sse' the response will be treated as a server-sent event stream
-     * and the requets will return a Promise<ReadableStream<ServerSentEvent>> object
+     * and the request will return a Promise<ReadableStream<ServerSentEvent>> object
      */
     reader?: 'sse' | ((response: Response) => any);
     /**
@@ -145,7 +145,7 @@ export abstract class ClientBase {
         }).catch((err) => {
             return {
                 status: res.status,
-                error: "Unable to load repsonse content",
+                error: "Unable to load response content",
                 message: err.message,
             };
         });

--- a/packages/api-fetch-client/src/client.ts
+++ b/packages/api-fetch-client/src/client.ts
@@ -10,7 +10,7 @@ export class AbstractFetchClient<T extends AbstractFetchClient<T>> extends Clien
 
     headers: Record<string, string>;
     _auth?: () => Promise<string>;
-    // callbacks usefull to log requests and responses
+    // callbacks useful to log requests and responses
     onRequest?: (req: Request) => void;
     onResponse?: (res: Response, req: Request) => void;
     // the last response. Can be used to inspect the response headers
@@ -28,7 +28,7 @@ export class AbstractFetchClient<T extends AbstractFetchClient<T>> extends Clien
 
     /**
      * Install an auth callback. If the callback is undefined or null then remove the auth callback.
-     * @param authCb a fucntion returning a promise that resolves to the value to use for the authorization header
+     * @param authCb a function returning a promise that resolves to the value to use for the authorization header
      * @returns the client instance
      */
     withAuthCallback(authCb?: (() => Promise<string>) | null) {
@@ -85,7 +85,7 @@ export class AbstractFetchClient<T extends AbstractFetchClient<T>> extends Clien
     }
 
     async handleResponse(req: Request, res: Response, params: IRequestParamsWithPayload | undefined): Promise<any> {
-        this.response = res; // store last repsonse
+        this.response = res; // store last response
         this.onResponse && this.onResponse(res, req);
         return super.handleResponse(req, res, params);
     }

--- a/packages/api-fetch-client/src/sse/EventSourceParserStream.ts
+++ b/packages/api-fetch-client/src/sse/EventSourceParserStream.ts
@@ -2,7 +2,7 @@ import { createParser, ReconnectInterval, type EventSourceParser, type ParsedEve
 
 /**
  * We copied this file from the eventsource-parser/stream package and made it a part of our project.
- * because importing the eventsource-parser/stream breaks tsc build when buuilding the commonjs version
+ * because importing the eventsource-parser/stream breaks tsc build when building the commonjs version
  * see for a similar error: 
  * https://stackoverflow.com/questions/77280140/why-typescript-dont-see-exports-of-package-with-module-commonjs-and-moduleres
  */

--- a/packages/api-fetch-client/src/sse/TextDecoderStream.ts
+++ b/packages/api-fetch-client/src/sse/TextDecoderStream.ts
@@ -1,7 +1,7 @@
 /**
  * Decode a stream of bytes into a stream of characters.
  * Some javascript env like Bun.js doesn't supports the TextDecoderStream (as for jan 2024)
- * This is a polyfill for bunjs
+ * This is a polyfill for bunJS
  */
 let _TextDecoderStream: typeof TextDecoderStream;
 if (globalThis.TextDecoderStream && typeof globalThis.TextDecoderStream === 'function') {

--- a/packages/cli/src/agent/docker.ts
+++ b/packages/cli/src/agent/docker.ts
@@ -9,7 +9,7 @@ import { AgentProject } from "./project.js";
 
 const LOCAL_DOCKER_CONFIG_DIR = '.docker';
 
-export function genrateDockerConfig() {
+export function generateDockerConfig() {
     return JSON.stringify({
         "credHelpers": {
             "us-central1-docker.pkg.dev": "vertesia"

--- a/packages/cli/src/agent/index.ts
+++ b/packages/cli/src/agent/index.ts
@@ -20,7 +20,7 @@ export function registerAgentCommand(program: Command) {
     agent.command("publish <version>")
         .description("Deploy a custom workflow worker. The user will be asked for a target image version.")
         .option("-d, --dir [project_dir]", "Use this as the current directory.")
-        .option("--push-only", "If used the docker image will be push only. The deoloyment will not be triggered.")
+        .option("--push-only", "If used the docker image will be push only. The deployment will not be triggered.")
         .option("--deploy-only", "If used the docker is assumed to be already pushed and only the deploy will be triggered.")
         .option("--verbose", "Print more information.")
         //.option("-p, --profile [profile]", "The profile name to use. If not specified the one from the package.json will be used.")

--- a/packages/cli/src/agent/project.ts
+++ b/packages/cli/src/agent/project.ts
@@ -57,7 +57,7 @@ export class PackageJson implements AgentPackageJson {
         return this.data.vertesia.profile;
     }
 
-    set proffile(value: string) {
+    set profile(value: string) {
         this.data.vertesia.profile = value;
     }
 

--- a/packages/cli/src/agent/refresh.ts
+++ b/packages/cli/src/agent/refresh.ts
@@ -3,7 +3,7 @@ import { config, Profile, shouldRefreshProfileToken } from "../profiles/index.js
 import { ConfigResult } from "../profiles/server/index.js";
 import { AgentProject } from "./project.js";
 
-export function tryRrefreshProjectToken(project: AgentProject): Promise<ConfigResult | undefined> {
+export function tryRefreshProjectToken(project: AgentProject): Promise<ConfigResult | undefined> {
     const profileName = project.packageJson.vertesia?.profile;
     if (!profileName) {
         console.error('No vertesia.profile entry found in package.json');
@@ -14,24 +14,24 @@ export function tryRrefreshProjectToken(project: AgentProject): Promise<ConfigRe
         console.error('No such profile exists: ' + profileName);
         process.exit(1);
     }
-    return tryRrefreshToken(profile);
+    return tryRefreshToken(profile);
 }
 
-export function tryRrefreshToken(profile: Profile): Promise<ConfigResult | undefined> {
+export function tryRefreshToken(profile: Profile): Promise<ConfigResult | undefined> {
     // Create abort controller for cancellation
     const abortController = new AbortController();
-    
+
     // Set up signal handler
     const handleSignal = () => {
         abortController.abort();
         console.log("\nToken refresh interrupted");
         process.exit(0);
     };
-    
+
     // Register signal handlers
     process.on('SIGINT', handleSignal);
     process.on('SIGTERM', handleSignal);
-    
+
     return new Promise<ConfigResult | undefined>((resolve) => {
         // If token doesn't need refresh, resolve immediately
         if (!shouldRefreshProfileToken(profile, 10)) {
@@ -40,16 +40,16 @@ export function tryRrefreshToken(profile: Profile): Promise<ConfigResult | undef
             resolve(undefined);
             return;
         }
-        
+
         console.log("Refreshing auth token for profile:", profile.name);
-        
+
         // Create a callback that cleans up signal handlers
         const wrappedResolve = (result: ConfigResult | undefined) => {
             process.off('SIGINT', handleSignal);
             process.off('SIGTERM', handleSignal);
             resolve(result);
         };
-        
+
         // Start the update with our wrapped resolver
         updateProfile(profile.name, wrappedResolve, abortController.signal);
     });

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -6,7 +6,7 @@ import { config, Profile } from "./profiles/index.js";
 let _client: VertesiaClient | undefined;
 //TODO remove program?
 export function getClient(_program?: Command) {
-    //TODO use program -p ioption to get the profile?
+    //TODO use program -p option to get the profile?
     if (!_client) {
         _client = createClient(config.current);
     }

--- a/packages/cli/src/datagen/index.ts
+++ b/packages/cli/src/datagen/index.ts
@@ -1,13 +1,13 @@
 import { Command } from "commander";
 import { resolve } from "path";
 import { getClient } from "../client.js";
-import { Spinner, restoreCursotOnExit } from "../utils/console.js";
+import { Spinner, restoreCursorOnExit } from "../utils/console.js";
 import { writeJsonFile } from "../utils/stdio.js";
 import { ConfigModes } from "@vertesia/common";
 import { TextFallbackOptions } from "../../../../llumiverse/core/src/options.js";
 
 function convertConfigMode(raw_config_mode: any): ConfigModes | undefined {
-    const configStr: string =  typeof raw_config_mode === 'string' ? raw_config_mode.toUpperCase() : "";
+    const configStr: string = typeof raw_config_mode === 'string' ? raw_config_mode.toUpperCase() : "";
     return Object.values(ConfigModes).includes(configStr as ConfigModes) ? configStr as ConfigModes : undefined;
 }
 
@@ -17,30 +17,30 @@ export function genTestData(program: Command, interactionId: string, options: Re
     const output = options.output || undefined;
     const spinner = new Spinner('dots');
     spinner.prefix = "Generating data. Please be patient ";
-    
+
     // Create abort controller for handling interruption
     const abortController = new AbortController();
     const { signal } = abortController;
-    
+
     // Set up cleanup function
     const cleanup = () => {
         spinner.done(false);
         console.log("\nData generation interrupted");
         process.exit(0);
     };
-    
+
     // Set up signal handlers
     const handleSignal = () => {
         abortController.abort();
         cleanup();
     };
-    
+
     process.on('SIGINT', handleSignal);
     process.on('SIGTERM', handleSignal);
-    
+
     spinner.start();
 
-   //TODO: Support for other modalities, like images
+    //TODO: Support for other modalities, like images
     const model_options: TextFallbackOptions = {
         _option_id: "text-fallback",
         temperature: typeof options.temperature === 'string' ? parseFloat(options.temperature) : undefined,
@@ -51,7 +51,7 @@ export function genTestData(program: Command, interactionId: string, options: Re
         frequency_penalty: typeof options.frequencyPenalty === 'string' ? parseFloat(options.frequencyPenalty) : undefined,
         stop_sequence: options.stopSequence ? options.stopSequence.trim().split(/\s*,\s*/) : undefined,
     };
-    
+
     getClient(program).interactions.generateTestData(interactionId, {
         count,
         message,
@@ -67,7 +67,7 @@ export function genTestData(program: Command, interactionId: string, options: Re
         // Remove signal handlers
         process.off('SIGINT', handleSignal);
         process.off('SIGTERM', handleSignal);
-        
+
         spinner.done();
         if (output) {
             const file = resolve(output);
@@ -80,15 +80,15 @@ export function genTestData(program: Command, interactionId: string, options: Re
         // Remove signal handlers
         process.off('SIGINT', handleSignal);
         process.off('SIGTERM', handleSignal);
-        
+
         // Don't show error if aborted
         if (signal.aborted) {
             return;
         }
-        
+
         spinner.done(false);
         console.log('Failed to generate data:', err.message);
     });
 }
 
-restoreCursotOnExit();
+restoreCursorOnExit();

--- a/packages/cli/src/envs/index.ts
+++ b/packages/cli/src/envs/index.ts
@@ -4,7 +4,7 @@ import { ExecutionEnvironment } from "@vertesia/common";
 import colors from "ansi-colors";
 
 
-export function listEnvirnments(program: Command, envId: string | undefined, options: Record<string, any>) {
+export function listEnvironments(program: Command, envId: string | undefined, options: Record<string, any>) {
     if (envId) {
         getClient(program).environments.retrieve(envId).then((env) => {
             printEnv(env, options);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,12 +3,12 @@ import { Command } from 'commander';
 import { registerAgentCommand } from './agent/index.js';
 import runExport from './codegen/index.js';
 import { genTestData } from './datagen/index.js';
-import { listEnvirnments } from './envs/index.js';
+import { listEnvironments } from './envs/index.js';
 import { listInteractions } from './interactions/index.js';
 import { getPublishMemoryAction } from './memory/index.js';
 import { registerObjectsCommand } from './objects/index.js';
 import { getVersion, upgrade } from './package.js';
-import { createProfile, deleteProfile, listProfiles, showActiveAuthToken, showProfile, tryRrefreshToken, updateCurrentProfile, updateProfile, useProfile } from './profiles/commands.js';
+import { createProfile, deleteProfile, listProfiles, showActiveAuthToken, showProfile, tryRefreshToken, updateCurrentProfile, updateProfile, useProfile } from './profiles/commands.js';
 import { getConfigFile } from './profiles/index.js';
 import { listProjects } from './projects/index.js';
 import runInteraction from './run/index.js';
@@ -49,7 +49,7 @@ authRoot.command("refresh")
 program.command("envs [envId]")
     .description("List the environments you have access to")
     .action((envId: string | undefined, options: Record<string, any>) => {
-        listEnvirnments(program, envId, options);
+        listEnvironments(program, envId, options);
     })
 program.command("interactions [interaction]")
     .description("List the interactions available in the current project")
@@ -85,7 +85,7 @@ program.command("run <interaction>")
     .description("Run an interaction by full name. The full name is composed by an optional namespace, a required endpoint name and an optional tag or version. Examples: name, namespace:name, namespace:name@version")
     .option('-i, --input [file]', 'The input data if any. If no file path is specified it will read from stdin')
     .option('-o, --output [file]', 'The output file if any. If not specified it will print to stdout')
-    .option('-d, --data [json]', 'Inline data as a JSON string. If specified takes precendence over --input')
+    .option('-d, --data [json]', 'Inline data as a JSON string. If specified takes precedence over --input')
     .option('-T, --tags [tags]', 'A comma separated list of tags to add to the execution run')
     .option('-t, --temperature [temperature]', 'The temperature to use')
     .option('--max-tokens [max-tokens]', 'The maximum number of tokens to generate')
@@ -185,7 +185,7 @@ program.parseAsync(process.argv).catch(err => {
 
 process.on("unhandledRejection", (err: any) => {
     if (err.status === 401) { // token expired?
-        console.error("ERROROR", err);
-        tryRrefreshToken();
+        console.error("ERROR", err);
+        tryRefreshToken();
     }
 })

--- a/packages/cli/src/objects/commands.ts
+++ b/packages/cli/src/objects/commands.ts
@@ -44,8 +44,8 @@ async function listFilesInDirectory(dir: string, recursive = false): Promise<str
     return await readdir(dir, {
         withFileTypes: true,
         recursive,
-    }).then((ents: Dirent[]) => ents.filter(ent => {
-        // eclude hidden files and include only file with extensions
+    }).then((entries: Dirent[]) => entries.filter(ent => {
+        // exclude hidden files and include only file with extensions
         return ent.isFile() && ent.name.lastIndexOf('.') > 0;
     }).map(ent => join(ent.path || '', ent.name)));
 }

--- a/packages/cli/src/objects/index.ts
+++ b/packages/cli/src/objects/index.ts
@@ -31,9 +31,9 @@ export function registerObjectsCommand(program: Command) {
             getObject(program, objectId, options);
         });
     store.command('list [folderPath]')
-        .description("List the objects inside a folder. If no folder is specified all the obejcts are listed.")
-        .option('-l,--limit [limit]', 'Limit the number of objects returned. The default limit is 100. Usefull for pagination.')
-        .option('-s,--skip [skip]', 'Skip the number of objects to skip. Default is 0. Usefull for pagination.')
+        .description("List the objects inside a folder. If no folder is specified all the objects are listed.")
+        .option('-l,--limit [limit]', 'Limit the number of objects returned. The default limit is 100. Useful for pagination.')
+        .option('-s,--skip [skip]', 'Skip the number of objects to skip. Default is 0. Useful for pagination.')
         .action((folderPath: string | undefined, options: Record<string, any>) => {
             listObjects(program, folderPath, options);
         });

--- a/packages/cli/src/profiles/commands.ts
+++ b/packages/cli/src/profiles/commands.ts
@@ -68,7 +68,7 @@ export function showActiveAuthToken() {
             console.log(config.current.apikey);
         }
     } else {
-        console.log('No profile is selected. Run `vertesia auth refresh` to refrehs the token');
+        console.log('No profile is selected. Run `vertesia auth refresh` to refresh the token');
     }
 }
 
@@ -185,7 +185,7 @@ async function selectProfile(message = "Select the profile") {
     return response.name as string;
 }
 
-export async function tryRrefreshToken() {
+export async function tryRefreshToken() {
     if (!config.current) {
         console.log("No profile is selected. Run `vertesia profiles use <name>` to select a profile");
         process.exit(1);

--- a/packages/cli/src/workflows/commands.ts
+++ b/packages/cli/src/workflows/commands.ts
@@ -11,7 +11,7 @@ import { streamRun } from "./streams.js";
 export async function createWorkflowRule(program: Command, options: Record<string, any>) {
     const { name, on, run, inputType } = options;
     if (!name) {
-        console.log("A name for the worklow is required. Use --name argument");
+        console.log("A name for the workflow is required. Use --name argument");
         process.exit(1);
     }
     if (!on) {

--- a/packages/cli/src/workflows/index.ts
+++ b/packages/cli/src/workflows/index.ts
@@ -104,7 +104,7 @@ export function registerWorkflowsCommand(program: Command) {
         .description("Transpile a typescript workflow definition to JSON.")
         .option(
             "-o, --out [file]",
-            "An output file or directory. When multiple files are specified it must be a directory. If not specified the transpiled files are printed to stdoud.",
+            "An output file or directory. When multiple files are specified it must be a directory. If not specified the transpiled files are printed to stdout.",
         )
         .action(async (files: string[], options: Record<string, any>) => {
             await transpileWorkflow(program, files, options);

--- a/packages/client/src/ApiKeysApi.ts
+++ b/packages/client/src/ApiKeysApi.ts
@@ -50,7 +50,7 @@ export class ApiKeysApi extends ApiTopic {
     }
 
     /**
-     * get or create a temporary public key which can be used from browser to browse and execute itneractions.
+     * get or create a temporary public key which can be used from browser to browse and execute interactions.
      * If a public key already exists for the given project (or for the current organization) then it is returned, otherwise a new one is created.
      * The payload object can contain the following properties:
      * - name: the name of the public key. If not specified a random name is generated.

--- a/packages/client/src/EnvironmentsApi.ts
+++ b/packages/client/src/EnvironmentsApi.ts
@@ -34,8 +34,8 @@ export default class EnvironmentsApi extends ApiTopic {
     }
 
     /**
-     * udpate enabled models and / or config. If enabled_models is not provided, the existing enabled models will not change.
-     * Same, if config is not provioded the exiting config is not changed.
+     * Update enabled models and / or config. If enabled_models is not provided, the existing enabled models will not change.
+     * Same, if config is not provided the exiting config is not changed.
      * If the config is provided then it will be updated without removing fields that are not provided.
      *
      * @param id

--- a/packages/client/src/InteractionBase.ts
+++ b/packages/client/src/InteractionBase.ts
@@ -31,7 +31,7 @@ export class InteractionBase<P = any, R = any> {
      * the run completes or fails.
      * If the onChunk callback is passed then the streaming of the result is enabled.
      * The onChunk callback with be called with the next chunk of the result as soon as it is available.
-     * When all chunks are received the fucntion will return the resolved promise
+     * When all chunks are received the function will return the resolved promise
      * @param id of the interaction to execute
      * @param payload InteractionExecutionPayload
      * @param onChunk callback to be called when the next chunk of the response is available

--- a/packages/client/src/InteractionsApi.ts
+++ b/packages/client/src/InteractionsApi.ts
@@ -32,7 +32,7 @@ export default class InteractionsApi extends ApiTopic {
         });
     }
     /**
-     * Find interractions given a mongo match query.
+     * Find interactions given a mongo match query.
      * You can also specify if prompts schemas are included in the result
      */
     listEndpoints(payload: InteractionEndpointQuery): Promise<InteractionRef[]> {
@@ -92,7 +92,7 @@ export default class InteractionsApi extends ApiTopic {
     }
 
     /**
-     * Retrieve an existing interaction definiton
+     * Retrieve an existing interaction definition
      * @param id of the interaction to retrieve
      * @returns Interaction
      **/
@@ -101,7 +101,7 @@ export default class InteractionsApi extends ApiTopic {
     }
 
     /**
-     * Update an existing interaction definiton
+     * Update an existing interaction definition
      * @param id of the interaction to update
      * @param payload InteractionUpdatePayload
      * @returns Interaction
@@ -121,7 +121,7 @@ export default class InteractionsApi extends ApiTopic {
      * the run completes or fails.
      * If the onChunk callback is passed then the streaming of the result is enabled.
      * The onChunk callback with be called with the next chunk of the result as soon as it is available.
-     * When all chunks are received the fucntion will return the resolved promise
+     * When all chunks are received the function will return the resolved promise
      * @param id of the interaction to execute
      * @param payload InteractionExecutionPayload
      * @param onChunk callback to be called when the next chunk of the response is available
@@ -146,7 +146,7 @@ export default class InteractionsApi extends ApiTopic {
     /**
      * Same as execute but uses the interaction name selector instead of the id.
      *
-     * A name selector is the interaction endpoint name suffuxed with an optional tag or version wich is starting with a `@` character.
+     * A name selector is the interaction endpoint name suffixed with an optional tag or version which is starting with a `@` character.
      * The special `draft` tag is used to select the draft version of the interaction. If no tag or version is specified then the latest version is selected.
      * Examples of selectors:
      * - `ReviewContract` - select the latest version of the ReviewContract interaction

--- a/packages/client/src/ProjectsApi.ts
+++ b/packages/client/src/ProjectsApi.ts
@@ -1,5 +1,5 @@
 import { ApiTopic, ClientBase } from "@vertesia/api-fetch-client";
-import { AwsConfiguration, GithubConfiguration, GladiaConfiguration, ICreateProjectPayload, MacgicPdfConfiguration, Project, ProjectIntegrationListEntry, ProjectRef, SupportedIntegrations } from "@vertesia/common";
+import { AwsConfiguration, GithubConfiguration, GladiaConfiguration, ICreateProjectPayload, MagicPdfConfiguration, Project, ProjectIntegrationListEntry, ProjectRef, SupportedIntegrations } from "@vertesia/common";
 
 export default class ProjectsApi extends ApiTopic {
     constructor(parent: ClientBase) {
@@ -40,7 +40,7 @@ class IntegrationsConfigurationApi extends ApiTopic {
         return this.get(`/${projectId}/integrations`).then(res => res.integrations);
     }
 
-    retrieve(projectId: string, integrationId: SupportedIntegrations): Promise<GladiaConfiguration | GithubConfiguration | AwsConfiguration | MacgicPdfConfiguration | undefined> {
+    retrieve(projectId: string, integrationId: SupportedIntegrations): Promise<GladiaConfiguration | GithubConfiguration | AwsConfiguration | MagicPdfConfiguration | undefined> {
         return this.get(`/${projectId}/integrations/${integrationId}`).catch(err => {
             if (err.status === 404) {
                 return undefined;

--- a/packages/client/src/PromptsApi.ts
+++ b/packages/client/src/PromptsApi.ts
@@ -123,7 +123,7 @@ export default class PromptsApi extends ApiTopic {
     }
 
     /**
-     * List the versions of the prompt template. Returens an empty array if no versions are found
+     * List the versions of the prompt template. Returns an empty array if no versions are found
      * @param id
      * @returns the versions list or an empty array if no versions are found
      */

--- a/packages/client/src/execute.ts
+++ b/packages/client/src/execute.ts
@@ -14,7 +14,7 @@ export async function EventSourceProvider(): Promise<typeof EventSource> {
  * the run completes or fails.
  * If the onChunk callback is passed then the streaming of the result is enabled.
  * The onChunk callback with be called with the next chunk of the result as soon as it is available.
- * When all chunks are received the fucntion will return the resolved promise
+ * When all chunks are received the function will return the resolved promise
  * @param id of the interaction to execute
  * @param payload InteractionExecutionPayload
  * @param onChunk callback to be called when the next chunk of the response is available
@@ -38,7 +38,7 @@ export async function executeInteraction<P = any, R = any>(client: VertesiaClien
 
 /**
  * Same as executeInteraction but uses the interaction name selector instead of the id.
- * A name selector is the interaction endpoint name suffuxed with an optional tag or version wich is starting with a `@` character.
+ * A name selector is the interaction endpoint name suffixed with an optional tag or version which is starting with a `@` character.
  * The special `draft` tag is used to select the draft version of the interaction. If no tag or version is specified then the latest version is selected.
  * Examples of selectors:
  * - `ReviewContract` - select the latest version of the ReviewContract interaction

--- a/packages/common/src/apikey.ts
+++ b/packages/common/src/apikey.ts
@@ -64,5 +64,5 @@ export interface AuthTokenPayload {
 export enum PrincipalType {
     User = "user",
     ApiKey = "apikey",
-    ServiceAcount = "service_account",
+    ServiceAccount = "service_account",
 }

--- a/packages/common/src/integrations.ts
+++ b/packages/common/src/integrations.ts
@@ -18,7 +18,7 @@ export interface AwsConfiguration extends IntegrationConfigurationBase {
     s3_role_arn: string;
 }
 
-export interface MacgicPdfConfiguration extends IntegrationConfigurationBase {
+export interface MagicPdfConfiguration extends IntegrationConfigurationBase {
     // No additional configuration
     default_features?: string[];
     default_zones?: string[];

--- a/packages/common/src/interaction.ts
+++ b/packages/common/src/interaction.ts
@@ -42,13 +42,13 @@ export interface InteractionEndpointQuery {
 
     /**
      * Filter by interaction endpoint name to include only the specified endpoints
-     * * If both includes and excludes are specified then omly the includes filter will be used.
+     * * If both includes and excludes are specified then only the includes filter will be used.
      */
     includes?: string[];
 
     /**
      * Filter by interaction endpoint name to excludes the specified endpoints.
-     * If both includes and excludes are specified then omly the includes filter will be used.
+     * If both includes and excludes are specified then only the includes filter will be used.
      */
     excludes?: string[];
 
@@ -104,7 +104,7 @@ export interface InteractionRefWithSchema extends Omit<InteractionRef, "prompts"
 
 export interface InteractionsExportPayload {
     /**
-     * The name of the interaction. If not spcified all the interactions in the current project will be exported
+     * The name of the interaction. If not specified all the interactions in the current project will be exported
      */
     name?: string;
     /*
@@ -239,7 +239,7 @@ export interface InteractionForkPayload {
 export interface InteractionExecutionPayload {
     /**
      * If a `@memory` property exists on the input data then the value will be used as the value of a memory pack location.
-     * and the other proerties of the data will contain the memory pack mapping.
+     * and the other properties of the data will contain the memory pack mapping.
      */
     data?: Record<string, any> | `memory:${string}`;
     config?: InteractionExecutionConfiguration;
@@ -413,7 +413,7 @@ export interface ExecutionRun<P = any, R = any> {
     /**
      * The parameters used to create the interaction.
      * If the parameters contains the special property "@memory" it will be used
-     * to locate a meory pack and the other properties will be used as the memory pack mapping.
+     * to locate a memory pack and the other properties will be used as the memory pack mapping.
      */
     parameters: P; //params used to create the interaction, only in varies on?
     tags?: string[];

--- a/packages/common/src/prompt.ts
+++ b/packages/common/src/prompt.ts
@@ -68,7 +68,7 @@ export interface PromptTemplate {
     inputSchema?: JSONSchema4;
     project: string | ProjectRef; // or projectRef? ObjectIdType;
     // The name of a field in the input data that is of the specified schema and on each the template will iterate.
-    // If not specified then the sceham will define the whole input data
+    // If not specified then the schema will define the whole input data
     tags?: string[];
     // only for drafts - when it was last published
     last_published_at?: Date;

--- a/packages/common/src/query.ts
+++ b/packages/common/src/query.ts
@@ -43,7 +43,7 @@ export interface ObjectSearchQuery extends SimpleSearchQuery {
 }
 
 export interface ObjectTypeSearchQuery extends SimpleSearchQuery {
-    chunckable?: boolean;
+    chunkable?: boolean;
 }
 
 export interface PromptSearchQuery extends SimpleSearchQuery {

--- a/packages/common/src/runs.ts
+++ b/packages/common/src/runs.ts
@@ -12,7 +12,7 @@ export interface ExecutionRunDocRef {
 
 /**
  * Interaction execution payload for creating a new run
- * It uses interaction field (from NamedInteractionExecutionPayload) to pass the intercation ID to run
+ * It uses interaction field (from NamedInteractionExecutionPayload) to pass the interaction ID to run
  */
 export interface RunCreatePayload extends NamedInteractionExecutionPayload {
 }
@@ -27,7 +27,7 @@ export interface RangeValue {
     lte?: number | string,
 }
 
-export interface RunSearchMetaRepsonse {
+export interface RunSearchMetaResponse {
     count: {
         lower_bound?: number,
         total?: number,

--- a/packages/common/src/store/activity-catalog.ts
+++ b/packages/common/src/store/activity-catalog.ts
@@ -12,7 +12,7 @@ export interface ActivityTypeDefinition {
     value: string | boolean | number | null;
     // in case of objects
     members?: ActivityPropertyDefinition[];
-    // in case of arrays or promises will be innertype (i.e. the element type for arrays)
+    // in case of arrays or promises will be innerType (i.e. the element type for arrays)
     innerType?: ActivityTypeDefinition;
     // in case of enums the enum values will be here
     enum?: string[] | number[] | undefined;

--- a/packages/common/src/store/agent.ts
+++ b/packages/common/src/store/agent.ts
@@ -1,6 +1,6 @@
 export interface CreateAgentDeploymentRequest {
     /**
-     * The agent ID is composed from the agent organization and the agen name, separated by a slash.
+     * The agent ID is composed from the agent organization and the agent name, separated by a slash.
      * Example: vertesia/docgen-agent
      */
     agentId: string;

--- a/packages/common/src/store/collections.ts
+++ b/packages/common/src/store/collections.ts
@@ -22,7 +22,7 @@ export interface CollectionItem extends BaseObject {
     /**
      * A flag to indicate if the collection is dynamic or static.
      * If the collection is dynamic, the members are determined by a query using the query field.
-     * Id the collection is static, the members are explicitly defined jusing the members array.
+     * If the collection is static, the members are explicitly defined using the members array.
      */
     dynamic: boolean;
     status: CollectionStatus;

--- a/packages/common/src/store/doc-analyzer.ts
+++ b/packages/common/src/store/doc-analyzer.ts
@@ -121,12 +121,12 @@ export interface AdaptTablesParams {
 }
 
 interface DocAnalyzerRequestBase {
-    synchroneous?: boolean;
+    synchronous?: boolean;
 
     notify_endpoints?: string[];
 
     /**
-     * What environmenet to use to run the request
+     * What environment to use to run the request
      * If none specified the project embedded environment will be used
      */
     environment?: string;

--- a/packages/common/src/store/dsl-workflow.ts
+++ b/packages/common/src/store/dsl-workflow.ts
@@ -16,7 +16,7 @@ export interface DSLWorkflowExecutionPayload extends WorkflowExecutionPayload {
 }
 
 /**
- * The payload for a DSL acitivty options.
+ * The payload for a DSL activity options.
  *
  * @see ActivityOptions in @temporalio/common
  */
@@ -58,7 +58,7 @@ export interface ActivityFetchSpec {
      */
     type: "document" | "document_type" | "interaction_run";
     /**
-     * An optinal URI to the data source.
+     * An optional URI to the data source.
      */
     source?: string;
     /**
@@ -72,13 +72,13 @@ export interface ActivityFetchSpec {
     select?: string;
 
     /**
-     * The number of results to return. If the result is limitedto 1 the result will be a single object
+     * The number of results to return. If the result is limited to 1 the result will be a single object
      */
     limit?: number;
 
     /**
      * How to handle not found objects.
-     * 1. ignore - Ignore and return an empty array for multi objects query (or undefined for single object query) or empty array for multiple objectthrow an error.
+     * 1. ignore - Ignore and return an empty array for multi objects query (or undefined for single object query) or empty array for multiple objects throw an error.
      * 2. throw - Throw an error if the object or no objects are found.
      */
     on_not_found?: "ignore" | "throw";
@@ -107,7 +107,7 @@ export interface DSLActivitySpec<PARAMS extends Record<string, any> = Record<str
     description?: string;
     /**
      * Activities parameters. These parameters can be either literals
-     * (hardcoded strings, numbers, booleans, obejcts, arrays etc.), either
+     * (hardcoded strings, numbers, booleans, objects, arrays etc.), either
      * references to the workflow variables.
      * The workflow variables are built from the workflow params (e.g. the workflow configuration)
      * and from the result of the previous activities.
@@ -116,14 +116,14 @@ export interface DSLActivitySpec<PARAMS extends Record<string, any> = Record<str
     /**
      * The name of the workflow variable that will store the result of the activity
      * If not specified the result will not be stored
-     * The parameters describe how the actual parameters will be obtained from the worlkfow execution vars.
+     * The parameters describe how the actual parameters will be obtained from the workflow execution vars.
      * since it may contain references to workflow execution vars.
      */
     output?: string;
 
     /**
      * A JSON expression which evaluate to true or false similar to mongo matches.
-     * We support fow now basic expreion like: $true, $false, $eq, $ne, $gt, $gte, $lt, $lte, $in, $nin, $regexp
+     * We support for now basic expression like: $true, $false, $eq, $ne, $gt, $gte, $lt, $lte, $in, $nin, $regexp
      * {$eq: {name: value}},
      * Ex: {$eq: {wfVarName: value}}
      */
@@ -186,7 +186,7 @@ export interface DSLChildWorkflowStep extends DSLWorkflowStepBase {
     /**
      * The name of the workflow variable that will store the result of the child workflow (if async the workflow id is stored)
      * If not specified the result will not be stored
-     * The parameters describe how the actual parameters will be obtained from the worlkfow execution vars.
+     * The parameters describe how the actual parameters will be obtained from the workflow execution vars.
      * since it may contain references to workflow execution vars.
      */
     output?: string;
@@ -257,7 +257,7 @@ export interface DSLWorkflowSpecWithActivities extends DSLWorkflowSpecBase {
 }
 
 /**
- * activities and steps fields are mutally exclusive
+ * activities and steps fields are mutually exclusive
  * steps was added after activities and may contain a mix of activities and other tasks like exec child workflows.
  * For backward compatibility we keep the activities field as a fallback but one should use one or the other not both.
  */

--- a/packages/common/src/store/store.ts
+++ b/packages/common/src/store/store.ts
@@ -143,7 +143,7 @@ export interface ContentObjectItem<T = any> extends BaseObject {
 }
 
 /**
- * When creating from an uploaded file the content shouild be an URL to the uploaded file
+ * When creating from an uploaded file the content should be an URL to the uploaded file
  */
 export interface CreateContentObjectPayload<T = any> extends Partial<Omit<ContentObject<T>,
     'id' | 'root' | 'created_at' | 'updated_at' | 'type'
@@ -190,12 +190,12 @@ export interface ContentObjectType extends ContentObjectTypeItem {
 export interface ContentObjectTypeItem extends BaseObject {
     is_chunkable?: boolean;
     /**
-     * This is only included in ContentObjectTypeItem if explicitely requested
+     * This is only included in ContentObjectTypeItem if explicitly requested
      * It is always included in ContentObjectType
      */
     table_layout?: ColumnLayout[];
     /**
-     * this is only included in ContentObjectTypeItem if explicitely requested
+     * this is only included in ContentObjectTypeItem if explicitly requested
      * It is always included in ContentObjectType
      */
     object_schema?: Record<string, any>; // an optional JSON schema for the object properties.

--- a/packages/common/src/store/workflow.ts
+++ b/packages/common/src/store/workflow.ts
@@ -16,7 +16,7 @@ export interface WorkflowExecutionBaseParams<T = Record<string, any>> {
 
     /**
      * The account ID of the user who created the activity.
-     * This is usefull to select the right database to work on.
+     * This is useful to select the right database to work on.
      */
     account_id: string;
 
@@ -32,7 +32,7 @@ export interface WorkflowExecutionBaseParams<T = Record<string, any>> {
      *
      * In the case of workflows started by events (e.g. using a a workflow rule) the user input vars will be initialized with the workflow rule configuration field.
      *
-     * In case of dsl workflows the worflow execution payload vars will be applied over the default vars values stored in the DSL vars field.
+     * In case of dsl workflows the workflow execution payload vars will be applied over the default vars values stored in the DSL vars field.
      */
     vars: T;
 
@@ -53,7 +53,7 @@ export interface WorkflowExecutionBaseParams<T = Record<string, any>> {
 
     /**
      * The list of endpoints to notify when the workflow finishes.
-     * It is handled by a subworkflow execution, so the main workflow will not wait for the notification to be sent.
+     * It is handled by a sub-workflow execution, so the main workflow will not wait for the notification to be sent.
      */
     notify_endpoints?: string[];
 }

--- a/packages/create-agent/README.md
+++ b/packages/create-agent/README.md
@@ -27,7 +27,7 @@ These generated files are containing a "Hello world!" workflow and activity as a
 
 ## Developing your agent workflows / activities.
 
-Export your temporal wrofklows `from src/workflows.ts` and your activities from `src/activities.ts`
+Export your temporal workflows `from src/workflows.ts` and your activities from `src/activities.ts`
 
 ## Test locally the workflows.
 
@@ -47,7 +47,7 @@ See https://docs.temporal.io/develop/typescript/debugging for more information
 ## Packaging and publishing your Vertesia agent
 
 When the workflows are working you will want to publish the agent to Vertesia.
-The agent should be packaged as a docker imageand then published to the Vertesia cloud.
+The agent should be packaged as a docker image and then published to the Vertesia cloud.
 
 ### Build the agent docker image
 
@@ -58,7 +58,7 @@ This image is only useable to test locally. You cannot push it to Vertesia.
 
 ### Releasing the agent docker image
 
-When you aready to push your agent to Vertesia you must first create a version using the following command:
+When you are ready to push your agent to Vertesia you must first create a version using the following command:
 
 ```
 vertesia agent release <version>
@@ -71,7 +71,7 @@ This command is creating a new docker tag `your-organization/your-agent-name:ver
 
 ### Publishing the agent docker image to Vertesia
 
-Versionned images (using the `release` command) can be published to Vertesia. This can be done using the following command:
+Versioned images (using the `release` command) can be published to Vertesia. This can be done using the following command:
 
 ```
 vertesia agent publish <version>
@@ -91,7 +91,7 @@ The you can deploy an agent that you previously uploaded to Vertesia by using th
 vertesia agent publish <version> --deploy-only
 ```
 
-## Manaing agent versions
+## Managing agent versions
 
 You can see the docker image versions you created using the following command:
 

--- a/packages/create-agent/src/init.ts
+++ b/packages/create-agent/src/init.ts
@@ -73,8 +73,8 @@ export async function init(dirName?: string | undefined) {
     const cmd = answer.pm;
 
     // copy template to current directory
-    const templDir = resolve(fileURLToPath(import.meta.url), '../../template');
-    await copyTree(templDir, dir);
+    const templateDirectory = resolve(fileURLToPath(import.meta.url), '../../template');
+    await copyTree(templateDirectory, dir);
 
     console.log("Generating package.json");
     const pkg = new Package({

--- a/packages/workflow/src/activities/createDocumentFromOther.ts
+++ b/packages/workflow/src/activities/createDocumentFromOther.ts
@@ -24,7 +24,7 @@ export interface CreatePdfDocumentFromSource extends DSLActivitySpec<CreatePdfDo
 
 
 /**
- * Create a new PDF by extrracting pages from a source PDF
+ * Create a new PDF by extracting pages from a source PDF
  * @returns
  */
 export async function createPdfDocumentFromSource(payload: DSLActivityExecutionPayload<CreatePdfDocumentFromSourceParams>) {

--- a/packages/workflow/src/activities/executeInteraction.ts
+++ b/packages/workflow/src/activities/executeInteraction.ts
@@ -56,13 +56,13 @@ const JSON: DSLActivitySpec = {
 export interface InteractionExecutionParams {
     /**
      * The environment to use. If not specified the project default environment will be used.
-     * If the latter is not specified an exeption will be thrown.
+     * If the latter is not specified an exception will be thrown.
      */
     environment?: string;
     /**
      * The model to use. If not specified the project default model will be used.
      * If the latter is not specified the default model of the environment will be used.
-     * If the latter is not specified an exeption will be thrown.
+     * If the latter is not specified an exception will be thrown.
      */
     model?: string;
 
@@ -90,7 +90,7 @@ export interface InteractionExecutionParams {
 /**
  * TODO: must be kept in sync with InteractionAsyncExecutionPayload form @vertesia/common
  * Also see the executeInteractionAsync endpoint on the server for how the client payload is sent to the workflow.
- * (interaction is translsted to interactionName)
+ * (interaction is translated to interactionName)
  */
 export interface ExecuteInteractionParams extends InteractionExecutionParams {
     //TODO rename to interaction as in InteractionAsyncExecutionPayload

--- a/packages/workflow/src/activities/generateEmbeddings.ts
+++ b/packages/workflow/src/activities/generateEmbeddings.ts
@@ -214,7 +214,7 @@ async function generateTextEmbeddings({ document, client, type, config }: Execut
                 }
                 log.info(`Generated embeddings for part ${i}`, { len: e.values.length, duration: new Date().getTime() - localStart });
 
-                return { inumber: i, result: e }
+                return { number: i, result: e }
             } catch (err: any) {
                 log.info(`Error generating ${type} embeddings for part ${i} of ${document.id}`, { error: err });
                 return { number: i, result: null, message: "error generating embeddings", error: err.message }

--- a/packages/workflow/src/activities/generateImageRendition.ts
+++ b/packages/workflow/src/activities/generateImageRendition.ts
@@ -11,7 +11,7 @@ import { NoDocumentFound, WorkflowParamNotFound } from "../errors.js";
 import { saveBlobToTempFile } from "../utils/blobs.js";
 
 interface GenerateImageRenditionParams {
-    max_hw: number; //maximum size of the longuest side of the image
+    max_hw: number; //maximum size of the longest side of the image
     format: string; //format of the output image
 }
 

--- a/packages/workflow/src/activities/generateOrAssignContentType.ts
+++ b/packages/workflow/src/activities/generateOrAssignContentType.ts
@@ -113,7 +113,7 @@ export async function generateOrAssignContentType(
     selectedType = types.find((t) => t.name === res.result.document_type);
 
     if (!selectedType) {
-        log.warn("Document type not idenfified: starting type generation");
+        log.warn("Document type not identified: starting type generation");
         const newType = await generateNewType(context, existing_types, content, fileRef);
         selectedType = { id: newType.id, name: newType.name };
     }

--- a/packages/workflow/src/activities/getObjectFromStore.ts
+++ b/packages/workflow/src/activities/getObjectFromStore.ts
@@ -12,7 +12,7 @@ export interface GetObject extends DSLActivitySpec<GetObjectParams> {
 }
 
 /**
- * We are using a union type for the status parameter since typescript enumbs breaks the workflow code generation
+ * We are using a union type for the status parameter since typescript enums breaks the workflow code generation
  * @param objectId
  * @param status
  */

--- a/packages/workflow/src/activities/media/processPdfWithTextract.ts
+++ b/packages/workflow/src/activities/media/processPdfWithTextract.ts
@@ -91,11 +91,11 @@ export async function convertPdfToStructuredText(payload: DSLActivityExecutionPa
 
         if (jobStatus === "SUCCEEDED") {
             log.info(`Job ${jobId} succeeded, saving results`, { jobId });
-            const ftext = await processor.processResults(jobId);
-            const tokensData = countTokens(ftext);
-            const etag = object.content.etag ?? md5(ftext);
+            const fText = await processor.processResults(jobId);
+            const tokensData = countTokens(fText);
+            const etag = object.content.etag ?? md5(fText);
             const updateData: CreateContentObjectPayload = {
-                text: ftext,
+                text: fText,
                 text_etag: etag,
                 tokens: {
                     ...tokensData,

--- a/packages/workflow/src/activities/setDocumentStatus.ts
+++ b/packages/workflow/src/activities/setDocumentStatus.ts
@@ -11,7 +11,7 @@ export interface SetDocumentStatus extends DSLActivitySpec<SetDocumentStatusPara
 }
 
 /**
- * We are using a union type for the status parameter since typescript enumbs breaks the workflow code generation
+ * We are using a union type for the status parameter since typescript enums breaks the workflow code generation
  * @param objectId
  * @param status
  */

--- a/packages/workflow/src/conversion/TextractProcessor.ts
+++ b/packages/workflow/src/conversion/TextractProcessor.ts
@@ -472,21 +472,21 @@ export class TextractProcessor {
         }
     
         // Build final output
-        let fulltext = '';
+        let fullText = '';
         let imgNumber = 1;
         let tableNumber = 1;
         for (const page of pageContents) {
-            fulltext += `<page number="${page.pageNumber}">\n`;
+            fullText += `<page number="${page.pageNumber}">\n`;
             for (const block of page.blocks) {
                 if (block.type === 'text') {
-                    fulltext += `<text>\n${block.content}\n</text>\n\n`;
+                    fullText += `<text>\n${block.content}\n</text>\n\n`;
                 } else if (block.type === 'table') {
                     const confidenceAttr = block.confidence !== undefined && this.includeConfidenceInTables
                         ? ` confidence="${block.confidence.toFixed(2)}"`
                         : '';
-                    fulltext += `<table number=${tableNumber++} type="csv" ${confidenceAttr}>\n`;
-                    fulltext += `${block.content}\n`;
-                    fulltext += `</table>\n\n`;
+                    fullText += `<table number=${tableNumber++} type="csv" ${confidenceAttr}>\n`;
+                    fullText += `${block.content}\n`;
+                    fullText += `</table>\n\n`;
                 } else if (block.type === 'image') {
                     // Include geometry if you like
                     const leftAttr = block.left ? ` left="${block.left.toFixed(4)}"` : '';
@@ -494,13 +494,13 @@ export class TextractProcessor {
                     const widthAttr = block.width ? ` width="${block.width.toFixed(4)}"` : '';
                     const heightAttr = block.height ? ` height="${block.height.toFixed(4)}"` : '';
     
-                    fulltext += `<image id="${imgNumber++}" ${leftAttr}${topAttr}${widthAttr}${heightAttr}>\n${block.content.trim()}\n</image>\n\n`;
+                    fullText += `<image id="${imgNumber++}" ${leftAttr}${topAttr}${widthAttr}${heightAttr}>\n${block.content.trim()}\n</image>\n\n`;
                 }
             }
-            fulltext += `</page>\n\n`;
+            fullText += `</page>\n\n`;
         }
     
-        return fulltext;
+        return fullText;
     }
     
 }

--- a/packages/workflow/src/conversion/mutool.ts
+++ b/packages/workflow/src/conversion/mutool.ts
@@ -120,7 +120,7 @@ export async function pdfToImages(file: Buffer | string, pages?: number[]): Prom
 
 
 /**
- * Get somes pages from a PDF to create a new one
+ * Get some pages from a PDF to create a new one
  */
 
 export async function pdfExtractPages(file: Buffer | string, pages: number[]): Promise<string> {

--- a/packages/workflow/src/dsl/dsl-workflow.ts
+++ b/packages/workflow/src/dsl/dsl-workflow.ts
@@ -45,7 +45,7 @@ export async function dslWorkflow(payload: DSLWorkflowExecutionPayload) {
     if (!definition) {
         throw new WorkflowParamNotFound("workflow");
     }
-    // the base payload wiull be used to create the activities payload
+    // the base payload will be used to create the activities payload
     const basePayload: BaseActivityPayload = {
         ...payload,
         workflow_name: definition.name,
@@ -73,7 +73,7 @@ export async function dslWorkflow(payload: DSLWorkflowExecutionPayload) {
     });
     const defaultProxy = proxyActivities(defaultOptions);
     log.debug("Default activity proxy is ready");
-    // merge default vars with the payload vars and add objectIds and obejctId
+    // merge default vars with the payload vars and add objectIds and objectId
     const vars = new Vars({
         ...definition.vars,
         ...payload.vars,
@@ -186,7 +186,7 @@ async function executeChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWork
         Object.assign(resolvedVars, step.vars);
     }
     if (debug_mode) {
-        log.debug(`Workflow vars before excuting child workflow ${step.name}`, { vars: resolvedVars });
+        log.debug(`Workflow vars before executing child workflow ${step.name}`, { vars: resolvedVars });
     }
     const result = await executeChild(step.name, {
         ...step.options,
@@ -217,7 +217,7 @@ async function runActivity(activity: DSLActivitySpec, basePayload: BaseActivityP
         log.debug(`Workflow vars before executing activity ${activity.name}`, { vars: vars.resolve() });
     }
     if (activity.condition && !vars.match(activity.condition)) {
-        log.info("Activity skiped: condition not satisfied", activity.condition);
+        log.info("Activity skipped: condition not satisfied", activity.condition);
         return;
     }
     const importParams = vars.createImportVars(activity.import);

--- a/packages/workflow/src/dsl/validation.test.ts
+++ b/packages/workflow/src/dsl/validation.test.ts
@@ -18,7 +18,7 @@ describe('workflow validation', () => {
         expect(errors.length).toBe(1);
     })
 
-    test('activities shpuld be an array', () => {
+    test('activities should be an array', () => {
         const workflow: any = {
             name: "test",
             activities: {}
@@ -81,7 +81,7 @@ describe('workflow validation', () => {
         expect(errors.length).toBe(0);
     })
 
-    test('import unknown imorted var through expressions', () => {
+    test('import unknown imported var through expressions', () => {
         const workflow: any = {
             name: "test",
             vars: { "foo": true },

--- a/packages/workflow/src/dsl/vars.test.ts
+++ b/packages/workflow/src/dsl/vars.test.ts
@@ -125,7 +125,7 @@ describe('Workflow vars', () => {
         expect(resolved.prompt_data.message).toBe("hello");
         expect(resolved.data2).toBeTypeOf("object");
         expect(resolved.data2.message).toBe("hello");
-        expect(resolved.unnown).toBeUndefined();
+        expect(resolved.unknown).toBeUndefined();
     });
 
 

--- a/packages/workflow/src/dsl/vars.ts
+++ b/packages/workflow/src/dsl/vars.ts
@@ -20,9 +20,9 @@ export function splitPath(path: string) {
 
 /**
  * Get the property named by "name" of the given object
- * If an array is idnexed using a string key then a map is done and an array with the content of the properties with that name are returned
+ * If an array is indexed using a string key then a map is done and an array with the content of the properties with that name are returned
  * Ex: docs.text => will return an array of text properties of the docs array
- * @param object the obejct
+ * @param object the object
  * @param name the name of the property.
  * @returns the property value
  */
@@ -128,7 +128,7 @@ export class Vars {
     map: Record<string, any>;
     /**
      * This property is used when resolving params. It contains the list of references that should not be resolved to their value
-     * but instead they need to return the string representation of the expression to eb able to regenrate another Vars instance with the same expression
+     * but instead they need to return the string representation of the expression to be able to regenerate another Vars instance with the same expression
      */
     //TODO this feature is no more used - it was replaced by importVars so we can now delete `preserveRefs`
     preserveRefs: Set<string> | undefined;
@@ -154,7 +154,7 @@ export class Vars {
     }
 
     /**
-     * Set a literal value (canboot set a ref)
+     * Set a literal value (cannot set a ref)
      * To add refs use `append()`
      * @param name
      * @param value
@@ -291,7 +291,7 @@ export class Vars {
     }
 
     getUnknownReferences(obj: any) {
-        const visitor = new UnknownRefrencesVisitor(this);
+        const visitor = new UnknownReferencesVisitor(this);
         new ObjectWalker().walk(obj, visitor);
         return visitor.result;
     }
@@ -311,7 +311,7 @@ function addImportVar(varPath: string, asName: string | undefined, vars: Vars, r
 }
 
 
-class UnknownRefrencesVisitor implements ObjectVisitor {
+class UnknownReferencesVisitor implements ObjectVisitor {
 
     result: { name: string, expression: string }[] = [];
 

--- a/packages/workflow/src/dsl/workflow-exec-child.test.ts
+++ b/packages/workflow/src/dsl/workflow-exec-child.test.ts
@@ -87,7 +87,7 @@ const steps2: DSLWorkflowStep[] = [
 // ========== test env setup ==========
 
 
-describe('DSL Workflow with chld workflows', () => {
+describe('DSL Workflow with child workflows', () => {
 
     let testEnv: TestWorkflowEnvironment;
 
@@ -132,7 +132,7 @@ describe('DSL Workflow with chld workflows', () => {
             auth_token: 'test',
             config: {
                 studio_url: process.env.CP_STUDIO_URL || "http://localhost:8081",
-                store_url: process.env.CP_STODRE_URL || "http://localhost:8082",
+                store_url: process.env.CP_STORE_URL || "http://localhost:8082",
             },
             workflow: {
                 steps: steps1,
@@ -177,7 +177,7 @@ describe('DSL Workflow with chld workflows', () => {
             auth_token: 'test',
             config: {
                 studio_url: process.env.CP_STUDIO_URL || "http://localhost:8081",
-                store_url: process.env.CP_STODRE_URL || "http://localhost:8082",
+                store_url: process.env.CP_STORE_URL || "http://localhost:8082",
             },
             workflow: {
                 steps: steps2,

--- a/packages/workflow/src/dsl/workflow-fetch.test.ts
+++ b/packages/workflow/src/dsl/workflow-fetch.test.ts
@@ -110,7 +110,7 @@ describe('DSL Workflow', () => {
             auth_token: 'test',
             config: {
                 studio_url: process.env.CP_STUDIO_URL || "http://localhost:8081",
-                store_url: process.env.CP_STODRE_URL || "http://localhost:8082",
+                store_url: process.env.CP_STORE_URL || "http://localhost:8082",
             },
             workflow: {
                 activities,

--- a/packages/workflow/src/dsl/workflow-import.test.ts
+++ b/packages/workflow/src/dsl/workflow-import.test.ts
@@ -64,7 +64,7 @@ describe('DSL Workflow import vars', () => {
             auth_token: 'test',
             config: {
                 studio_url: process.env.CP_STUDIO_URL || "http://localhost:8081",
-                store_url: process.env.CP_STODRE_URL || "http://localhost:8082",
+                store_url: process.env.CP_STORE_URL || "http://localhost:8082",
             },
             workflow: {
                 activities,

--- a/packages/workflow/src/dsl/workflow.test.ts
+++ b/packages/workflow/src/dsl/workflow.test.ts
@@ -92,7 +92,7 @@ describe('DSL Workflow', () => {
             auth_token: 'test',
             config: {
                 studio_url: process.env.CP_STUDIO_URL || "http://localhost:8081",
-                store_url: process.env.CP_STODRE_URL || "http://localhost:8082",
+                store_url: process.env.CP_STORE_URL || "http://localhost:8082",
             },
             workflow: {
                 activities,

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -3,7 +3,7 @@
  * Modify the `./activities/index.ts` if you want to modify activity exports
  * 2. Workflows are exported through the '/workflows' named export in package.json.
  * Modify the `./workflows.ts` file if you want to modify workflow exports
- * 3. Here we export the API to be used to validate workflows and the types reuired to create workflow TS definitions.
+ * 3. Here we export the API to be used to validate workflows and the types required to create workflow TS definitions.
  */
 
 //TODO remove this - it is only for backward compat - iot is used from old workflows

--- a/packages/workflow/src/iterative-generation/activities/extractToc.ts
+++ b/packages/workflow/src/iterative-generation/activities/extractToc.ts
@@ -40,7 +40,7 @@ export async function it_gen_extractToc(payload: WorkflowExecutionPayload): Prom
     await buildAndPublishMemoryPack(client, `${vars.memory}/output`, async () => {
         return {
             toc,
-            lastProcessdPart: undefined, // the part index (a number array)
+            lastProcessedPart: undefined, // the part index (a number array)
             previouslyGenerated: ""
         } as OutputMemoryMeta
     });

--- a/packages/workflow/src/iterative-generation/activities/generatePart.ts
+++ b/packages/workflow/src/iterative-generation/activities/generatePart.ts
@@ -32,7 +32,7 @@ export async function it_gen_generatePart(payload: WorkflowExecutionPayload, pat
 
     const content = await loadGeneratedContent(outMemory);
 
-    let previously_generated = getPreviouslyGeneratedContent(content, !part, vars.rememberance_strategy);
+    let previously_generated = getPreviouslyGeneratedContent(content, !part, vars.remembrance_strategy);
 
     if (!part) { // a new section
         content.push({
@@ -58,7 +58,7 @@ export async function it_gen_generatePart(payload: WorkflowExecutionPayload, pat
 
     const result = r.result as string;
     content[content.length - 1].content += result;
-    meta.lastProcessdPart = path;
+    meta.lastProcessedPart = path;
     await buildAndPublishMemoryPack(client, `${memory}/output`, async ({ copyText }) => {
         copyText(JSON.stringify(content, null, 2), "content.json");
         return meta;

--- a/packages/workflow/src/iterative-generation/activities/generateToc.ts
+++ b/packages/workflow/src/iterative-generation/activities/generateToc.ts
@@ -89,7 +89,7 @@ export async function it_gen_generateToc(payload: WorkflowExecutionPayload): Pro
     await buildAndPublishMemoryPack(client, `${vars.memory}/output`, async () => {
         return {
             toc,
-            lastProcessdPart: undefined, // the part index (a number array)
+            lastProcessedPart: undefined, // the part index (a number array)
             previouslyGenerated: ""
         } as OutputMemoryMeta
     });

--- a/packages/workflow/src/iterative-generation/iterativeGenerationWorkflow.ts
+++ b/packages/workflow/src/iterative-generation/iterativeGenerationWorkflow.ts
@@ -30,7 +30,7 @@ export async function iterativeGenerationWorkflow(payload: WorkflowExecutionPayl
     }
 
     // extractToc tries to extract the toc from the input memory pack (toc.json or toc.yaml)
-    // the generateToc activity is retiurning the toc hierarchy.
+    // the generateToc activity is returning the toc hierarchy.
     // It doesn't include extra TOC details like description etc.
     // To minimize the payload size only the hierarchy and the section/part names are returned
     let toc = await it_gen_extractToc(payload);

--- a/packages/workflow/src/iterative-generation/types.ts
+++ b/packages/workflow/src/iterative-generation/types.ts
@@ -13,7 +13,7 @@ export interface IterativeGenerationPayload {
     // the main interaction will only be used to prepare the iteration (to generate the TOC)
     // otherwise it will be used for the iterative generation too.
     interaction: string;
-    // if defined this will be used for the iterative interaction which will genrate parts.
+    // if defined this will be used for the iterative interaction which will generate parts.
     // otherwise the main interaction will be used for iterative generation.
     iterative_interaction?: string;
     // the environment to use
@@ -34,10 +34,10 @@ export interface IterativeGenerationPayload {
      * If not set to "none" the previously generated content will be passed to the iteration.
      * If not set at all defaults to "section".
      * If "section" is used only the section content previously generated will be passed to the next iteration.
-     * If "document" is used the whole previopusly generated document content will be passed to the next iteration.
+     * If "document" is used the whole previously generated document content will be passed to the next iteration.
      * Defaults to section.
      */
-    rememberance_strategy?: "document" | "section" | "none";
+    remembrance_strategy?: "document" | "section" | "none";
     /**
      * If present will save sections in files using the pattern
      * The pattern must include a placeholder for the section id: %id.
@@ -88,7 +88,7 @@ export interface TocIndex {
 export interface OutputMemoryMeta {
     toc: Toc;
     previouslyGenerated: string;
-    lastProcessdPart?: number[] | undefined;
+    lastProcessedPart?: number[] | undefined;
 }
 
 export interface Section {

--- a/packages/workflow/src/iterative-generation/utils.ts
+++ b/packages/workflow/src/iterative-generation/utils.ts
@@ -79,19 +79,19 @@ export function getPreviousPathIndex(toc: Toc, pathIndex: number[]): number[] | 
 
 
 export function expectMemoryIsConsistent(meta: OutputMemoryMeta, pathIndex: number[]) {
-    const metaLastProcessedPart = meta.lastProcessdPart;
+    const metaLastProcessedPart = meta.lastProcessedPart;
     if (!metaLastProcessedPart) {
         if (pathIndex.length > 1 && pathIndex[0] !== 0) {
-            throw ApplicationFailure.nonRetryable('Memory last processed part is not consitent with the workflow.', 'MemoryPackNotConsistent', { currentIndex: pathIndex, expectedPreviousIndex: [pathIndex[0], pathIndex[1] - 1], previousIndex: metaLastProcessedPart });
+            throw ApplicationFailure.nonRetryable('Memory last processed part is not consistent with the workflow.', 'MemoryPackNotConsistent', { currentIndex: pathIndex, expectedPreviousIndex: [pathIndex[0], pathIndex[1] - 1], previousIndex: metaLastProcessedPart });
         } else {
             return;
         }
     }
     const prevPathIndex = getPreviousPathIndex(meta.toc, pathIndex);
     if (!prevPathIndex) {
-        throw ApplicationFailure.nonRetryable('Memory last processed part is not consitent with the workflow', 'MemoryPackNotConsistent', { currentIndex: pathIndex, expectedPreviousIndex: prevPathIndex, previousIndex: metaLastProcessedPart });
+        throw ApplicationFailure.nonRetryable('Memory last processed part is not consistent with the workflow', 'MemoryPackNotConsistent', { currentIndex: pathIndex, expectedPreviousIndex: prevPathIndex, previousIndex: metaLastProcessedPart });
     } else if (!isSamePartIndex(prevPathIndex, metaLastProcessedPart)) {
-        throw ApplicationFailure.nonRetryable('Memory last processed part is not consitent with the workflow', 'MemoryPackNotConsistent', { currentIndex: pathIndex, expectedPreviousIndex: prevPathIndex, previousIndex: meta.lastProcessdPart });
+        throw ApplicationFailure.nonRetryable('Memory last processed part is not consistent with the workflow', 'MemoryPackNotConsistent', { currentIndex: pathIndex, expectedPreviousIndex: prevPathIndex, previousIndex: meta.lastProcessedPart });
     }
 }
 

--- a/tools/environment-configuration/src/index.ts
+++ b/tools/environment-configuration/src/index.ts
@@ -37,7 +37,7 @@ program
   .description("Configure AWS Bedrock Execution environment")
   .requiredOption("-r, --region <region>", "The AWS region to use")
   .option(
-    "--env <environnment_name>",
+    "--env <environment_name>",
     "The Vertesia Execution Environment Name",
     "AWS Bedrock",
   )
@@ -60,7 +60,7 @@ program
 
 program
   .command("gcp")
-  .description("Configure GCP Vertex AI xecution environment")
+  .description("Configure GCP Vertex AI execution environment")
   .requiredOption("-r, --region <region>", "The GCP region to use")
   .option(
     "--pool-name <pool_name>",
@@ -77,7 +77,7 @@ program
     "The GCP project to use. defaults to the default project configured in gcloud",
   )
   .option(
-    "--env <environnment_name>",
+    "--env <environment_name>",
     "The Vertesia Execution Environment Name",
     "GCP Vertex AI",
   )


### PR DESCRIPTION
Spell check across the repository.

Checks the following file types:
ts, tsx, md, mdx

There are functional changes for example:
`return { inumber: i, result: e } `
in generateEmbeddings.ts , correct form is `return { number: i, result: e } `

Related PRs:
* https://github.com/vertesia/llumiverse/pull/139
* https://github.com/vertesia/studio/pull/1832