### PR TITLE
fix: don't retry interaction activity if the model is missing

### DIFF
--- a/packages/common/src/store/workflow.ts
+++ b/packages/common/src/store/workflow.ts
@@ -282,5 +282,4 @@ export enum AgentMessageType {
     QUESTION = "question",
     REQUEST_INPUT = "request_input",
     IDLE = "idle",
-    FAILURE = "failure",
 }

--- a/packages/common/src/store/workflow.ts
+++ b/packages/common/src/store/workflow.ts
@@ -282,4 +282,5 @@ export enum AgentMessageType {
     QUESTION = "question",
     REQUEST_INPUT = "request_input",
     IDLE = "idle",
+    FAILURE = "failure",
 }

--- a/packages/workflow/src/activities/executeInteraction.ts
+++ b/packages/workflow/src/activities/executeInteraction.ts
@@ -154,6 +154,9 @@ export async function executeInteraction(payload: DSLActivityExecutionPayload<Ex
         if (error.message.includes("Failed to validate merged prompt schema")) {
             //issue with the input data, don't retry
             throw new ActivityParamInvalid("prompt_data", payload.activity, error.message);
+        } else if (error.message.includes("modelId: Path `modelId` is required")) {
+            //issue with the input data, don't retry
+            throw new ActivityParamInvalid("model", payload.activity, error.message);
         } else {
             throw error;
         }


### PR DESCRIPTION
In this case the activity will always fail so there is no point retrying