### PR TITLE
chore(deps): unify and update vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "npm-ws-tools": "^0.3.0",
         "rimraf": "^5.0.5",
         "typescript": "^5.3.3",
-        "vite": "^6.2.7"
+        "vite": "^6.3.5"
     },
     "packageManager": "pnpm@10.8.1",
     "pnpm": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "devDependencies": {
         "npm-ws-tools": "^0.3.0",
         "rimraf": "^5.0.5",
-        "typescript": "^5.3.3"
+        "typescript": "^5.3.3",
+        "vite": "^6.2.7"
     },
     "packageManager": "pnpm@10.8.1",
     "pnpm": {
@@ -20,7 +21,7 @@
             "cross-spawn@<6.0.6": "^6.0.6",
             "esbuild@<0.25.0": "^0.25.0",
             "koa@>=2.0.0 <2.15.4": "^2.15.4",
-            "vite@>=6.0.0 <6.2.6": "^6.2.6"
+            "vite": "$vite"
         }
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   cross-spawn@<6.0.6: ^6.0.6
   esbuild@<0.25.0: ^0.25.0
   koa@>=2.0.0 <2.15.4: ^2.15.4
-  vite: ^6.2.7
+  vite: ^6.3.5
 
 importers:
 
@@ -24,7 +24,7 @@ importers:
         specifier: ^5.3.3
         version: 5.8.3
       vite:
-        specifier: ^6.2.7
+        specifier: ^6.3.5
         version: 6.3.5(@types/node@22.13.8)(terser@5.39.0)(tsx@3.14.0)(yaml@2.7.1)
 
   llumiverse/core:
@@ -1612,7 +1612,7 @@ packages:
     resolution: {integrity: sha512-ryERPIBOnvevAkTq+L1lD+DTFBRcjueL9lOUfXsLfwP92h4e+Heb+PjiqS3/OURWPtywfafK0kj++yDFjWUmrA==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.2.7
+      vite: ^6.3.5
     peerDependenciesMeta:
       msw:
         optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   cross-spawn@<6.0.6: ^6.0.6
   esbuild@<0.25.0: ^0.25.0
   koa@>=2.0.0 <2.15.4: ^2.15.4
-  vite@>=6.0.0 <6.2.6: ^6.2.6
+  vite: ^6.2.7
 
 importers:
 
@@ -23,6 +23,9 @@ importers:
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
+      vite:
+        specifier: ^6.2.7
+        version: 6.3.5(@types/node@22.13.8)(terser@5.39.0)(tsx@3.14.0)(yaml@2.7.1)
 
   llumiverse/core:
     dependencies:
@@ -1609,7 +1612,7 @@ packages:
     resolution: {integrity: sha512-ryERPIBOnvevAkTq+L1lD+DTFBRcjueL9lOUfXsLfwP92h4e+Heb+PjiqS3/OURWPtywfafK0kj++yDFjWUmrA==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.2.6
+      vite: ^6.2.7
     peerDependenciesMeta:
       msw:
         optional: true
@@ -2234,6 +2237,14 @@ packages:
   fast-xml-parser@4.4.1:
     resolution: {integrity: sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==}
     hasBin: true
+
+  fdir@6.4.4:
+    resolution: {integrity: sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
@@ -2885,6 +2896,10 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
   postcss@8.5.3:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
     engines: {node: ^10 || ^12 || >=14}
@@ -3220,6 +3235,10 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
+  tinyglobby@0.2.13:
+    resolution: {integrity: sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==}
+    engines: {node: '>=12.0.0'}
+
   tinygradient@1.1.5:
     resolution: {integrity: sha512-8nIfc2vgQ4TeLnk2lFj4tRLvvJwEfQuabdsmvDdQPT0xlk9TaNtpGd6nNRxXoK6vQhN6RSzj+Cnp5tTQmpxmbw==}
 
@@ -3345,8 +3364,8 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@6.2.6:
-    resolution: {integrity: sha512-9xpjNl3kR4rVDZgPNdTL0/c6ao4km69a/2ihNQbcANz8RuCOK3hQBmLSJf3bRKVQjVMda+YvizNE8AwvogcPbw==}
+  vite@6.3.5:
+    resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -5162,13 +5181,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.9(vite@6.2.6(@types/node@22.13.8)(terser@5.39.0)(tsx@3.14.0)(yaml@2.7.1))':
+  '@vitest/mocker@3.0.9(vite@6.3.5(@types/node@22.13.8)(terser@5.39.0)(yaml@2.7.1))':
     dependencies:
       '@vitest/spy': 3.0.9
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.2.6(@types/node@22.13.8)(terser@5.39.0)(tsx@3.14.0)(yaml@2.7.1)
+      vite: 6.3.5(@types/node@22.13.8)(terser@5.39.0)(tsx@3.14.0)(yaml@2.7.1)
 
   '@vitest/pretty-format@3.0.9':
     dependencies:
@@ -5798,6 +5817,10 @@ snapshots:
   fast-xml-parser@4.4.1:
     dependencies:
       strnum: 1.1.2
+
+  fdir@6.4.4(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
 
   figures@6.1.0:
     dependencies:
@@ -6488,6 +6511,8 @@ snapshots:
 
   picomatch@2.3.1: {}
 
+  picomatch@4.0.2: {}
+
   postcss@8.5.3:
     dependencies:
       nanoid: 3.3.11
@@ -6878,6 +6903,11 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
+  tinyglobby@0.2.13:
+    dependencies:
+      fdir: 6.4.4(picomatch@4.0.2)
+      picomatch: 4.0.2
+
   tinygradient@1.1.5:
     dependencies:
       '@types/tinycolor2': 1.4.6
@@ -6991,7 +7021,7 @@ snapshots:
       debug: 4.4.0(supports-color@8.1.1)
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.2.6(@types/node@22.13.8)(terser@5.39.0)(tsx@3.14.0)(yaml@2.7.1)
+      vite: 6.3.5(@types/node@22.13.8)(terser@5.39.0)(tsx@3.14.0)(yaml@2.7.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -7006,11 +7036,14 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.2.6(@types/node@22.13.8)(terser@5.39.0)(tsx@3.14.0)(yaml@2.7.1):
+  vite@6.3.5(@types/node@22.13.8)(terser@5.39.0)(tsx@3.14.0)(yaml@2.7.1):
     dependencies:
       esbuild: 0.25.1
+      fdir: 6.4.4(picomatch@4.0.2)
+      picomatch: 4.0.2
       postcss: 8.5.3
       rollup: 4.39.0
+      tinyglobby: 0.2.13
     optionalDependencies:
       '@types/node': 22.13.8
       fsevents: 2.3.3
@@ -7021,7 +7054,7 @@ snapshots:
   vitest@3.0.9(@types/node@22.13.8)(terser@5.39.0)(tsx@3.14.0)(yaml@2.7.1):
     dependencies:
       '@vitest/expect': 3.0.9
-      '@vitest/mocker': 3.0.9(vite@6.2.6(@types/node@22.13.8)(terser@5.39.0)(tsx@3.14.0)(yaml@2.7.1))
+      '@vitest/mocker': 3.0.9(vite@6.3.5(@types/node@22.13.8)(terser@5.39.0)(yaml@2.7.1))
       '@vitest/pretty-format': 3.1.1
       '@vitest/runner': 3.0.9
       '@vitest/snapshot': 3.0.9
@@ -7037,7 +7070,7 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.2.6(@types/node@22.13.8)(terser@5.39.0)(tsx@3.14.0)(yaml@2.7.1)
+      vite: 6.3.5(@types/node@22.13.8)(terser@5.39.0)(tsx@3.14.0)(yaml@2.7.1)
       vite-node: 3.0.9(@types/node@22.13.8)(terser@5.39.0)(tsx@3.14.0)(yaml@2.7.1)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
This PR uses another way to manage the vite version by moving the version declaration to the devDependencies. This is inspired by [vitest](https://github.com/vitest-dev/vitest/blob/main/package.json). It facilitates the security updates and dependency management. This PR also updates Vite to the latest version.