### PR TITLE
fix: propagate the value of InitiatedBy

### DIFF
--- a/packages/workflow/src/dsl/dsl-workflow.ts
+++ b/packages/workflow/src/dsl/dsl-workflow.ts
@@ -173,6 +173,7 @@ async function startChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWorkfl
             AccountId: [payload.account_id],
             DocumentId: getDocumentIds(payload),
             ProjectId: [payload.project_id],
+            InitiatedBy: payload.initiated_by ? [payload.initiated_by] : [],
         },
     });
     if (step.output) {
@@ -200,6 +201,7 @@ async function executeChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWork
             AccountId: [payload.account_id],
             DocumentId: getDocumentIds(payload),
             ProjectId: [payload.project_id],
+            InitiatedBy: payload.initiated_by ? [payload.initiated_by] : [],
         },
     });
 

--- a/packages/workflow/src/dsl/dsl-workflow.ts
+++ b/packages/workflow/src/dsl/dsl-workflow.ts
@@ -169,6 +169,9 @@ async function startChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWorkfl
             workflow: step.spec,
             vars: resolvedVars
         }],
+        memo: {
+            InitiatedBy: payload.initiated_by,
+        },
         searchAttributes: {
             AccountId: [payload.account_id],
             DocumentId: getDocumentIds(payload),
@@ -197,6 +200,9 @@ async function executeChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWork
             workflow: step.spec,
             vars: resolvedVars,
         }],
+        memo: {
+            InitiatedBy: payload.initiated_by,
+        },
         searchAttributes: {
             AccountId: [payload.account_id],
             DocumentId: getDocumentIds(payload),

--- a/packages/workflow/src/dsl/workflow-exec-child.test.ts
+++ b/packages/workflow/src/dsl/workflow-exec-child.test.ts
@@ -100,6 +100,7 @@ describe('DSL Workflow with child workflows', () => {
                 AccountId: protos.temporal.api.enums.v1.IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
                 DocumentId: protos.temporal.api.enums.v1.IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
                 ProjectId: protos.temporal.api.enums.v1.IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
+                InitiatedBy: protos.temporal.api.enums.v1.IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
             },
         });
     });

--- a/packages/workflow/src/dsl/workflow.test.ts
+++ b/packages/workflow/src/dsl/workflow.test.ts
@@ -60,6 +60,7 @@ describe('DSL Workflow', () => {
                 AccountId: protos.temporal.api.enums.v1.IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
                 DocumentId: protos.temporal.api.enums.v1.IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
                 ProjectId: protos.temporal.api.enums.v1.IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
+                InitiatedBy: protos.temporal.api.enums.v1.IndexedValueType.INDEXED_VALUE_TYPE_KEYWORD,
             },
         });
     });


### PR DESCRIPTION
This PR propagates the value of `InitiatedBy` to child workflows in memo and search attributes so that we can display the data correctly in the UI and for search, too. Note that the field in `memo` is a fallback and will be removed once the search attributes are fully deployed to production.