### PR TITLE
feat: add missing properties in workflow run event

### DIFF
--- a/packages/common/src/store/workflow.ts
+++ b/packages/common/src/store/workflow.ts
@@ -184,19 +184,21 @@ interface WorkflowRunEvent {
     event_id: number;
     event_time: number;
     event_type: string;
-    task_id: string;
+    task_id?: string;
     attempt: number;
 
     activity?: {
-        name: string;
-        id: string;
+        name?: string;
+        id?: string;
         input?: any;
+        scheduledEventId?: string;
+        startedEventId?: string;
     };
 
     error?: {
-        message: string;
-        source: string;
-        stacktrace: string;
+        message?: string;
+        source?: string;
+        stacktrace?: string;
         type?: string;
     };
 


### PR DESCRIPTION
# Description

- Temporal events for activity include references to past events. Without these references, it is impossible to know which activity the event is related to.
- Make values that are not always present optional (so we don't need to set these to empty string)