### PR TITLE
fix: Update InteractionSearchQuery interface

### DIFF
--- a/packages/common/src/query.ts
+++ b/packages/common/src/query.ts
@@ -54,7 +54,7 @@ export interface PromptSearchQuery extends SimpleSearchQuery {
 export interface InteractionSearchQuery extends SimpleSearchQuery {
     prompt?: string;
     tags?: string[];
-    version?: number;
+    version?: string;
 }
 
 export interface RunSearchQuery extends SimpleSearchQuery {


### PR DESCRIPTION
Update InteractionSearchQuery version type
InteractionSearchQuery is used when searching for interactions, it's used as a query parameters, resulting in value being converted to string when parsed from URL
Search is then not working because it's using a string as a number
Server is using typescript and it think that the value is already a number so it cannot be changed to number using parseInt