### PR TITLE
feat: declare non-retryable error types

### DIFF
--- a/packages/workflow/src/activities/advanced/createDocumentTypeFromInteractionRun.ts
+++ b/packages/workflow/src/activities/advanced/createDocumentTypeFromInteractionRun.ts
@@ -2,7 +2,7 @@ import { CreateContentObjectTypePayload, DSLActivityExecutionPayload, DSLActivit
 import { log } from "@temporalio/activity";
 import { projectResult } from "../../dsl/projections.js";
 import { setupActivity } from "../../dsl/setup/ActivityContext.js";
-import { ActivityParamNotFound } from "../../errors.js";
+import { ActivityParamNotFoundError } from "../../errors.js";
 
 
 export interface CreateDocumentTypeFromInteractionRunParams {
@@ -25,7 +25,7 @@ export async function createDocumentTypeFromInteractionRun(payload: DSLActivityE
     const { params, client } = await setupActivity<CreateDocumentTypeFromInteractionRunParams>(payload);
 
     if (!params.run) {
-        throw new ActivityParamNotFound("run", payload.activity);
+        throw new ActivityParamNotFoundError("run", payload.activity);
     }
 
     const genTypeRes = params.run.result;

--- a/packages/workflow/src/activities/advanced/createOrUpdateDocumentFromInteractionRun.ts
+++ b/packages/workflow/src/activities/advanced/createOrUpdateDocumentFromInteractionRun.ts
@@ -1,7 +1,8 @@
 import { log } from "@temporalio/activity";
 import { ContentObjectStatus, DSLActivityExecutionPayload, DSLActivitySpec } from "@vertesia/common";
 import { setupActivity } from "../../dsl/setup/ActivityContext.js";
-import { ActivityParamNotFound, NoDocumentFound } from "../../errors.js";
+import { ActivityParamNotFoundError, DocumentNotFoundError } from "../../errors.js";
+
 interface CreateOrUpdateObjectFromInteractionRunParams {
     /**
      * The execution run object to use. Required.
@@ -47,21 +48,21 @@ export async function createOrUpdateDocumentFromInteractionRun(payload: DSLActiv
     const objectTypeName = params.object_type;
 
     if (!runId) {
-        throw new ActivityParamNotFound("run_id", payload.activity);
+        throw new ActivityParamNotFoundError("run_id", payload.activity);
     }
     if (!objectTypeName && !params.update_existing_id) {
-        throw new ActivityParamNotFound("object_type", payload.activity);
+        throw new ActivityParamNotFoundError("object_type", payload.activity);
     }
 
     log.info("Creating document from interaction result", { runId, objectTypeName });
 
     const run = await client.runs.retrieve(runId).catch((e) => {
-        throw new NoDocumentFound(`Error fetching run ${runId}: ${e.message}`);
+        throw new DocumentNotFoundError(`Error fetching run ${runId}: ${e.message}`);
     });
 
     const type = objectTypeName ?
         await client.types.getTypeByName(objectTypeName).catch((e) => {
-            throw new NoDocumentFound(`Error fetching type ${objectTypeName}: ${e.message}`);
+            throw new DocumentNotFoundError(`Error fetching type ${objectTypeName}: ${e.message}`);
         })
         : undefined;
 

--- a/packages/workflow/src/activities/advanced/updateDocumentFromInteractionRun.ts
+++ b/packages/workflow/src/activities/advanced/updateDocumentFromInteractionRun.ts
@@ -1,6 +1,6 @@
 import { DSLActivityExecutionPayload, DSLActivitySpec, ExecutionRun } from "@vertesia/common";
 import { setupActivity } from "../../dsl/setup/ActivityContext.js";
-import { ActivityParamNotFound } from "../../errors.js";
+import { ActivityParamNotFoundError } from "../../errors.js";
 
 
 export interface UpdateDocumentFromInteractionRunParams {
@@ -19,7 +19,7 @@ export async function updateDocumentFromInteractionRun(payload: DSLActivityExecu
     const { params, client, objectId } = await setupActivity<UpdateDocumentFromInteractionRunParams>(payload);
 
     if (!params.run) {
-        throw new ActivityParamNotFound("run", payload.activity);
+        throw new ActivityParamNotFoundError("run", payload.activity);
     }
 
     const docProps = params.run.result;

--- a/packages/workflow/src/activities/createDocumentFromOther.ts
+++ b/packages/workflow/src/activities/createDocumentFromOther.ts
@@ -4,7 +4,7 @@ import { DSLActivityExecutionPayload, DSLActivitySpec } from "@vertesia/common";
 import fs from 'fs';
 import { pdfExtractPages } from "../conversion/mutool.js";
 import { setupActivity } from "../dsl/setup/ActivityContext.js";
-import { NoDocumentFound } from "../errors.js";
+import { DocumentNotFoundError } from "../errors.js";
 import { saveBlobToTempFile } from "../utils/blobs.js";
 
 interface CreatePdfDocumentFromSourceParams {
@@ -41,23 +41,23 @@ export async function createPdfDocumentFromSource(payload: DSLActivityExecutionP
 
     if (!inputObject) {
         log.error(`Document ${objectId} not found`);
-        throw new NoDocumentFound(`Document ${objectId} not found`, [objectId]);
+        throw new DocumentNotFoundError(`Document ${objectId} not found`, [objectId]);
     }
 
     if (!inputObject.content?.source) {
         log.error(`Document ${objectId} has no source`);
-        throw new NoDocumentFound(`Document ${objectId} has no source`, [objectId]);
+        throw new DocumentNotFoundError(`Document ${objectId} has no source`, [objectId]);
     }
 
     if (!inputObject.content.type || (!inputObject.content.type?.startsWith('application/pdf'))) {
         log.error(`Document ${objectId} is not an image`);
-        throw new NoDocumentFound(`Document ${objectId} is not an image or pdf: ${inputObject.content.type}`, [objectId]);
+        throw new DocumentNotFoundError(`Document ${objectId} is not an image or pdf: ${inputObject.content.type}`, [objectId]);
     }
 
     const targetType = await client.types.getTypeByName(params.target_object_type);
     if (!targetType) {
         log.error(`Type ${params.target_object_type} not found`);
-        throw new NoDocumentFound(`Type ${params.target_object_type} not found`);
+        throw new DocumentNotFoundError(`Type ${params.target_object_type} not found`);
     }
 
     const tmpFile = await saveBlobToTempFile(client, inputObject.content.source, ".pdf");

--- a/packages/workflow/src/activities/executeInteraction.ts
+++ b/packages/workflow/src/activities/executeInteraction.ts
@@ -12,7 +12,7 @@ import {
 } from "@vertesia/common";
 import { projectResult } from "../dsl/projections.js";
 import { setupActivity } from "../dsl/setup/ActivityContext.js";
-import { ActivityParamInvalid, ActivityParamNotFound } from "../errors.js";
+import { ActivityParamInvalidError, ActivityParamNotFoundError } from "../errors.js";
 import { TruncateSpec, truncByMaxTokens } from "../utils/tokens.js";
 
 //Example:
@@ -130,7 +130,7 @@ export async function executeInteraction(payload: DSLActivityExecutionPayload<Ex
 
     if (!interactionName) {
         log.error("Missing interactionName", { params });
-        throw new ActivityParamNotFound("interactionName", payload.activity);
+        throw new ActivityParamNotFoundError("interactionName", payload.activity);
     }
 
     if (params.truncate) {
@@ -157,10 +157,10 @@ export async function executeInteraction(payload: DSLActivityExecutionPayload<Ex
         log.error("Failed to execute interaction", { error });
         if (error.message.includes("Failed to validate merged prompt schema")) {
             //issue with the input data, don't retry
-            throw new ActivityParamInvalid("prompt_data", payload.activity, error.message);
+            throw new ActivityParamInvalidError("prompt_data", payload.activity, error.message);
         } else if (error.message.includes("modelId: Path `modelId` is required")) {
             //issue with the input data, don't retry
-            throw new ActivityParamInvalid("model", payload.activity, error.message);
+            throw new ActivityParamInvalidError("model", payload.activity, error.message);
         } else {
             throw error;
         }

--- a/packages/workflow/src/activities/extractDocumentText.ts
+++ b/packages/workflow/src/activities/extractDocumentText.ts
@@ -5,14 +5,14 @@ import {
     DSLActivityExecutionPayload,
     DSLActivitySpec,
 } from "@vertesia/common";
+import { markdownWithMarkitdown } from "../conversion/markitdown.js";
 import { mutoolPdfToText } from "../conversion/mutool.js";
 import { markdownWithPandoc } from "../conversion/pandoc.js";
 import { setupActivity } from "../dsl/setup/ActivityContext.js";
-import { NoDocumentFound } from "../errors.js";
+import { DocumentNotFoundError } from "../errors.js";
 import { TextExtractionResult, TextExtractionStatus } from "../result-types.js";
 import { fetchBlobAsBuffer, md5 } from "../utils/blobs.js";
 import { countTokens } from "../utils/tokens.js";
-import { markdownWithMarkitdown } from "../conversion/markitdown.js";
 
 //@ts-ignore
 const JSON: DSLActivitySpec = {
@@ -39,7 +39,7 @@ export async function extractDocumentText(
     const doc = r[0] as ContentObject;
     if (!doc) {
         log.error(`Document ${objectId} not found`);
-        throw new NoDocumentFound(`Document ${objectId} not found`, payload.objectIds);
+        throw new DocumentNotFoundError(`Document ${objectId} not found`, payload.objectIds);
     }
 
     log.info(`Extracting text for object ${doc.id}`);

--- a/packages/workflow/src/activities/generateEmbeddings.ts
+++ b/packages/workflow/src/activities/generateEmbeddings.ts
@@ -10,7 +10,7 @@ import {
     SupportedEmbeddingTypes,
 } from "@vertesia/common";
 import { setupActivity } from "../dsl/setup/ActivityContext.js";
-import { NoDocumentFound } from "../errors.js";
+import { DocumentNotFoundError } from "../errors.js";
 import { fetchBlobAsBase64, md5 } from "../utils/blobs.js";
 import { DocPart, getContentParts } from "../utils/chunks.js";
 import { countTokens } from "../utils/tokens.js";
@@ -59,16 +59,16 @@ export async function generateEmbeddings(
     const projectData = await fetchProject();
     const config = projectData?.configuration.embeddings[type];
     if (!projectData) {
-        throw new NoDocumentFound("Project not found", [payload.project_id]);
+        throw new DocumentNotFoundError("Project not found", [payload.project_id]);
     }
     if (!config) {
-        throw new NoDocumentFound("Embeddings configuration not found", [
+        throw new DocumentNotFoundError("Embeddings configuration not found", [
             objectId,
         ]);
     }
 
     if (!projectData) {
-        throw new NoDocumentFound("Project not found", [payload.project_id]);
+        throw new DocumentNotFoundError("Project not found", [payload.project_id]);
     }
 
     if (!projectData?.configuration.embeddings[type]?.enabled) {
@@ -100,11 +100,11 @@ export async function generateEmbeddings(
     );
 
     if (!document) {
-        throw new NoDocumentFound("Document not found", [objectId]);
+        throw new DocumentNotFoundError("Document not found", [objectId]);
     }
 
     if (!document.content) {
-        throw new NoDocumentFound("Document content not found", [objectId]);
+        throw new DocumentNotFoundError("Document content not found", [objectId]);
     }
 
     let res;
@@ -413,12 +413,12 @@ async function generateImageEmbeddings({
         !resRnd.renditions ||
         !resRnd.renditions.length
     ) {
-        throw new NoDocumentFound("Rendition retrieval failed", [document.id]);
+        throw new DocumentNotFoundError("Rendition retrieval failed", [document.id]);
     }
 
     const renditions = resRnd.renditions;
     if (!renditions?.length) {
-        throw new NoDocumentFound("No source found in rendition", [
+        throw new DocumentNotFoundError("No source found in rendition", [
             document.id,
         ]);
     }

--- a/packages/workflow/src/activities/media/processPdfWithTextract.ts
+++ b/packages/workflow/src/activities/media/processPdfWithTextract.ts
@@ -16,7 +16,7 @@ import type { AwsCredentialIdentityProvider } from "@smithy/types";
 import { log } from "@temporalio/activity";
 import { TextractProcessor } from "../../conversion/TextractProcessor.js";
 import { setupActivity } from "../../dsl/setup/ActivityContext.js";
-import { NoDocumentFound } from "../../errors.js";
+import { DocumentNotFoundError } from "../../errors.js";
 import { TextExtractionResult, TextExtractionStatus } from "../../result-types.js";
 import { fetchBlobAsBuffer, md5 } from "../../utils/blobs.js";
 import { countTokens } from "../../utils/tokens.js";
@@ -49,13 +49,13 @@ export async function convertPdfToStructuredText(payload: DSLActivityExecutionPa
     }
 
     if (!object.content?.source) {
-        throw new NoDocumentFound(`No source found for object ${objectId}`);
+        throw new DocumentNotFoundError(`No source found for object ${objectId}`);
     }
 
     const pdfUrl = await client.store.objects.getContentSource(objectId).then(res => res.source);
 
     if (!pdfUrl) {
-        throw new NoDocumentFound(`Error fetching source ${object.content.source}`);
+        throw new DocumentNotFoundError(`Error fetching source ${object.content.source}`);
     }
 
 
@@ -123,10 +123,10 @@ export async function getS3AWSCredentials(awsConfig: AwsConfiguration, composabl
 
     // fetch s3 role ARN
     if (!awsConfig || !awsConfig.enabled) {
-        throw new NoDocumentFound("AWS integration is not enabled for this project");
+        throw new DocumentNotFoundError("AWS integration is not enabled for this project");
     }
     if (!awsConfig.s3_role_arn) {
-        throw new NoDocumentFound("S3 Role ARN is not defined in AWS project integration");
+        throw new DocumentNotFoundError("S3 Role ARN is not defined in AWS project integration");
     }
 
     log.info("Getting AWS credentials for Textract", { projectId, composableAuthToken, roleArn: awsConfig.s3_role_arn });

--- a/packages/workflow/src/activities/media/transcribeMediaWithGladia.ts
+++ b/packages/workflow/src/activities/media/transcribeMediaWithGladia.ts
@@ -2,7 +2,7 @@ import { DSLActivityExecutionPayload, DSLActivitySpec, GladiaConfiguration, Supp
 import { activityInfo, CompleteAsyncError, log } from "@temporalio/activity";
 import { FetchClient } from "@vertesia/api-fetch-client";
 import { setupActivity } from "../../dsl/setup/ActivityContext.js";
-import { NoDocumentFound } from "../../errors.js";
+import { DocumentNotFoundError } from "../../errors.js";
 import { TextExtractionResult, TextExtractionStatus } from "../../index.js";
 
 
@@ -27,7 +27,7 @@ export async function transcribeMedia(payload: DSLActivityExecutionPayload<Trans
 
     const gladiaConfig = await client.projects.integrations.retrieve(payload.project_id, SupportedIntegrations.gladia) as GladiaConfiguration | undefined;
     if (!gladiaConfig || !gladiaConfig.enabled) {
-        throw new NoDocumentFound("Gladia integration not enabled");
+        throw new DocumentNotFoundError("Gladia integration not enabled");
     }
 
     const object = await client.objects.retrieve(objectId, "+text");
@@ -39,13 +39,13 @@ export async function transcribeMedia(payload: DSLActivityExecutionPayload<Trans
     }
 
     if (!object.content?.source) {
-        throw new NoDocumentFound(`No source found for object ${objectId}`);
+        throw new DocumentNotFoundError(`No source found for object ${objectId}`);
     }
 
     const mediaUrl = await client.store.objects.getContentSource(objectId).then(res => res.source);
 
     if (!mediaUrl) {
-        throw new NoDocumentFound(`Error fetching source ${object.content.source}`);
+        throw new DocumentNotFoundError(`Error fetching source ${object.content.source}`);
     }
 
     const taskToken = Buffer.from(activityInfo().taskToken).toString('base64url');

--- a/packages/workflow/src/activities/notifyWebhook.ts
+++ b/packages/workflow/src/activities/notifyWebhook.ts
@@ -1,7 +1,7 @@
 import { log } from "@temporalio/activity";
 import { DSLActivityExecutionPayload, DSLActivitySpec } from "@vertesia/common";
 import { setupActivity } from "../dsl/setup/ActivityContext.js";
-import { WorkflowParamNotFound } from "../errors.js";
+import { WorkflowParamNotFoundError } from "../errors.js";
 
 export interface NotifyWebhookParams {
     target_url: string; //URL to send the notification to
@@ -21,7 +21,7 @@ export async function notifyWebhook(payload: DSLActivityExecutionPayload<NotifyW
     const { params } = await setupActivity<NotifyWebhookParams>(payload);
     const { target_url, method, payload: requestPayload, headers } = params
 
-    if (!target_url) throw new WorkflowParamNotFound('target_url');
+    if (!target_url) throw new WorkflowParamNotFoundError('target_url');
 
     const body = method === 'POST' ? JSON.stringify({
         ...requestPayload,

--- a/packages/workflow/src/activities/renditions/generateImageRendition.ts
+++ b/packages/workflow/src/activities/renditions/generateImageRendition.ts
@@ -1,7 +1,7 @@
 import { log } from "@temporalio/activity";
 import { DSLActivityExecutionPayload, DSLActivitySpec } from "@vertesia/common";
 import { setupActivity } from "../../dsl/setup/ActivityContext.js";
-import { NoDocumentFound, WorkflowParamNotFound } from "../../errors.js";
+import { DocumentNotFoundError, WorkflowParamNotFoundError } from "../../errors.js";
 import { saveBlobToTempFile } from "../../utils/blobs.js";
 import {
   ImageRenditionParams,
@@ -39,19 +39,19 @@ export async function generateImageRendition(
   const inputObject = await client.objects.retrieve(objectId).catch((err) => {
     log.error(`Failed to retrieve document ${objectId}`, { err });
     if (err.message.includes("not found")) {
-      throw new NoDocumentFound(`Document ${objectId} not found`, [objectId]);
+      throw new DocumentNotFoundError(`Document ${objectId} not found`, [objectId]);
     }
     throw err;
   });
 
   if (!params.format) {
     log.error(`Format not found`);
-    throw new WorkflowParamNotFound(`format`);
+    throw new WorkflowParamNotFoundError(`format`);
   }
 
   if (!inputObject.content?.source) {
     log.error(`Document ${objectId} has no source`);
-    throw new NoDocumentFound(`Document ${objectId} has no source`, [objectId]);
+    throw new DocumentNotFoundError(`Document ${objectId} has no source`, [objectId]);
   }
 
   if (
@@ -61,7 +61,7 @@ export async function generateImageRendition(
     log.error(
       `Document ${objectId} is not an image or a video: ${inputObject.content.type}`,
     );
-    throw new NoDocumentFound(
+    throw new DocumentNotFoundError(
       `Document ${objectId} is not an image or a video: ${inputObject.content.type}`,
       [objectId],
     );

--- a/packages/workflow/src/activities/renditions/generateVideoRendition.ts
+++ b/packages/workflow/src/activities/renditions/generateVideoRendition.ts
@@ -6,7 +6,7 @@ import os from "os";
 import path from "path";
 import { promisify } from "util";
 import { setupActivity } from "../../dsl/setup/ActivityContext.js";
-import { NoDocumentFound, WorkflowParamNotFound } from "../../errors.js";
+import { DocumentNotFoundError, WorkflowParamNotFoundError } from "../../errors.js";
 import { saveBlobToTempFile } from "../../utils/blobs.js";
 import {
     ImageRenditionParams,
@@ -136,7 +136,7 @@ export async function generateVideoRendition(
     const inputObject = await client.objects.retrieve(objectId).catch((err) => {
         log.error(`Failed to retrieve document ${objectId}`, { err });
         if (err.message.includes("not found")) {
-            throw new NoDocumentFound(`Document ${objectId} not found`, [
+            throw new DocumentNotFoundError(`Document ${objectId} not found`, [
                 objectId,
             ]);
         }
@@ -145,12 +145,12 @@ export async function generateVideoRendition(
 
     if (!params.format) {
         log.error(`Format not found`);
-        throw new WorkflowParamNotFound(`format`);
+        throw new WorkflowParamNotFoundError(`format`);
     }
 
     if (!inputObject.content?.source) {
         log.error(`Document ${objectId} has no source`);
-        throw new NoDocumentFound(`Document ${objectId} has no source`, [
+        throw new DocumentNotFoundError(`Document ${objectId} has no source`, [
             objectId,
         ]);
     }
@@ -162,7 +162,7 @@ export async function generateVideoRendition(
         log.error(
             `Document ${objectId} is not a video: ${inputObject.content.type}`,
         );
-        throw new NoDocumentFound(
+        throw new DocumentNotFoundError(
             `Document ${objectId} is not a video: ${inputObject.content.type}`,
             [objectId],
         );

--- a/packages/workflow/src/dsl/dsl-workflow.ts
+++ b/packages/workflow/src/dsl/dsl-workflow.ts
@@ -21,10 +21,10 @@ import {
     WorkflowExecutionPayload
 } from "@vertesia/common";
 import ms, { StringValue } from 'ms';
-import { ActivityParamInvalid, ActivityParamNotFound, NoDocumentFound, WorkflowParamNotFound } from "../errors.js";
-import { Vars } from "./vars.js";
 import { HandleDslErrorParams } from "../activities/handleError.js";
 import * as activities from "../activities/index.js";
+import { WF_NON_RETRYABLE_ERRORS, WorkflowParamNotFoundError } from "../errors.js";
+import { Vars } from "./vars.js";
 
 interface BaseActivityPayload extends WorkflowExecutionPayload {
     workflow_name: string;
@@ -43,7 +43,7 @@ export async function dslWorkflow(payload: DSLWorkflowExecutionPayload) {
 
     const definition = payload.workflow;
     if (!definition) {
-        throw new WorkflowParamNotFound("workflow");
+        throw new WorkflowParamNotFoundError("workflow");
     }
     // the base payload will be used to create the activities payload
     const basePayload: BaseActivityPayload = {
@@ -61,12 +61,7 @@ export async function dslWorkflow(payload: DSLWorkflowExecutionPayload) {
             backoffCoefficient: 2,
             maximumAttempts: 10,
             maximumInterval: 100 * 30 * 1000, //ms
-            nonRetryableErrorTypes: [
-                NoDocumentFound.name,
-                ActivityParamNotFound.name,
-                WorkflowParamNotFound.name,
-                ActivityParamInvalid.name,
-            ],
+            nonRetryableErrorTypes: WF_NON_RETRYABLE_ERRORS,
         },
     };
     log.debug("Global activity options", {

--- a/packages/workflow/src/dsl/setup/ActivityContext.ts
+++ b/packages/workflow/src/dsl/setup/ActivityContext.ts
@@ -6,7 +6,7 @@ import {
     Project,
     WorkflowExecutionPayload,
 } from "@vertesia/common";
-import { NoDocumentFound, WorkflowParamNotFound } from "../../errors.js";
+import { DocumentNotFoundError, WorkflowParamNotFoundError } from "../../errors.js";
 import { getProjectFromToken } from "../../utils/auth.js";
 import { getVertesiaClient } from "../../utils/client.js";
 import { Vars } from "../vars.js";
@@ -38,7 +38,7 @@ export class ActivityContext<ParamsT extends Record<string, any>> {
         const objectId = this.payload.objectIds && this.payload.objectIds[0];
         if (!objectId) {
             log.error("No objectId found in payload");
-            throw new WorkflowParamNotFound(
+            throw new WorkflowParamNotFoundError(
                 "objectIds[0]",
                 (this.payload as WorkflowExecutionPayload as DSLWorkflowExecutionPayload).workflow,
             );
@@ -54,7 +54,7 @@ export class ActivityContext<ParamsT extends Record<string, any>> {
         const runId = activityInfo().workflowExecution.runId;
         if (!runId) {
             log.error("No runId found in activityInfo");
-            throw new WorkflowParamNotFound(
+            throw new WorkflowParamNotFoundError(
                 "runId",
                 (this.payload as WorkflowExecutionPayload as DSLWorkflowExecutionPayload).workflow,
             );
@@ -66,7 +66,7 @@ export class ActivityContext<ParamsT extends Record<string, any>> {
         const workflowId = activityInfo().workflowExecution.workflowId;
         if (!workflowId) {
             log.error("No workflowId found in activityInfo");
-            throw new WorkflowParamNotFound(
+            throw new WorkflowParamNotFoundError(
                 "workflowId",
                 (this.payload as WorkflowExecutionPayload as DSLWorkflowExecutionPayload).workflow,
             );
@@ -127,7 +127,7 @@ export async function setupActivity<ParamsT extends Record<string, any>>(
                         vars.setValue(key, result);
                     }
                 } else if (fetchSpec.on_not_found === "throw") {
-                    throw new NoDocumentFound("No documents found for: " + JSON.stringify(fetchSpec));
+                    throw new DocumentNotFoundError("No documents found for: " + JSON.stringify(fetchSpec));
                 } else {
                     vars.setValue(key, null);
                 }

--- a/packages/workflow/src/errors.ts
+++ b/packages/workflow/src/errors.ts
@@ -1,6 +1,9 @@
 import { ApplicationFailure } from "@temporalio/workflow";
 import { DSLActivitySpec, DSLWorkflowSpec } from "@vertesia/common";
 
+/**
+ * @deprecated Use {@link DocumentNotFoundError} instead.
+ */
 export class NoDocumentFound extends Error {
     constructor(
         message: string,
@@ -22,6 +25,9 @@ export class DocumentNotFoundError extends ApplicationFailure {
     }
 }
 
+/**
+ * @deprecated Use {@link ActivityParamNotFoundError} instead.
+ */
 export class ActivityParamNotFound extends Error {
     constructor(
         public paramName: string,
@@ -32,6 +38,22 @@ export class ActivityParamNotFound extends Error {
     }
 }
 
+export class ActivityParamNotFoundError extends ApplicationFailure {
+    constructor(
+        public paramName: string,
+        public activity: DSLActivitySpec,
+    ) {
+        super(
+            `Required parameter ${paramName} not found in activity ${activity.name}`,
+            "ActivityParamNotFoundError",
+            true, // non-retryable
+        );
+    }
+}
+
+/**
+ * @deprecated Use {@link ActivityParamInvalidError} instead.
+ */
 export class ActivityParamInvalid extends Error {
     constructor(
         public paramName: string,
@@ -43,6 +65,23 @@ export class ActivityParamInvalid extends Error {
     }
 }
 
+export class ActivityParamInvalidError extends ApplicationFailure {
+    constructor(
+        public paramName: string,
+        public activity: DSLActivitySpec,
+        reason?: string,
+    ) {
+        super(
+            `${paramName} in activity ${activity.name} is invalid${reason ? ` ${reason}` : ""}`,
+            "ActivityParamInvalidError",
+            true, // non-retryable
+        );
+    }
+}
+
+/**
+ * @deprecated Use {@link WorkflowParamNotFoundError} instead.
+ */
 export class WorkflowParamNotFound extends Error {
     constructor(
         public paramName: string,
@@ -53,9 +92,26 @@ export class WorkflowParamNotFound extends Error {
     }
 }
 
+export class WorkflowParamNotFoundError extends ApplicationFailure {
+    constructor(
+        public paramName: string,
+        public workflow?: DSLWorkflowSpec,
+    ) {
+        super(
+            `Required parameter ${paramName} not found in workflow ${workflow?.name}`,
+            "WorkflowParamNotFoundError",
+            true, // non-retryable
+        );
+    }
+}
+
 export const WF_NON_RETRYABLE_ERRORS = [
     "NoDocumentFound",
     "DocumentNotFoundError",
+    "ActivityParamInvalid",
+    "ActivityParamInvalidError",
     "ActivityParamNotFound",
+    "ActivityParamNotFoundError",
     "WorkflowParamNotFound",
+    "WorkflowParamNotFoundError",
 ];

--- a/packages/workflow/src/utils/blobs.ts
+++ b/packages/workflow/src/utils/blobs.ts
@@ -1,10 +1,10 @@
 import { VertesiaClient } from "@vertesia/client";
 import crypto from "crypto";
 import { createWriteStream } from "fs";
-import tmp from "tmp";
-import { NoDocumentFound } from "../errors.js";
 import { Readable } from "stream";
 import { pipeline } from "stream/promises";
+import tmp from "tmp";
+import { DocumentNotFoundError } from "../errors.js";
 
 tmp.setGracefulCleanup();
 
@@ -14,7 +14,7 @@ export async function fetchBlobAsStream(client: VertesiaClient, blobUri: string)
     } catch (err: any) {
         if (err.message.includes("not found")) {
             //TODO improve error handling with a fetch fail error class in the client
-            throw new NoDocumentFound(`Failed to download blob ${blobUri}: ${err.message}`, []);
+            throw new DocumentNotFoundError(`Failed to download blob ${blobUri}: ${err.message}`, []);
         } else {
             throw new Error(`Failed to download blob ${blobUri}: ${err.message}`);
         }

--- a/packages/workflow/src/utils/client.ts
+++ b/packages/workflow/src/utils/client.ts
@@ -4,21 +4,21 @@
 
 import { VertesiaClient } from "@vertesia/client";
 import { WorkflowExecutionBaseParams } from "@vertesia/common";
-import { WorkflowParamNotFound } from "../errors.js";
+import { WorkflowParamNotFoundError } from "../errors.js";
 
 
 export function getVertesiaClient(payload: WorkflowExecutionBaseParams) {
 
     if (!payload.auth_token) {
-        throw new WorkflowParamNotFound("Authentication Token is missing from WorkflowExecutionPayload.authToken");
+        throw new WorkflowParamNotFoundError("Authentication Token is missing from WorkflowExecutionPayload.authToken");
     }
 
     if (!payload.config?.studio_url) {
-        throw new WorkflowParamNotFound("Content Store URL is missing from WorkflowExecutionPayload.servers.storeUrl");
+        throw new WorkflowParamNotFoundError("Content Store URL is missing from WorkflowExecutionPayload.servers.storeUrl");
     }
 
     if (!payload.config?.store_url) {
-        throw new WorkflowParamNotFound("Content Store URL is missing from WorkflowExecutionPayload.servers.storeUrl");
+        throw new WorkflowParamNotFoundError("Content Store URL is missing from WorkflowExecutionPayload.servers.storeUrl");
     }
 
     const client = new VertesiaClient({


### PR DESCRIPTION
Currently, the errors thrown by the workflow can be retried, but they are not retryable. This PR provides new error types that wrap the non-retryable error `ApplicationFailure` from Temporal SDK to mark the activity or workflow execution as failed. Therefore, callers won't need to specify a custom retry policy anymore.