### PR TITLE
refactor(ui): standardize editor headers and button styles

### DIFF
--- a/packages/ui/src/features/store/types/ObjectSchemaEditor.tsx
+++ b/packages/ui/src/features/store/types/ObjectSchemaEditor.tsx
@@ -85,9 +85,9 @@ export function ObjectSchemaEditor({ objectType, onSchemaUpdate }: ObjectSchemaE
     };
 
     return (
-        <div className="mx-2 my-2 rounded-md border border-solid shadow-md border-spacing-2">
-            <div className="flex items-center rounded-t-md border-b gap-x-2 py-2 px-4">
-                <div className="text-lg font-semibold">Schema Editor</div>
+        <div className="mx-2 my-2 rounded-2xl border border-solid shadow-md border-spacing-2">
+            <div className="flex items-center rounded-t-md border-b gap-x-2 py-2 pl-4 pr-2">
+                <div className="text-base font-semibold">Schema Editor</div>
                 <div>
                     <Button variant="outline" size="sm" onClick={handleOnSave}>
                         {

--- a/packages/ui/src/features/store/types/TableLayoutEditor.tsx
+++ b/packages/ui/src/features/store/types/TableLayoutEditor.tsx
@@ -81,11 +81,11 @@ export function TableLayoutEditor({ objectType, onLayoutUpdate }: TableLayoutEdi
 
 
     return (
-        <div className="mx-2 my-2 rounded-md border border-solid shadow-xs">
-            <div className="flex items-center rounded-t-md gap-x-2 bg-gray-50 dark:bg-slate-800 py-2 px-2">
-                <div className="text-lg font-semibold ">Table Layout Editor</div>
+        <div className="mx-2 my-2 rounded-2xl border border-solid shadow-xs">
+            <div className="flex items-center rounded-t-md border-b gap-x-2 py-2 pl-4 pr-2">
+                <div className="text-base font-semibold ">Table Layout Editor</div>
                 <div className="ml-auto flex gap-x-2">
-                    <Button isLoading={isUpdating} variant="secondary" onClick={onSave}>Save Changes</Button>
+                    <Button isLoading={isUpdating} variant="outline" size="sm" onClick={onSave}>Save Changes</Button>
                 </div>
             </div>
             <div className="px-4 py-2">

--- a/packages/ui/src/widgets/schema-editor/editor/SchemaEditor.tsx
+++ b/packages/ui/src/widgets/schema-editor/editor/SchemaEditor.tsx
@@ -154,7 +154,7 @@ function AddPropertyButton({ parent }: AddPropertyButtonProps) {
         parent.reloadTree();
     }
     return (
-        <Button variant="outline" onClick={add}>
+        <Button variant="ghost" onClick={add}>
             <Plus className='size-4' />Add property
         </Button>
     )


### PR DESCRIPTION
- Change 'Add property' button variant from 'ghost' to 'outline' for consistency
- Clean up editor headers:
  - Reduce heading text size for better visual hierarchy
  - Remove legacy background colors
  - Standardize right-side action buttons to 'outline' variant
- Affected components:
  - Schema Editor header
  - Table Layout Editor header
  - Add property button