### PR TITLE
chore: remove deprecated workflow types

### DIFF
--- a/packages/workflow/src/errors.ts
+++ b/packages/workflow/src/errors.ts
@@ -1,20 +1,6 @@
 import { ApplicationFailure } from "@temporalio/workflow";
 import { DSLActivitySpec, DSLWorkflowSpec } from "@vertesia/common";
 
-/**
- * @deprecated Use {@link DocumentNotFoundError} instead.
- */
-export class NoDocumentFound extends Error {
-    constructor(
-        message: string,
-        public ids?: string[],
-    ) {
-        super(message);
-        this.name = "NoDocumentFound";
-        this.ids = ids;
-    }
-}
-
 export class DocumentNotFoundError extends ApplicationFailure {
     constructor(message: string, public ids?: string[]) {
         super(
@@ -22,19 +8,6 @@ export class DocumentNotFoundError extends ApplicationFailure {
             "DocumentNotFoundError",
             true, // non-retryable
         )
-    }
-}
-
-/**
- * @deprecated Use {@link ActivityParamNotFoundError} instead.
- */
-export class ActivityParamNotFound extends Error {
-    constructor(
-        public paramName: string,
-        public activity: DSLActivitySpec,
-    ) {
-        super(`Required parameter ${paramName} not found in activity ${activity.name}`);
-        this.name = "ActivityParamNotFound";
     }
 }
 
@@ -48,20 +21,6 @@ export class ActivityParamNotFoundError extends ApplicationFailure {
             "ActivityParamNotFoundError",
             true, // non-retryable
         );
-    }
-}
-
-/**
- * @deprecated Use {@link ActivityParamInvalidError} instead.
- */
-export class ActivityParamInvalid extends Error {
-    constructor(
-        public paramName: string,
-        public activity: DSLActivitySpec,
-        reason?: string,
-    ) {
-        super(`${paramName} in activity ${activity.name} is invalid${reason ? ` ${reason}` : ""}`);
-        this.name = "ActivityParamInvalid";
     }
 }
 
@@ -79,19 +38,6 @@ export class ActivityParamInvalidError extends ApplicationFailure {
     }
 }
 
-/**
- * @deprecated Use {@link WorkflowParamNotFoundError} instead.
- */
-export class WorkflowParamNotFound extends Error {
-    constructor(
-        public paramName: string,
-        public workflow?: DSLWorkflowSpec,
-    ) {
-        super(`Required parameter ${paramName} not found in workflow ${workflow?.name}`);
-        this.name = "WorkflowParamNotFound";
-    }
-}
-
 export class WorkflowParamNotFoundError extends ApplicationFailure {
     constructor(
         public paramName: string,
@@ -106,12 +52,8 @@ export class WorkflowParamNotFoundError extends ApplicationFailure {
 }
 
 export const WF_NON_RETRYABLE_ERRORS = [
-    "NoDocumentFound",
     "DocumentNotFoundError",
-    "ActivityParamInvalid",
     "ActivityParamInvalidError",
-    "ActivityParamNotFound",
     "ActivityParamNotFoundError",
-    "WorkflowParamNotFound",
     "WorkflowParamNotFoundError",
 ];


### PR DESCRIPTION
These types are replaced by the non-retryable version, so they are no longer used. They can be safely removed.