### PR TITLE
fix: standardise meaning of Env.IsProd, replace with Env.IsStable

### DIFF
--- a/packages/ui/src/env/index.ts
+++ b/packages/ui/src/env/index.ts
@@ -64,8 +64,12 @@ export class VertesiaEnvironment implements Readonly<EnvProps> {
         return this.type === "production";
     }
 
+    get isStable() {
+        return this.type === "production" || this.type === "preview" || this.type === "dr";
+    }
+
     get isDev() {
-        return !this.isProd;
+        return !this.isStable;
     }
 
     get isPreview() {


### PR DESCRIPTION
Env.IsProd, sometimes meant preview, production and disaster recovery and sometimes (for UI env) meant just prod.

To clear up usage in the future, this introduces Env.IsStable, which means preview, production and disaster recovery.
While Env.IsProd, just means production.