### PR TITLE
feat: remove start a new agent from current agent action

### DIFF
--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/Header.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/Header.tsx
@@ -148,11 +148,6 @@ function MoreDropdown({
         }
     };
 
-    const startNewAgent = () => {
-        builder.reset();
-        resetWorkflow?.();
-    }
-
     const openUrl = (url: string) => {
         window.open(url, "_blank");
         return url;
@@ -215,11 +210,6 @@ function MoreDropdown({
                                     }}>
                                         <XIcon className="size-3.5 mr-2 text-destructive" /> Cancel Workflow
                                     </CommandItem>
-                                    {!isModal && (
-                                        <CommandItem className="text-xs" onSelect={startNewAgent}>
-                                            <Plus className="size-3.5 mr-2 text-muted" /> Start a new Agent
-                                        </CommandItem>
-                                    )}
                                 </CommandGroup>
                             </CommandList>
                         </Command>

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/Header.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/Header.tsx
@@ -8,7 +8,6 @@ import {
     DownloadCloudIcon,
     ExternalLink,
     MoreVertical,
-    Plus,
     XIcon,
 } from "lucide-react";
 import { PayloadBuilderProvider, usePayloadBuilder } from "../../PayloadBuilder";


### PR DESCRIPTION
There was a "start a new agent" in the action of the current agent; the following issues were raised
- It's hard to find for first-time user
- should not mix with the current agent action

## Before
<img width="833" alt="Screenshot 2025-06-09 at 16 04 27" src="https://github.com/user-attachments/assets/789ac10c-1506-45de-bb6c-8fdb715e5cec" />
