### PR TITLE
feat: enhance content type description support

### DIFF
--- a/packages/ui/src/features/store/types/ContentObjectTypeView.tsx
+++ b/packages/ui/src/features/store/types/ContentObjectTypeView.tsx
@@ -130,6 +130,7 @@ function MetadataView({ objectType }: MetadataViewProps) {
     return (
         <PropertiesView className='w-full' properties={[
             { name: "Id", value: objectType.id },
+            { name: "Description", value: objectType.description ?? ""},
             { name: "Name", value: objectType.name },
             { name: "Is Chunkable", value: <ChunkableSwitch objectType={objectType} /> },
             { name: "Strict Mode", value: <StrictModeSwitch objectType={objectType} /> },

--- a/packages/ui/src/features/store/types/CreateOrUpdateTypeModal.tsx
+++ b/packages/ui/src/features/store/types/CreateOrUpdateTypeModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { Button, Input, Modal, ModalBody, ModalFooter, ModalTitle, Switch, useToast } from '@vertesia/ui/core';
+import { Button, Input, Modal, ModalBody, ModalFooter, ModalTitle, Switch, useToast, Textarea } from '@vertesia/ui/core';
 
 export interface CreateOrUpdateTypePayload {
     name: string;
@@ -48,7 +48,7 @@ export function CreateOrUpdateTypeModal({ title, isOpen, onClose, okLabel, initi
                     </div>
                     <div>
                         <label className="block text-sm font-medium text-muted">Description</label>
-                        <Input value={description} onChange={setDescription} />
+                        <Textarea value={description} onChange={setDescription} />
                     </div>
                     <div className="flex items-center justify-between">
                         <label className="block text-sm font-medium text-muted-foreground">Strict Mode</label>


### PR DESCRIPTION
## Summary
- Add description field display in ContentObjectTypeView metadata section
- Replace Input with Textarea component for better description editing experience in CreateOrUpdateTypeModal
- Improve UX for managing content type descriptions with proper multi-line support

## Test plan
- [ ] Verify description field appears in content type metadata view
- [ ] Test description editing with Textarea component in create/update modal
- [ ] Confirm description saves and displays correctly

🤖 Generated with [Claude Code](https://claude.ai/code)