### PR TITLE
Fix: name filter was not working on content object

### DIFF
--- a/packages/ui/src/features/facets/VFacetsNav.tsx
+++ b/packages/ui/src/features/facets/VFacetsNav.tsx
@@ -115,6 +115,7 @@ export function VFacetsNav({ facets, search, textSearch = '' }: FacetsNavProps) 
                 switch (filterName) {
                     case 'name':
                         search.query.search_term = filterValue;
+                        search.query.name = filterValue;
                         break;
                     case 'user':
                         search.query.initiated_by = filterValue === 'Unknown User' ? 'unknown' : filterValue;


### PR DESCRIPTION
## Description 
On the Content Objects Page, the `by Name or ID` was not working 
The problem was found in the API call, the column name was not aligned

This PR fixed the problem and tested as shown in screenshot
<img width="1229" alt="Screenshot 2025-06-16 at 09 39 44" src="https://github.com/user-attachments/assets/e0023efb-244c-42f0-a942-ef6a1d5f6cb7" />
