### PR TITLE
Fix: name filter was not working on content object (#311)

### DIFF
--- a/packages/ui/src/features/facets/VFacetsNav.tsx
+++ b/packages/ui/src/features/facets/VFacetsNav.tsx
@@ -115,6 +115,7 @@ export function VFacetsNav({ facets, search, textSearch = '' }: FacetsNavProps) 
                 switch (filterName) {
                     case 'name':
                         search.query.search_term = filterValue;
+                        search.query.name = filterValue;
                         break;
                     case 'user':
                         search.query.initiated_by = filterValue === 'Unknown User' ? 'unknown' : filterValue;


### PR DESCRIPTION
Sync `preview` back to `main`
