### PR TITLE
Fix: Content objects grid view

### DIFF
--- a/packages/ui/src/features/store/objects/components/DocumentIcon.tsx
+++ b/packages/ui/src/features/store/objects/components/DocumentIcon.tsx
@@ -38,8 +38,6 @@ export function DocumentIcon({ selection, document, onSelectionChange }: Readonl
         retrieveRendition(client, document, setRenditionUrl, setRenditionAlt)
     }, [document])
 
-    console.log("renditionUrl", document)
-
     return (
         <Card className="relative flex flex-col border h-fit" onClick={handleNavigateToDocument}>
             {

--- a/packages/ui/src/features/store/objects/components/DocumentIcon.tsx
+++ b/packages/ui/src/features/store/objects/components/DocumentIcon.tsx
@@ -40,7 +40,7 @@ export function DocumentIcon({ selection, document, onSelectionChange, onRowClic
     }, [document])
 
     return (
-        <Card className="relative flex flex-col border h-fit" onClick={(e) => onRowClick ? onRowClick(document) : handleNavigateToDocument()}>
+        <Card className="relative flex flex-col border h-fit" onClick={() => onRowClick ? onRowClick(document) : handleNavigateToDocument()}>
             {
                 selection && (
                     <div

--- a/packages/ui/src/features/store/objects/components/DocumentIcon.tsx
+++ b/packages/ui/src/features/store/objects/components/DocumentIcon.tsx
@@ -12,9 +12,10 @@ interface DocumentIconProps {
     document: ContentObjectItem
     onSelectionChange: ((object: ContentObjectItem, ev: ChangeEvent<HTMLInputElement>) => void);
     selection: DocumentSelection;
+    onRowClick?: (object: ContentObjectItem) => void;
 
 }
-export function DocumentIcon({ selection, document, onSelectionChange }: Readonly<DocumentIconProps>) {
+export function DocumentIcon({ selection, document, onSelectionChange, onRowClick }: Readonly<DocumentIconProps>) {
     const { client } = useUserSession()
     const navigate = useNavigate()
 
@@ -39,7 +40,7 @@ export function DocumentIcon({ selection, document, onSelectionChange }: Readonl
     }, [document])
 
     return (
-        <Card className="relative flex flex-col border h-fit" onClick={handleNavigateToDocument}>
+        <Card className="relative flex flex-col border h-fit" onClick={(e) => onRowClick ? onRowClick(document) : handleNavigateToDocument()}>
             {
                 selection && (
                     <div

--- a/packages/ui/src/features/store/objects/components/SelectDocument.tsx
+++ b/packages/ui/src/features/store/objects/components/SelectDocument.tsx
@@ -33,9 +33,11 @@ export function SelectDocument({ onChange }: SelectDocumentProps) {
 interface SelectDocumentImplProps {
     onRowClick: (selected: ContentObjectItem) => void;
 }
+const LAST_DISPLAYED_VIEW = 'vertesia.content_store.lastDisplayedView'
+
 function SelectDocumentImpl({ onRowClick }: SelectDocumentImplProps) {
     const [isReady, setIsReady] = useState(false);
-    const [isGridView, setIsGridView] = useState(localStorage.getItem('lastDisplayedView') === 'grid');
+    const [isGridView, setIsGridView] = useState(localStorage.getItem(LAST_DISPLAYED_VIEW) === 'grid');
     const { search, isLoading, error, objects } = useWatchDocumentSearchResult();
 
     const loadMoreRef = useRef<HTMLDivElement>(null);

--- a/packages/ui/src/features/store/objects/layout/documentLayout.tsx
+++ b/packages/ui/src/features/store/objects/layout/documentLayout.tsx
@@ -52,7 +52,7 @@ export function DocumentTableView({ objects, selection, isLoading, onRowClick, c
     )
 }
 
-export function DocumentGridView({ objects, selection, isLoading, onSelectionChange }: ViewProps) {
+export function DocumentGridView({ objects, selection, isLoading, onSelectionChange, onRowClick }: ViewProps) {
 
     return (
         <>
@@ -61,7 +61,7 @@ export function DocumentGridView({ objects, selection, isLoading, onSelectionCha
             </div>
             <div className="w-full gap-2 grid lg:grid-cols-6">
                 {objects.map((document) => (
-                    <DocumentIcon key={document.id} document={document} selection={selection} onSelectionChange={onSelectionChange} />
+                    <DocumentIcon key={document.id} document={document} selection={selection} onSelectionChange={onSelectionChange} onRowClick={onRowClick} />
                 ))}
             </div>
         </>


### PR DESCRIPTION
## Description
Inside Interaction > Playground, you can select an object from a content object table, which allows the user to view it as a table or a thumbnail. There were the following issues.
- https://github.com/vertesia/studio/issues/2111 
  -  The problem was found because the default click behavior set on the grid view is to navigate to the object page, instead of being set by a caller function like the table view
  - The fix in this PR will pass down the `onRowClick` behavior to the Grid Rendering Component 
- https://github.com/vertesia/studio/issues/2106
  - The problem was found while the button was getting the last view status from the `localstorage`, the table was initialized as `table` every time
  - The fix in this PR will align both by fetching the last view status from the `localstorage`
  