### PR TITLE
Fix: reset query to handle removed filters

### DIFF
--- a/packages/ui/src/features/facets/VFacetsNav.tsx
+++ b/packages/ui/src/features/facets/VFacetsNav.tsx
@@ -106,6 +106,10 @@ export function VFacetsNav({ facets, search, textSearch = '' }: FacetsNavProps) 
         }
         setFilters(newFilters);
 
+        // Reset the actual query before reapplying filters. Otherwise the removed filters remain.
+        // Design should be improved to avoid this hack
+        search.query = {};
+
         newFilters.forEach(filter => {
             if (filter.value && filter.value.length > 0) {
                 const filterName = filter.name.toLowerCase();


### PR DESCRIPTION
## Summary
Fix issue where removed filters (like name search) remained in the workflow execution query, preventing proper filter clearing.

## Changes Made
- **Fixed VFacetsNav filter handling**: Reset query object before applying new filters to ensure removed filters are properly cleared
- **Improved filter state consistency**: When filters change, clear the query and reapply only active filters

## Problem
When filtering workflows by name and then removing the name filter, the `search_term` parameter remained in the query object, causing the search to continue using the old filter value.

## Solution
In `VFacetsNav.tsx`, when filters change:
1. Reset `search.query = {}` to clear all existing filters
2. Reapply only the currently active filters from the new filter set
3. Call `search.search()` once with the correct filter state

## Test Plan
- [x] Apply name filter to workflow executions
- [x] Remove name filter - results should show all workflows
- [x] Other filters continue to work correctly
- [x] Multiple filter combinations work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>