### PR TITLE
UX copy for page headers and spacing

### DIFF
--- a/packages/ui/src/features/layout/GenericPageNavHeader.tsx
+++ b/packages/ui/src/features/layout/GenericPageNavHeader.tsx
@@ -40,7 +40,7 @@ export function GenericPageNavHeader({ className, children, title, description, 
                         }
                     </div>
                 </div>
-                <div className="flex gap-x-4 shrink-0">{actions}</div>
+                <div className="flex gap-x-2 shrink-0">{actions}</div>
             </div>
             {children && <div className="w-full flex items-center">{children}</div>}
         </div>

--- a/packages/ui/src/features/permissions/SecureButton.tsx
+++ b/packages/ui/src/features/permissions/SecureButton.tsx
@@ -1,5 +1,5 @@
 import { Permission } from "@vertesia/common";
-import { Button, ButtonProps } from "@vertesia/ui/core";
+import { Button, ButtonProps } from "@vertesia/ui/core/components/shadcn/button";
 import { useUserPermissions } from "./UserPermissionsProvider";
 
 interface SecureButtonProps extends ButtonProps {


### PR DESCRIPTION
I reduced the spacing for the header area buttons and also updated the buttons to use the new shadcn button so we dont have two primary button