### PR TITLE
Fix: Re-enable PDF export functionality

### DIFF
--- a/packages/ui/src/features/store/objects/components/ContentOverview.tsx
+++ b/packages/ui/src/features/store/objects/components/ContentOverview.tsx
@@ -144,7 +144,7 @@ export function ContentOverview({
     };
 
     const handleExportDocx = () => handleExportDocument("docx");
-    //const handleExportPdf = () => handleExportDocument("pdf");
+    const handleExportPdf = () => handleExportDocument("pdf");
 
     const content = object.content;
     const isImage =
@@ -294,6 +294,15 @@ export function ContentOverview({
                                     >
                                         <Download className="h-4 w-4" />
                                         DOCX
+                                    </Button>
+                                    <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        onClick={handleExportPdf}
+                                        className="flex items-center gap-2"
+                                    >
+                                        <Download className="h-4 w-4" />
+                                        PDF
                                     </Button>
                                 </>
                             )}


### PR DESCRIPTION
## Summary
- Re-enabled PDF export functionality in ContentOverview component
- Uncommented the handleExportPdf function and added the PDF export button back to the UI

## Changes
- Restored the `handleExportPdf` function call in ContentOverview.tsx
- Added the PDF export button alongside the existing DOCX export button

## Test plan
- [ ] Verify PDF export button appears in content overview
- [ ] Test PDF export functionality works correctly
- [ ] Ensure no regression in existing DOCX export functionality

Part of the solution for https://github.com/vertesia/studio/issues/2027

🤖 Generated with [Claude Code](https://claude.ai/code)