### PR TITLE
feat: improve empty state layouts with full-height centering

### DIFF
--- a/packages/ui/src/core/components/EmptyCollection.tsx
+++ b/packages/ui/src/core/components/EmptyCollection.tsx
@@ -1,5 +1,5 @@
 import { Plus } from "lucide-react";
-import { Button } from "@vertesia/ui/core/components/shadcn/button";
+import { Button } from "@vertesia/ui/core";
 
 
 interface EmptyInteractionsProps {
@@ -13,7 +13,7 @@ export function EmptyCollection({ buttonLabel, title, children, onClick }: Empty
         <div className="flex items-center justify-center h-full text-center">
             <div className="py-12">
                 <svg
-                    className="mx-auto h-12 w-12"
+                    className="mx-auto size-12"
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor"

--- a/packages/ui/src/core/components/EmptyCollection.tsx
+++ b/packages/ui/src/core/components/EmptyCollection.tsx
@@ -1,5 +1,5 @@
 import { Plus } from "lucide-react";
-import { Button } from "./Button.js";
+import { Button } from "@vertesia/ui/core/components/shadcn/button";
 
 
 interface EmptyInteractionsProps {
@@ -10,29 +10,31 @@ interface EmptyInteractionsProps {
 }
 export function EmptyCollection({ buttonLabel, title, children, onClick }: EmptyInteractionsProps) {
     return (
-        <div className="text-center py-12">
-            <svg
-                className="mx-auto h-12 w-12 text-gray-400 dark:text-gray-200"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                aria-hidden="true"
-            >
-                <path
-                    vectorEffect="non-scaling-stroke"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M9 13h6m-3-3v6m-9 1V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z"
-                />
-            </svg>
-            <h3 className="mt-2 text-sm font-semibold text-gray-500">{title}</h3>
-            <p className="mt-1 text-sm text-gray-500">{children}</p>
-            <div className="mt-6">
-                <Button onClick={onClick} size='lg'>
-                    <Plus className="-ml-0.5 mr-1.5 size-5" aria-hidden="true" />
-                    {buttonLabel}
-                </Button>
+        <div className="flex items-center justify-center h-full text-center">
+            <div className="py-12">
+                <svg
+                    className="mx-auto h-12 w-12"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    aria-hidden="true"
+                >
+                    <path
+                        vectorEffect="non-scaling-stroke"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M9 13h6m-3-3v6m-9 1V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z"
+                    />
+                </svg>
+                <h3 className="mt-2 text-sm font-semibold">{title}</h3>
+                <p className="mt-1 text-sm text-muted">{children}</p>
+                <div className="mt-6">
+                    <Button onClick={onClick}>
+                        <Plus className="-ml-0.5 mr-1.5 size-5" aria-hidden="true" />
+                        {buttonLabel}
+                    </Button>
+                </div>
             </div>
         </div>
     )

--- a/packages/ui/src/features/store/collections/CollectionsTable.tsx
+++ b/packages/ui/src/features/store/collections/CollectionsTable.tsx
@@ -1,10 +1,11 @@
 import { NavLink } from "@vertesia/ui/router";
 import { useUserSession } from "@vertesia/ui/session";
 import { FolderClosed, Search, Trash2 } from "lucide-react";
-import { Button, ConfirmModal, ErrorBox, Table, TBody, TR, useToast, VTooltip, useFetch } from "@vertesia/ui/core";
+import { Button, ConfirmModal, ErrorBox, Table, TBody, TR, useToast, VTooltip, useFetch, EmptyCollection } from "@vertesia/ui/core";
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { useState, useEffect } from "react";
+import { CreateCollectionModal } from "./CreateCollection";
 
 dayjs.extend(relativeTime);
 
@@ -15,9 +16,10 @@ export function CollectionsTable({ }: CollectionsTableProps) {
     const toast = useToast();
     const [collectionToDelete, setCollectionToDelete] = useState<string | undefined>();
     const [isLoading, setIsLoading] = useState(true);
+    const [isOpen, setOpen] = useState(false);
 
     const { data: collections, error, refetch } = useFetch(() => client.store.collections.list(), []);
-    
+
     // Update loading state when data is fetched
     useEffect(() => {
         if (collections || error) {
@@ -31,7 +33,7 @@ export function CollectionsTable({ }: CollectionsTableProps) {
 
     const deleteCollection = async () => {
         if (!collectionToDelete) return;
-        
+
         try {
             await client.store.collections.delete(collectionToDelete);
             toast({
@@ -55,42 +57,50 @@ export function CollectionsTable({ }: CollectionsTableProps) {
 
     return (
         <>
-            {collections && <Table className="w-full">
-                <thead>
-                    <tr>
-                        <th>Name</th>
-                        <th>Type</th>
-                        <th>Created</th>
-                        <th></th>
-                    </tr>
-                </thead>
-                <TBody columns={4} isLoading={isLoading}>
-                    {
-                        collections.map((c) => {
-                            return <TR key={c.id}>
-                                <td>
-                                    <div className="flex items-center gap-2">
-                                        {collectionIcon(c.dynamic)}
-                                        <NavLink href={`/collections/${c.id}`}>{c.name}</NavLink>
-                                    </div>
-                                </td>
-                                <td>{c.type?.name || "-"}</td>
-                                <td>{dayjs(c.created_at).fromNow()}</td>
-                                <td className="text-right">
-                                    <Button 
-                                        variant="destructive" 
-                                        size="sm"
-                                        onClick={() => setCollectionToDelete(c.id)}
-                                    >
-                                        <Trash2 className="size-4" />
-                                    </Button>
-                                </td>
-                            </TR>
-                        })
-                    }
-                </TBody>
-            </Table>}
-            
+            {collections &&
+                (collections.length > 0 ?
+                    (<Table className="w-full">
+                        <thead>
+                            <tr>
+                                <th>Name</th >
+                                <th>Type</th>
+                                <th>Created</th>
+                                <th></th>
+                            </tr >
+                        </thead >
+                        <TBody columns={4} isLoading={isLoading}>
+                            {
+                                collections.map((c) => {
+                                    return <TR key={c.id}>
+                                        <td>
+                                            <div className="flex items-center gap-2">
+                                                {collectionIcon(c.dynamic)}
+                                                <NavLink href={`/collections/${c.id}`}>{c.name}</NavLink>
+                                            </div>
+                                        </td>
+                                        <td>{c.type?.name || "-"}</td>
+                                        <td>{dayjs(c.created_at).fromNow()}</td>
+                                        <td className="text-right">
+                                            <Button
+                                                variant="destructive"
+                                                size="sm"
+                                                onClick={() => setCollectionToDelete(c.id)}
+                                            >
+                                                <Trash2 className="size-4" />
+                                            </Button>
+                                        </td>
+                                    </TR>
+                                })
+                            }
+                        </TBody>
+                    </Table >) :
+                    <EmptyCollection title="No Collections" buttonLabel='New Collections' onClick={() => setOpen(true)}>
+                        Get started by creating a new Collections.
+                    </EmptyCollection>)
+            }
+
+            <CreateCollectionModal isOpen={isOpen} onClose={() => setOpen(false)} />
+
             <ConfirmModal
                 isOpen={!!collectionToDelete}
                 title="Delete Collection"

--- a/packages/ui/src/features/store/collections/CreateCollection.tsx
+++ b/packages/ui/src/features/store/collections/CreateCollection.tsx
@@ -1,5 +1,5 @@
 import { CreateCollectionPayload } from "@vertesia/common";
-import { useToast, VModalBody, FormItem, Styles, VModalFooter, Input, Switch, Button } from "@vertesia/ui/core";
+import { useToast, VModalBody, FormItem, Styles, VModalFooter, Input, Switch, Button, VModal, VModalTitle } from "@vertesia/ui/core";
 import { SelectContentType } from "../types/SelectContentType";
 import { useNavigate } from "@vertesia/ui/router";
 import { useUserSession } from "@vertesia/ui/session";
@@ -122,5 +122,18 @@ export function CreateCollectionForm({ onClose, redirect = true, onAddToCollecti
                 </Button>
             </VModalFooter>
         </form >
+    );
+}
+
+interface CreateCollectionModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+}
+export function CreateCollectionModal({ isOpen, onClose }: CreateCollectionModalProps) {
+    return (
+        <VModal onClose={onClose} isOpen={isOpen}>
+            <VModalTitle>Create a Collection</VModalTitle>
+            <CreateCollectionForm onClose={onClose} />
+        </VModal>
     );
 }

--- a/packages/ui/src/features/store/types/ContentObjectTypesSearch.tsx
+++ b/packages/ui/src/features/store/types/ContentObjectTypesSearch.tsx
@@ -89,12 +89,12 @@ export function ContentObjectTypesSearch({ isDirty = false }: ContentObjectTypes
     };
 
     return (
-        <div>
+        <div className='flex flex-col gap-4 h-full'>
             <div className="flex gap-4">
                 <Input placeholder="Filter by Name" value={searchTerm} onChange={setSearchTerm} />
                 <SelectBox className="w-60" isClearable options={Object.values(ChunkableOptions)} value={chunkable} onChange={onChunkableChange} placeholder={"Is Chunkable"} />
             </div>
-            <div className="w-full">
+            <div className="flex-1">
                 {
                     (!isLoading && objects?.length === 0) ?
                         <EmptyCollection title="No Type" buttonLabel='Create Type' onClick={onOpenCreateModal}>


### PR DESCRIPTION
- Update `EmptyCollection` component to use `h-full` instead of `min-h-full`
- Apply flexbox centering to fill the remaining screen height
- Fix layout across training, settings, interactions, prompts, and store types pages
- Ensure a consistent empty state experience across all pages
- Handle empty view on collections list