### PR TITLE
Fix: optimize thumbnail view handler

### DIFF
--- a/packages/ui/src/features/store/objects/DocumentSearchResults.tsx
+++ b/packages/ui/src/features/store/objects/DocumentSearchResults.tsx
@@ -4,7 +4,7 @@ import { ColumnLayout, ContentObject, ContentObjectItem, VectorSearchQuery } fro
 import { Button, Divider, ErrorBox, SidePanel, Spinner, useDebounce, useIntersectionObserver, useToast } from '@vertesia/ui/core';
 import { useNavigate } from "@vertesia/ui/router";
 import { TypeRegistry, useUserSession } from '@vertesia/ui/session';
-import { Download, RefreshCw, SquareArrowOutUpRight } from 'lucide-react';
+import { Download, RefreshCw, Eye } from 'lucide-react';
 import { VFacetsNav } from "../../facets";
 import { VectorSearchWidget } from './components/VectorSearchWidget';
 
@@ -195,7 +195,7 @@ function OverviewDrawer({ object, onClose }: OverviewDrawerProps) {
         <SidePanel title={object.properties?.title || object.name} isOpen={true} onClose={onClose}>
             <div className="flex items-center gap-x-2">
                 <Button variant="ghost" size="sm" title="Open Object" onClick={() => navigate(`/objects/${object.id}`)}>
-                    <SquareArrowOutUpRight className="size-4" />
+                    <Eye className="size-4" />
                 </Button>
                 {object.content?.source && (
                     <Button variant="ghost" size="sm" title="Download" onClick={onDownload}>

--- a/packages/ui/src/features/store/objects/components/DocumentIcon.tsx
+++ b/packages/ui/src/features/store/objects/components/DocumentIcon.tsx
@@ -59,7 +59,9 @@ export function DocumentIcon({ selection, document, onSelectionChange, onRowClic
                 renditionUrl ? (
                     <img src={renditionUrl} alt={renditionAlt} className="w-auto h-48 object-cover rounded-t-xl" />
                 ) : (
-                    <div className="h-48 bg-gray-700 rounded-t-xl"></div>
+                    <div className="h-48 bg-gray-700 rounded-t-xl flex items-center justify-center text-muted">
+                        Preparing preview...
+                    </div>
                 )
             }
             <Separator className='bg-gray-200 h-[2px]' />

--- a/packages/ui/src/features/store/objects/components/SelectDocument.tsx
+++ b/packages/ui/src/features/store/objects/components/SelectDocument.tsx
@@ -1,11 +1,12 @@
 import { ColumnLayout, ContentObjectItem } from "@vertesia/common";
-import { ErrorBox, Spinner, useIntersectionObserver } from "@vertesia/ui/core";
+import { Button, ErrorBox, Spinner, useIntersectionObserver } from "@vertesia/ui/core";
 import { useEffect, useRef, useState } from "react";
 import { VFacetsNav } from "../../../facets";
 import { DocumentTable } from "../DocumentTable";
 import { useDocumentSearch, useWatchDocumentSearchFacets, useWatchDocumentSearchResult } from "../search/DocumentSearchContext";
 import { DocumentSearchProvider } from "../search/DocumentSearchProvider";
 import { ContentDispositionButton } from "./ContentDispositionButton";
+import { RefreshCw } from "lucide-react";
 
 const layout: ColumnLayout[] = [
     { "name": "Name", "field": "properties.title", "type": "string", "fallback": "name" },
@@ -41,15 +42,22 @@ function SelectDocumentImpl({ onRowClick }: SelectDocumentImplProps) {
     const { search, isLoading, error, objects } = useWatchDocumentSearchResult();
 
     const loadMoreRef = useRef<HTMLDivElement>(null);
+
     useIntersectionObserver(loadMoreRef, () => {
         isReady && search.loadMore(true)
     }, { deps: [isReady] });
+
     useEffect(() => {
         search.search().then(() => setIsReady(true));
     }, []);
 
     const facets = useWatchDocumentSearchFacets();
     const facetSearch = useDocumentSearch();
+
+    const handleRefetch = () => {
+        setIsReady(false);
+        search.search().then(() => setIsReady(true));
+    }
 
     if (error) {
         return <ErrorBox title="Search failed">{error.message}</ErrorBox>
@@ -59,7 +67,12 @@ function SelectDocumentImpl({ onRowClick }: SelectDocumentImplProps) {
         <div>
             <div className="flex justify-between items-center mb-4">
                 <VFacetsNav facets={facets} search={facetSearch} textSearch="Filter content" />
-                <ContentDispositionButton onUpdate={setIsGridView} />
+                <div className="flex items-center gap-2">
+                    <Button variant="outline" onClick={handleRefetch} alt="Refresh">
+                        <RefreshCw size={16} />
+                    </Button>
+                    <ContentDispositionButton onUpdate={setIsGridView} />
+                </div>
             </div>
             <DocumentTable objects={objects || []} isLoading={false} layout={layout} onRowClick={onRowClick} isGridView={isGridView} />
             <div ref={loadMoreRef} className='mt-10' />

--- a/packages/ui/src/features/store/objects/components/SelectDocumentModal.tsx
+++ b/packages/ui/src/features/store/objects/components/SelectDocumentModal.tsx
@@ -1,5 +1,5 @@
 import { ContentObjectItem } from "@vertesia/common";
-import { Modal, ModalBody, ModalTitle } from "@vertesia/ui/core";
+import { VModal, VModalBody, VModalTitle } from "@vertesia/ui/core";
 import { SelectDocument } from "./SelectDocument";
 
 interface SelectDocumentModalProps {
@@ -10,11 +10,11 @@ interface SelectDocumentModalProps {
 }
 export function SelectDocumentModal({ isOpen, onClose }: SelectDocumentModalProps) {
     return (
-        <Modal onClose={() => onClose()} isOpen={!!isOpen} className='min-w-[60vw]'>
-            <ModalTitle>Select Content</ModalTitle>
-            <ModalBody className='p-4 pt-0 overflow-y-auto max-h-[80vh] min-h-[80vh]'>
+        <VModal onClose={() => onClose()} isOpen={!!isOpen} className='min-w-[60vw]'>
+            <VModalTitle>Select Content</VModalTitle>
+            <VModalBody className='pt-0 overflow-y-auto max-h-[80vh] min-h-[80vh]'>
                 {isOpen && <SelectDocument onChange={onClose} />}
-            </ModalBody>
-        </Modal>
+            </VModalBody>
+        </VModal>
     )
 }

--- a/packages/ui/src/features/store/objects/layout/renderers.tsx
+++ b/packages/ui/src/features/store/objects/layout/renderers.tsx
@@ -1,11 +1,10 @@
-import { NavLink, useNavigate } from "@vertesia/ui/router";
+import { useNavigate } from "@vertesia/ui/router";
 import dayjs from "dayjs";
 import LocalizedFormat from "dayjs/plugin/localizedFormat";
 import RelativeTime from "dayjs/plugin/relativeTime";
 import { shortId } from "../../../utils";
 import { Button } from "@vertesia/ui/core/components/shadcn/button";
 import { EyeIcon } from "lucide-react";
-import { use } from "react";
 dayjs.extend(RelativeTime);
 dayjs.extend(LocalizedFormat);
 
@@ -94,7 +93,6 @@ const renderers: Record<string, (params?: URLSearchParams) => (value: any, index
     // value must be the object itself
     objectLink(params?: URLSearchParams) {
         let title = "title";
-        const navigate = useNavigate();
 
         //let underline = "hover";
         if (params) {
@@ -102,11 +100,13 @@ const renderers: Record<string, (params?: URLSearchParams) => (value: any, index
             //underline = params.get("underline") || "hover";
         }
 
-        const onClick = (value: string) => {
-            navigate(`/objects/${value}`);
-        }
-
         return (value: any, index: number) => {
+            const navigate = useNavigate();
+            
+            const onClick = (value: string) => {
+                navigate(`/objects/${value}`);
+            }
+
             return (
                 <td key={index} className="flex items-center gap-2">
                     {value.properties?.[title] || value.name || shortId(value.id)}

--- a/packages/ui/src/features/store/objects/layout/renderers.tsx
+++ b/packages/ui/src/features/store/objects/layout/renderers.tsx
@@ -1,8 +1,11 @@
-import { NavLink } from "@vertesia/ui/router";
+import { NavLink, useNavigate } from "@vertesia/ui/router";
 import dayjs from "dayjs";
 import LocalizedFormat from "dayjs/plugin/localizedFormat";
 import RelativeTime from "dayjs/plugin/relativeTime";
 import { shortId } from "../../../utils";
+import { Button } from "@vertesia/ui/core/components/shadcn/button";
+import { EyeIcon } from "lucide-react";
+import { use } from "react";
 dayjs.extend(RelativeTime);
 dayjs.extend(LocalizedFormat);
 
@@ -91,22 +94,32 @@ const renderers: Record<string, (params?: URLSearchParams) => (value: any, index
     // value must be the object itself
     objectLink(params?: URLSearchParams) {
         let title = "title";
+        const navigate = useNavigate();
+
         //let underline = "hover";
         if (params) {
             title = params.get("title") || "title";
             //underline = params.get("underline") || "hover";
         }
+
+        const onClick = (value: string) => {
+            navigate(`/objects/${value}`);
+        }
+
         return (value: any, index: number) => {
             return (
-                <td key={index}>
-                    <NavLink
-                        topLevelNav
-                        className="underline text-indigo-800 dark:text-indigo-300"
-                        href={`/store/objects/${value.id}`}
-                    >
-                        {value.properties?.[title] || value.name || shortId(value.id)}
-                    </NavLink>
-                </td>
+                <td key={index} className="flex items-center gap-2">
+                    {value.properties?.[title] || value.name || shortId(value.id)}
+                    <Button variant="ghost" size="xs"
+                        title="Open Object"
+                        onClick={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            onClick(value.id);
+                        }}>
+                        <EyeIcon />
+                    </Button>
+                </td >
             );
         };
     },

--- a/packages/ui/src/features/store/objects/layout/renderers.tsx
+++ b/packages/ui/src/features/store/objects/layout/renderers.tsx
@@ -94,10 +94,8 @@ const renderers: Record<string, (params?: URLSearchParams) => (value: any, index
     objectLink(params?: URLSearchParams) {
         let title = "title";
 
-        //let underline = "hover";
         if (params) {
             title = params.get("title") || "title";
-            //underline = params.get("underline") || "hover";
         }
 
         return (value: any, index: number) => {
@@ -110,8 +108,7 @@ const renderers: Record<string, (params?: URLSearchParams) => (value: any, index
             return (
                 <td key={index} className="flex items-center gap-2">
                     {value.properties?.[title] || value.name || shortId(value.id)}
-                    <Button variant="ghost" size="xs"
-                        title="Open Object"
+                    <Button variant="ghost" size="xs" title="Open Object"
                         onClick={(e) => {
                             e.preventDefault();
                             e.stopPropagation();


### PR DESCRIPTION
* https://github.com/vertesia/studio/issues/2251

## Description 

- Add refresh button for **Select Object** modal in the Playground and **Link Object** model in Agent Runner, next to the button for switching between table and thumbnail views.
- Add placeholder text for missing thumbnails: `Preparing preview`.
- Improve navigation from Object table and thumbnail views to open the object (vs. expand the side panel) using a button icon.