### PR TITLE
fix: use warn() for rendition failures

### DIFF
--- a/packages/ui/src/features/utils/rendition.ts
+++ b/packages/ui/src/features/utils/rendition.ts
@@ -71,5 +71,7 @@ export async function retrieveRendition(
       setRenditionUrl(rendition);
       setRenditionAlt(`${doc.name} Rendition`);
     }
+  }).catch((error) => {
+    console.warn("Failed to retrieve rendition:", error);
   });
 }


### PR DESCRIPTION
Sometimes, the retrieval of the rendition of an object fails because the rendition generation is in progress or because the source attached to the object is incorrect. In these cases, the backend API returns a 4xx error and the UI should not treat it as an error because this is not incorrect behavior in the frontend.