### PR TITLE
Fix: link in object not found if created by agent 

### DIFF
--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageItem.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageItem.tsx
@@ -254,7 +254,7 @@ export default function MessageItem({ message, showPulsatingCircle = false }: Me
                     components={{
                         a: ({ node, ...props }: { node?: any; href?: string; children?: React.ReactNode }) => {
                             const href = props.href || "";
-                            if (href.startsWith("/store/")) {
+                            if (href.includes("/store/objects")) {
                                 return (
                                     <NavLink
                                         href={href}

--- a/packages/ui/src/features/store/objects/components/ContentOverview.tsx
+++ b/packages/ui/src/features/store/objects/components/ContentOverview.tsx
@@ -3,11 +3,12 @@ import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 import { useUserSession } from "@vertesia/ui/session";
-import { Button, Link, Spinner, useToast } from "@vertesia/ui/core";
+import { Button, Spinner, useToast } from "@vertesia/ui/core";
 import { JSONDisplay } from "@vertesia/ui/widgets";
 import { ContentObject, ImageRenditionFormat } from "@vertesia/common";
 import { Copy, Download, SquarePen } from "lucide-react";
 import { PropertiesEditorModal } from "./PropertiesEditorModal";
+import { NavLink } from "@vertesia/ui/router";
 
 interface ContentOverviewProps {
     object: ContentObject;
@@ -320,17 +321,18 @@ export function ContentOverview({
                                         components={{
                                             a: ({ node, ...props }: { node?: any; href?: string; children?: React.ReactNode }) => {
                                                 const href = props.href || "";
-                                                if (href.startsWith("/store/objects/")) {
+                                                if (href.includes("/store/objects/")) {
                                                     return (
-                                                        <Link
+                                                        <NavLink
+                                                            topLevelNav
                                                             href={href}
                                                             className="text-info"
                                                         >
                                                             {props.children}
-                                                        </Link>
+                                                        </NavLink>
                                                     );
                                                 }
-                                                return <a {...props} target="_blank" rel="noopener noreferrer" />;
+                                                return <a {...props} data-debug="test" target="_blank" rel="noopener noreferrer" />;
                                             },
                                             p: ({ node, ...props }: { node?: any; children?: React.ReactNode }) => (
                                                 <p {...props} className={`my-0`} />


### PR DESCRIPTION
## Description 

- The previous approach was if the url start with `/store` then we use internal navigator, otherwise it will just use `a` tag
- But the object that agent created, the link is `https://cloud.vertesia.io/store/objects/123` which will not apply to the previous logic
- This PR changes the logic to check if the url contains `/store/objects/` 
- And instead of using `Link`, ues `NavLink` to maintain the router better