### PR TITLE
fix: add missing notify_endpoint property

### DIFF
--- a/packages/common/src/interaction.ts
+++ b/packages/common/src/interaction.ts
@@ -320,6 +320,11 @@ interface AsyncExecutionPayloadBase {
      * Optional tags to add to the execution run
      */
     tags?: string[];
+
+    /**
+     * A list of notification endpoints to notify when the execution is finished.
+     */
+    notify_endpoints?: string[];
 }
 
 export type ConversationVisibility = 'private' | 'project';


### PR DESCRIPTION
## Summary
- Add missing notify_endpoint property to the async interaction execution payload

🤖 Generated with [Claude Code](https://claude.ai/code)