### PR TITLE
feat: remove 'tags' from `<Omit>` in `InteractionCreatePayload` interface

### DIFF
--- a/packages/common/src/interaction.ts
+++ b/packages/common/src/interaction.ts
@@ -209,7 +209,6 @@ export interface InteractionCreatePayload
         | "updated_by"
         | "project"
         | "formatter"
-        | "tags"
         | "parent"
         | "version"
         | "visibility"


### PR DESCRIPTION
## Overview:

The interface for newly generated interactions omits the `tags` field. This is provided by the LLM, but gets dropped before saving.

This is required for #2335 in the `studio` repo, where the tags signifying an interaction is agentic are created but not saved.

## Related:

- Issue: Improve Generate Interaction server side [#2335](https://github.com/vertesia/studio/issues/2335)
- PR ([#2338](https://github.com/vertesia/studio/pull/2338))

## Problem:

```typescript
export interface InteractionCreatePayload
    extends Omit<
        Interaction,
        | "id"
        | "created_at"
        | "updated_at"
        | "created_by"
        | "updated_by"
        | "project"
        | "formatter"
        | "tags" <--- We need this field
        | "parent"
        | "version"
        | "visibility"
        | "endpoint"
    > {
    visibility?: InteractionVisibility;
}
```

## Testing:

- Generation from LLM with both `agent` and without `agent` tags succeeded
- Manual creation of interaction succeeded

---

Closes #397 