### PR TITLE
fix: consistent default rendition max_hw of 1596

### DIFF
--- a/packages/converters/src/image.test.ts
+++ b/packages/converters/src/image.test.ts
@@ -6,7 +6,7 @@ import { createImageTransformer } from './image';
 
 
 test('should resize an image to a maximum height or width', async () => {
-  const max_hw = 1024;
+  const max_hw = 1596;
   const format: keyof sharp.FormatEnum = 'jpeg';
   const imageFile = fs.readFileSync(path.join(__dirname, '../fixtures', 'cat-picture.jpg'));
 

--- a/packages/ui/src/features/store/objects/DocumentPreviewPanel.tsx
+++ b/packages/ui/src/features/store/objects/DocumentPreviewPanel.tsx
@@ -102,7 +102,6 @@ export function DocumentPreviewPanel({
     try {
       // Try to get a rendition first
       const rendition = await client.objects.getRendition(obj.id, {
-        max_hw: 1024,
         format: ImageRenditionFormat.jpeg,
         generate_if_missing: false,
       });

--- a/packages/ui/src/features/store/objects/components/ContentOverview.tsx
+++ b/packages/ui/src/features/store/objects/components/ContentOverview.tsx
@@ -83,7 +83,6 @@ export function ContentOverview({
             // Request document rendition from the server
             const response = await client.objects.getRendition(object.id, {
                 format: format as any, // We're extending the format type
-                max_hw: 1024, // Not used for document exports but required by API
                 generate_if_missing: true,
                 sign_url: true,
             });
@@ -172,7 +171,6 @@ export function ContentOverview({
         if (isImage) {
             client.objects
                 .getRendition(object.id, {
-                    max_hw: 1024,
                     format: ImageRenditionFormat.jpeg,
                     generate_if_missing: false,
                     sign_url: true,

--- a/packages/workflow/src/activities/generateEmbeddings.ts
+++ b/packages/workflow/src/activities/generateEmbeddings.ts
@@ -398,7 +398,6 @@ async function generateImageEmbeddings({
 
     const resRnd = await client.store.objects.getRendition(document.id, {
         format: ImageRenditionFormat.jpeg,
-        max_hw: 1024,
         generate_if_missing: true,
         sign_url: true,
     });

--- a/packages/workflow/src/activities/generateOrAssignContentType.ts
+++ b/packages/workflow/src/activities/generateOrAssignContentType.ts
@@ -104,7 +104,6 @@ export async function generateOrAssignContentType(
       return undefined;
     }
     const res = await client.objects.getRendition(objectId, {
-      max_hw: 1024,
       format: ImageRenditionFormat.jpeg,
       generate_if_missing: true,
     });

--- a/packages/workflow/src/activities/renditions/generateImageRendition.ts
+++ b/packages/workflow/src/activities/renditions/generateImageRendition.ts
@@ -27,7 +27,7 @@ export async function generateImageRendition(
     // Fix: Use maxHeightWidth if max_hw is not provided
     const params = {
         ...originParams,
-        max_hw: originParams.max_hw || (originParams as any).maxHeightWidth || 1024, // Default to 1024 if both are missing
+        max_hw: originParams.max_hw || (originParams as any).maxHeightWidth || 1596, // Default to 1596 if both are missing
         format: originParams.format || (originParams as any).format_output || "png", // Default to png if format is missing
     };
 

--- a/packages/workflow/src/conversion/image.test.ts
+++ b/packages/workflow/src/conversion/image.test.ts
@@ -20,7 +20,7 @@ const execAsync = promisify(exec);
 
 describe("ImageMagick image resizing", () => {
     test("should resize an image to a maximum height or width using ImageMagick", async () => {
-        const max_hw = 1024;
+        const max_hw = 1596;
         const format = "jpeg";
         const inputImagePath = path.join(__dirname, "../../fixtures", "cat-picture.jpg");
 
@@ -48,7 +48,7 @@ describe("ImageMagick image resizing", () => {
     });
 
     test("should throw an error for non-existent input file", async () => {
-        const max_hw = 1024;
+        const max_hw = 1596;
         const format = "jpeg";
         const nonExistentPath = path.join(__dirname, "non-existent-image.jpg");
 
@@ -60,7 +60,7 @@ describe("ImageMagick image resizing", () => {
     });
 
     test("should throw error with empty format", async () => {
-        const max_hw = 1024;
+        const max_hw = 1596;
         const format = "";
         const inputImagePath = path.join(__dirname, "../../fixtures", "cat-picture.jpg");
 


### PR DESCRIPTION
Uses 1596 instead of 1024 as the default max_hw, thumbnails still use 256