### PR TITLE
fix: resolve child workflow variables with expressions

### DIFF
--- a/packages/workflow/src/dsl/dsl-workflow.ts
+++ b/packages/workflow/src/dsl/dsl-workflow.ts
@@ -151,8 +151,9 @@ async function handleError(originalError: any, basePayload: BaseActivityPayload,
 async function startChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWorkflowExecutionPayload, vars: Vars, debug_mode?: boolean) {
     const resolvedVars = vars.resolve();
     if (step.vars) {
-        // copy user vars (from step definition) to the resolved vars
-        Object.assign(resolvedVars, step.vars);
+        // copy user vars (from step definition) to the resolved vars, resolving any expressions
+        const resolvedStepVars = vars.resolveParams(step.vars);
+        Object.assign(resolvedVars, resolvedStepVars);
     }
     if (debug_mode) {
         log.debug(`Workflow vars before starting child workflow ${step.name}`, { vars: resolvedVars });
@@ -182,8 +183,9 @@ async function startChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWorkfl
 async function executeChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWorkflowExecutionPayload, vars: Vars, debug_mode?: boolean) {
     const resolvedVars = vars.resolve();
     if (step.vars) {
-        // copy user vars (from step definition) to the resolved vars
-        Object.assign(resolvedVars, step.vars);
+        // copy user vars (from step definition) to the resolved vars, resolving any expressions
+        const resolvedStepVars = vars.resolveParams(step.vars);
+        Object.assign(resolvedVars, resolvedStepVars);
     }
     if (debug_mode) {
         log.debug(`Workflow vars before executing child workflow ${step.name}`, { vars: resolvedVars });


### PR DESCRIPTION
## Summary
- Fixed variable resolution in child workflows when variables contain expressions like `store:${objectIds[0]}`
- Updated `startChildWorkflow` and `executeChildWorkflow` functions to use `vars.resolveParams()` instead of just copying step variables
- Added test case to verify the fix works correctly

## Issue
When a step is a child workflow, variables that are expressions like `"store:${objectIds[0]}"` were not being resolved with the actual values. The child workflow would receive the literal string instead of the resolved value.

## Solution
The issue was in the `startChildWorkflow` and `executeChildWorkflow` functions in `dsl-workflow.ts:152,183`. When step variables are assigned, we now use `vars.resolveParams(step.vars)` to properly resolve any expressions containing variable references before merging them into the resolved variables.

## Test plan
- [x] Added test case `execute DSL child workflow with variable resolution`
- [x] Existing tests continue to pass
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.ai/code)