### PR TITLE
handle terminated status for agent

### DIFF
--- a/packages/common/src/store/workflow.ts
+++ b/packages/common/src/store/workflow.ts
@@ -376,6 +376,7 @@ export enum AgentMessageType {
     QUESTION = "question",
     REQUEST_INPUT = "request_input",
     IDLE = "idle",
+    TERMINATED = "terminated",
 }
 
 export interface PlanTask {

--- a/packages/ui/src/core/components/FormItem.tsx
+++ b/packages/ui/src/core/components/FormItem.tsx
@@ -15,7 +15,7 @@ interface FormItemProps {
 }
 export function FormItem({ description, required, label, className, direction = "column", children, disabled = false }: FormItemProps) {
     return (
-        <div className={clsx("flex w-full space-y-1", className, direction === "row" ? "flex-row justify-center items-center gap-2" : "flex-col")}>
+        <div className={clsx("flex w-full space-y-1", className, direction === "row" ? "flex-row justify-between items-center gap-2" : "flex-col")}>
             <div className='flex items-center gap-1'>
                 <label className={`text-sm font-medium mb-1 ${disabled ? "text-muted" : ""}`}>
                     {label}{required ? <span className='text-destructive -mt-4 ml-1'>*</span> : ""}

--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
@@ -489,10 +489,16 @@ function ModernAgentConversationInner({
 
         const lastMessage = messages[messages.length - 1];
         if (lastMessage) {
-            if (interactive) {
-                setShowInput(true);
-            } else {
-                setShowInput(lastMessage.type === AgentMessageType.REQUEST_INPUT);
+            if (lastMessage.type === AgentMessageType.TERMINATED) {
+                setShowInput(false);
+                setWorkflowStatus("TERMINATED");
+            }
+            else {
+                if (interactive) {
+                    setShowInput(true);
+                } else {
+                    setShowInput(lastMessage.type === AgentMessageType.REQUEST_INPUT);
+                }
             }
         }
     }, [messages, plans, activePlanIndex]);

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/AllMessagesMixed.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/AllMessagesMixed.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import InlineSlidingPlanPanel from "./InlineSlidingPlanPanel";
 import MessageItem from "./MessageItem";
 import WorkstreamTabs, { extractWorkstreams, filterMessagesByWorkstream } from "./WorkstreamTabs";
-import { getWorkstreamId } from "./utils";
+import { DONE_STATES, getWorkstreamId } from "./utils";
 
 interface AllMessagesMixedProps {
     messages: AgentMessage[];
@@ -115,7 +115,8 @@ export default function AllMessagesMixed({
                 statusMap.set(workstreamId, [
                     AgentMessageType.COMPLETE,
                     AgentMessageType.IDLE,
-                    AgentMessageType.REQUEST_INPUT
+                    AgentMessageType.REQUEST_INPUT,
+                    AgentMessageType.TERMINATED
                 ].includes(lastMessage.type));
             }
         }
@@ -171,7 +172,7 @@ export default function AllMessagesMixed({
                             // Find if this is the latest non-completion message
                             const isLatestNonCompletionMessage = !isCompleted &&
                                 index === displayMessages.length - 1 &&
-                                ![AgentMessageType.COMPLETE, AgentMessageType.IDLE, AgentMessageType.REQUEST_INPUT].includes(message.type);
+                                !DONE_STATES.includes(message.type);
 
                             return (
                                 <MessageItem
@@ -186,12 +187,12 @@ export default function AllMessagesMixed({
                         <>
                             {/* Get all messages to display in sliding view */}
                             {(() => {
-                                // First get all permanent messages (ANSWER, QUESTION, COMPLETE, REQUEST_INPUT)
+                                // First get all permanent messages (ANSWER, QUESTION, COMPLETE, REQUEST_INPUT, TERMINATED)
                                 const permanentMessages = displayMessages.filter(msg =>
                                     msg.type === AgentMessageType.ANSWER ||
                                     msg.type === AgentMessageType.QUESTION ||
                                     msg.type === AgentMessageType.COMPLETE ||
-                                    msg.type === AgentMessageType.REQUEST_INPUT
+                                    msg.type === AgentMessageType.TERMINATED
                                 );
 
                                 // Then get the latest thinking message if not completed
@@ -224,7 +225,7 @@ export default function AllMessagesMixed({
                                 return allMessages.map((message, index) => {
                                     const isLatestMessage = !isCompleted &&
                                         index === allMessages.length - 1 &&
-                                        ![AgentMessageType.COMPLETE, AgentMessageType.IDLE, AgentMessageType.REQUEST_INPUT].includes(message.type);
+                                        !DONE_STATES.includes(message.type);
 
                                     return (
                                         <MessageItem

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageItem.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageItem.tsx
@@ -44,9 +44,16 @@ export default function MessageItem({ message, showPulsatingCircle = false }: Me
             case AgentMessageType.COMPLETE:
                 return {
                     ...baseStyle,
-                    containerClass: "bg-white border-l-4 border-l-green-500 shadow-sm",
+                    containerClass: "bg-white border-l-4 border-l-success shadow-sm",
                     iconComponent: <CheckCircle className="size-4 text-success" />,
                     sender: "Completed",
+                };
+            case AgentMessageType.TERMINATED:
+                return {
+                    ...baseStyle,
+                    containerClass: "bg-white border-l-4 border-l-attention shadow-sm",
+                    iconComponent: <CheckCircle className="size-4 text-attention" />,
+                    sender: "Terminated",
                 };
             case AgentMessageType.QUESTION:
                 return {
@@ -377,6 +384,8 @@ export default function MessageItem({ message, showPulsatingCircle = false }: Me
                 return "border-l-success bg-success";
             case AgentMessageType.PLAN:
                 return "border-l-attention bg-attention";
+            case AgentMessageType.TERMINATED:
+                return "border-l-muted bg-muted";
             default:
                 return "border-l-indigo-500 dark:border-l-indigo-400 bg-indigo-50/50 dark:bg-indigo-900/10";
         }
@@ -436,6 +445,8 @@ export default function MessageItem({ message, showPulsatingCircle = false }: Me
                     <Bot className={`size-4 ${iconColor}`} />
                 );
             case AgentMessageType.COMPLETE:
+                return <CheckCircle className={`size-4 ${iconColor}`} />;
+            case AgentMessageType.TERMINATED:
                 return <CheckCircle className={`size-4 ${iconColor}`} />;
             case AgentMessageType.IDLE:
                 return <Clock className={`size-4 ${iconColor}`} />;

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/SlidingMessages.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/SlidingMessages.tsx
@@ -27,7 +27,8 @@ function isPermanentMessage(message: AgentMessage): boolean {
         message.type === AgentMessageType.QUESTION ||
         message.type === AgentMessageType.COMPLETE ||
         message.type === AgentMessageType.IDLE ||
-        message.type === AgentMessageType.REQUEST_INPUT
+        message.type === AgentMessageType.REQUEST_INPUT || 
+        message.type === AgentMessageType.TERMINATED
     );
 }
 

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/utils.ts
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/utils.ts
@@ -17,6 +17,14 @@ export function insertMessageInTimeline(arr: AgentMessage[], m: AgentMessage) {
  * This function checks the main workstream status to determine if the conversation is complete
  * For multi-workstream scenarios, we keep streaming until the main workstream is complete
  */
+
+export const DONE_STATES = [
+    AgentMessageType.COMPLETE,
+    AgentMessageType.IDLE,
+    AgentMessageType.REQUEST_INPUT,
+    AgentMessageType.TERMINATED,
+];
+
 export function isInProgress(messages: AgentMessage[]) {
     if (!messages.length) return true;
 
@@ -46,7 +54,7 @@ export function isInProgress(messages: AgentMessage[]) {
         console.log(`[isInProgress] Last message type in only workstream: ${lastMessage.type}`);
 
         // Check if this single workstream is completed
-        if (![AgentMessageType.COMPLETE, AgentMessageType.IDLE, AgentMessageType.REQUEST_INPUT].includes(
+        if (!DONE_STATES.includes(
             lastMessage.type
         )) {
             console.log("[isInProgress] Only workstream is still in progress");
@@ -71,7 +79,7 @@ export function isInProgress(messages: AgentMessage[]) {
         const lastMainMessage = mainWorkstreamMsgs[mainWorkstreamMsgs.length - 1];
         console.log(`[isInProgress] Last message type in main workstream: ${lastMainMessage.type}`);
 
-        if (![AgentMessageType.COMPLETE, AgentMessageType.IDLE, AgentMessageType.REQUEST_INPUT].includes(
+        if (!DONE_STATES.includes(
             lastMainMessage.type
         )) {
             console.log("[isInProgress] Main workstream is still in progress");
@@ -89,7 +97,7 @@ export function isInProgress(messages: AgentMessage[]) {
     for (const [workstreamId, msgs] of workstreamMessages.entries()) {
         if (msgs.length > 0) {
             const lastMessage = msgs[msgs.length - 1];
-            if (![AgentMessageType.COMPLETE, AgentMessageType.IDLE, AgentMessageType.REQUEST_INPUT].includes(
+            if (!DONE_STATES.includes(
                 lastMessage.type
             )) {
                 console.log(`[isInProgress] Workstream ${workstreamId} is still active`);
@@ -168,7 +176,7 @@ export function getWorkstreamStatusMap(messages: AgentMessage[]): Map<string, "p
             );
 
             if (hasCompleteMessage ||
-                [AgentMessageType.COMPLETE, AgentMessageType.IDLE, AgentMessageType.REQUEST_INPUT].includes(lastMessage.type)) {
+                DONE_STATES.includes(lastMessage.type)) {
                 console.log(`[getWorkstreamStatusMap] Marking workstream ${workstreamId} as completed`);
                 statusMap.set(workstreamId, "completed");
             } else {


### PR DESCRIPTION
## Description

* https://github.com/becomposable/studio/issues/1875

- The workflow is now returning the failed message, but instead of showing `completed`, the more accurate status should be `terminated`
- This PR adds a terminated status, and handles it accordingly 

<img width="1165" height="820" alt="Screenshot 2025-07-15 at 12 18 51" src="https://github.com/user-attachments/assets/94f7f68d-f847-4453-89c7-e5d93c205f9c" />
