### PR TITLE
Feat: Invitation accept parameter

### DIFF
--- a/packages/client/src/AccountApi.ts
+++ b/packages/client/src/AccountApi.ts
@@ -53,8 +53,8 @@ export default class AccountApi extends ApiTopic {
      * Fetch Invites for Account
      * @returns UserInviteTokenData[]
      * */
-    listAccountInvitation(id: string): Promise<TransientToken<UserInviteTokenData>[]> {
-        return this.get(`/invites/${id}`);
+    listProjectInvitation(id: string): Promise<TransientToken<UserInviteTokenData>[]> {
+        return this.get(`/invites/project/${id}`);
     }
 
     /**

--- a/packages/client/src/AccountApi.ts
+++ b/packages/client/src/AccountApi.ts
@@ -48,13 +48,14 @@ export default class AccountApi extends ApiTopic {
     listInvites(): Promise<TransientToken<UserInviteTokenData>[]> {
         return this.get('/invites');
     }
-
     /**
-     * Fetch Invites for Account
+     * Fetch Invites for specific account or project
+     * @param type Type of the invitation, either "project" or "account"
+     * @param id ID of the project or organization to fetch invitations for
      * @returns UserInviteTokenData[]
      * */
-    listProjectInvitation(id: string): Promise<TransientToken<UserInviteTokenData>[]> {
-        return this.get(`/invites/project/${id}`);
+    listInvitation(id: string, type: "project" | "account" = "project"): Promise<TransientToken<UserInviteTokenData>[]> {
+        return this.get(`/invites/${type}/${id}`);
     }
 
     /**

--- a/packages/common/src/transient-tokens.ts
+++ b/packages/common/src/transient-tokens.ts
@@ -25,6 +25,6 @@ export interface UserInviteTokenData {
     email: string;
     role: ProjectRoles;
     account: AccountRef;
-    projects: string[] | ProjectRef[];
+    projects: ProjectRef;
     invitedBy: { name: string, email: string; };
 }

--- a/packages/common/src/transient-tokens.ts
+++ b/packages/common/src/transient-tokens.ts
@@ -1,4 +1,4 @@
-import { ProjectRoles, ProjectRef } from "./project.js";
+import { ProjectRef, ProjectRoles } from "./project.js";
 import { AccountRef } from "./user.js";
 
 
@@ -25,7 +25,6 @@ export interface UserInviteTokenData {
     email: string;
     role: ProjectRoles;
     account: AccountRef;
-    project: string;
-    projectRef?: ProjectRef;
+    project: ProjectRef;
     invitedBy: { name: string, email: string; };
 }

--- a/packages/common/src/transient-tokens.ts
+++ b/packages/common/src/transient-tokens.ts
@@ -25,7 +25,7 @@ export interface UserInviteTokenData {
     email: string;
     role: ProjectRoles;
     account: AccountRef;
-    projects: string;
+    projects: [string];
     projectsRef?: ProjectRef;
     invitedBy: { name: string, email: string; };
 }

--- a/packages/common/src/transient-tokens.ts
+++ b/packages/common/src/transient-tokens.ts
@@ -1,4 +1,4 @@
-import { ProjectRoles } from "./project.js";
+import { ProjectRoles, ProjectRef } from "./project.js";
 import { AccountRef } from "./user.js";
 
 
@@ -25,6 +25,6 @@ export interface UserInviteTokenData {
     email: string;
     role: ProjectRoles;
     account: AccountRef;
-    projects?: string[];
+    projects: string[] | ProjectRef[];
     invitedBy: { name: string, email: string; };
 }

--- a/packages/common/src/transient-tokens.ts
+++ b/packages/common/src/transient-tokens.ts
@@ -25,6 +25,7 @@ export interface UserInviteTokenData {
     email: string;
     role: ProjectRoles;
     account: AccountRef;
-    projects: ProjectRef;
+    projects: string;
+    projectsRef?: ProjectRef;
     invitedBy: { name: string, email: string; };
 }

--- a/packages/common/src/transient-tokens.ts
+++ b/packages/common/src/transient-tokens.ts
@@ -25,7 +25,7 @@ export interface UserInviteTokenData {
     email: string;
     role: ProjectRoles;
     account: AccountRef;
-    projects: [string];
-    projectsRef?: ProjectRef;
+    project: string;
+    projectRef?: ProjectRef;
     invitedBy: { name: string, email: string; };
 }

--- a/packages/common/src/user.ts
+++ b/packages/common/src/user.ts
@@ -85,7 +85,7 @@ export const AccountRefPopulate = "id name";
 export interface InviteUserRequestPayload {
     email: string;
     role: ProjectRoles;
-    projects?: string[];
+    project: string;
 }
 
 export interface InviteUserResponsePayload {

--- a/packages/ui/src/shell/login/InviteAcceptModal.tsx
+++ b/packages/ui/src/shell/login/InviteAcceptModal.tsx
@@ -51,7 +51,7 @@ export function InviteAcceptModal() {
         <div key={invite.id} className="flex flex-row w-full justify-between border rounded-sm px-2 py-2 ">
             <div className="flex flex-col">
                 <div className="w-full font-semibold">{invite.data.account.name}</div>
-                {invite.data.projectsRef && <div className="w-full text-base">- {invite.data.projectsRef.name}</div>}
+                {invite.data.projectRef && <div className="w-full text-base">- {invite.data.projectRef.name}</div>}
                 <div className="text-xs">Role: {invite.data.role}</div>
                 <div className="text-xs">by {invite.data.invitedBy.name}</div>
             </div>

--- a/packages/ui/src/shell/login/InviteAcceptModal.tsx
+++ b/packages/ui/src/shell/login/InviteAcceptModal.tsx
@@ -47,19 +47,24 @@ export function InviteAcceptModal() {
         }
     }
 
-    const inviteList = invites.map(invite => (
-        <div key={invite.id} className="flex flex-row w-full justify-between border rounded-sm px-2 py-2 ">
+    const inviteList = invites.map(invite => {
+        if (!invite.data.account) {
+            console.warn("Invite has no account data", invite);
+            return null; // Skip rendering this invite
+        }
+
+        return (<div key={invite.id} className="flex flex-row w-full justify-between border rounded-sm px-2 py-2 ">
             <div className="flex flex-col">
-                <div className="w-full font-semibold">{invite.data.account.name}</div>
-                {invite.data.projectRef && <div className="w-full text-base">- {invite.data.projectRef.name}</div>}
+                <div className="w-full font-semibold">{invite.data.account.name ?? invite.data.account}</div>
+                {invite.data.project && <div className="w-full text-base">- {invite.data.project.name}</div>}
                 <div className="text-xs">Role: {invite.data.role}</div>
                 <div className="text-xs">by {invite.data.invitedBy.name}</div>
             </div>
             <div className="flex flex-col gap-4">
                 <Button size={'xs'} onClick={() => accept(invite)}>Accept</Button> <Button size={'xs'} variant="secondary" onClick={() => reject(invite)}>Reject</Button>
             </div>
-        </div>
-    ))
+        </div>)
+    })
 
     return (
         <div>

--- a/packages/ui/src/shell/login/InviteAcceptModal.tsx
+++ b/packages/ui/src/shell/login/InviteAcceptModal.tsx
@@ -51,7 +51,7 @@ export function InviteAcceptModal() {
         <div key={invite.id} className="flex flex-row w-full justify-between border rounded-sm px-2 py-2 ">
             <div className="flex flex-col">
                 <div className="w-full font-semibold">{invite.data.account.name}</div>
-                <div className="w-full text-base">- {invite.data.projects.map(p => typeof p === 'string' ? p : p.name).join(', ')}</div>
+                <div className="w-full text-base">- {invite.data.projects.name}</div>
                 <div className="text-xs">Role: {invite.data.role}</div>
                 <div className="text-xs">by {invite.data.invitedBy.name}</div>
             </div>

--- a/packages/ui/src/shell/login/InviteAcceptModal.tsx
+++ b/packages/ui/src/shell/login/InviteAcceptModal.tsx
@@ -1,5 +1,5 @@
 import { TransientToken, UserInviteTokenData } from "@vertesia/common"
-import { Button, Modal, ModalBody, ModalTitle } from "@vertesia/ui/core"
+import { Button, VModal, VModalBody, VModalTitle } from "@vertesia/ui/core"
 import { useEffect, useState } from "react"
 import { useUserSession } from "@vertesia/ui/session"
 
@@ -51,6 +51,7 @@ export function InviteAcceptModal() {
         <div key={invite.id} className="flex flex-row w-full justify-between border rounded-sm px-2 py-2 ">
             <div className="flex flex-col">
                 <div className="w-full font-semibold">{invite.data.account.name}</div>
+                <div className="w-full text-base">- {invite.data.projects.map(p => typeof p === 'string' ? p : p.name).join(', ')}</div>
                 <div className="text-xs">Role: {invite.data.role}</div>
                 <div className="text-xs">by {invite.data.invitedBy.name}</div>
             </div>
@@ -62,16 +63,16 @@ export function InviteAcceptModal() {
 
     return (
         <div>
-            <Modal isOpen={showModal} onClose={closeModal}>
-                <ModalTitle>Review Invites</ModalTitle>
-                <ModalBody>
+            <VModal isOpen={showModal} onClose={closeModal}>
+                <VModalTitle>Review Invites</VModalTitle>
+                <VModalBody>
                     <div className="text-sm pb-4">
                         You have received the following invites to join other accounts.
                         Please review and accept or declined them.
                     </div>
                     {inviteList}
-                </ModalBody>
-            </Modal>
+                </VModalBody>
+            </VModal>
         </div>
     )
 

--- a/packages/ui/src/shell/login/InviteAcceptModal.tsx
+++ b/packages/ui/src/shell/login/InviteAcceptModal.tsx
@@ -51,7 +51,7 @@ export function InviteAcceptModal() {
         <div key={invite.id} className="flex flex-row w-full justify-between border rounded-sm px-2 py-2 ">
             <div className="flex flex-col">
                 <div className="w-full font-semibold">{invite.data.account.name}</div>
-                <div className="w-full text-base">- {invite.data.projects.name}</div>
+                {invite.data.projectsRef && <div className="w-full text-base">- {invite.data.projectsRef.name}</div>}
                 <div className="text-xs">Role: {invite.data.role}</div>
                 <div className="text-xs">by {invite.data.invitedBy.name}</div>
             </div>


### PR DESCRIPTION
## Related Ticket:
* https://github.com/vertesia/studio/issues/2131

## Description

1. Update database Schema
  - Create `InvitationDataSchema` which defines all the columns in the documents to increase type security
 - Store `ObjectId` for project, account, invitedBy, and only populate the related information when returning the api response
 - Schema
 ```typescript
 export const InvitationDataSchema = new mongoose.Schema<UserInviteTokenData>({
    email: { type: String, required: true },
    role: { type: String, required: true },
    account: { type: mongoose.Types.ObjectId, ref: 'Account', required: true },
    project: { type: mongoose.Types.ObjectId, ref: 'Project', required: true },
    invitedBy: { type: mongoose.Types.ObjectId, ref: 'User', required: true }
}, { _id: false });
```
---
2. Update the invitation accept modal to show the project name
<img width="560" height="363" alt="Screenshot 2025-07-18 at 14 26 25" src="https://github.com/user-attachments/assets/f5602286-08e6-4b44-b31f-cfdd54b52dbc" />

3. restrict listing invitation by updating the endpoint for the invitation: `/invites/${type}/${id}`
   
    ```typescript
    /**
     * Fetch Invites for specific account or project
     * @param type Type of the invitation, either "project" or "account"
     * @param id ID of the project or organization to fetch invitations for
     * @returns UserInviteTokenData[]
     * */
     ```
  - for project admin: Only list the invitation within the current project
  - for organization admin: Only list the invitation for those he has access to
Before: it was listing all the invitations in the current organization



## Note
- All the legacy invitations will not be displayed on the user dashboard

