### PR TITLE
fix: explicit typing and removing unsupported react props for intermittent build errors.

### DIFF
--- a/packages/ui/src/core/components/shadcn/command.tsx
+++ b/packages/ui/src/core/components/shadcn/command.tsx
@@ -7,7 +7,7 @@ import { cn } from "../libs/utils"
 import { Dialog, DialogContent } from "./dialog"
 
 const Command = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive>,
+  React.ComponentRef<typeof CommandPrimitive>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive>
 >(({ className, ...props }, ref) => (
   <CommandPrimitive
@@ -34,7 +34,7 @@ const CommandDialog = ({ children, ...props }: DialogProps) => {
 }
 
 const CommandInput = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Input>,
+  React.ComponentRef<typeof CommandPrimitive.Input>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 >(({ className, ...props }, ref) => (
   <div className="flex items-center px-3 border-b" cmdk-input-wrapper="">
@@ -54,7 +54,7 @@ const CommandInput = React.forwardRef<
 CommandInput.displayName = CommandPrimitive.Input.displayName
 
 const CommandList = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.List>,
+  React.ComponentRef<typeof CommandPrimitive.List>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.List
@@ -67,7 +67,7 @@ const CommandList = React.forwardRef<
 CommandList.displayName = CommandPrimitive.List.displayName
 
 const CommandEmpty = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Empty>,
+  React.ComponentRef<typeof CommandPrimitive.Empty>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
 >((props, ref) => (
   <CommandPrimitive.Empty
@@ -97,7 +97,7 @@ const CommandGroup = React.forwardRef<
 CommandGroup.displayName = CommandPrimitive.Group.displayName
 
 const CommandSeparator = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Separator>,
+  React.ComponentRef<typeof CommandPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Separator>
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.Separator
@@ -109,7 +109,7 @@ const CommandSeparator = React.forwardRef<
 CommandSeparator.displayName = CommandPrimitive.Separator.displayName
 
 const CommandItem = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Item>,
+  React.ComponentRef<typeof CommandPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.Item

--- a/packages/ui/src/core/components/shadcn/command.tsx
+++ b/packages/ui/src/core/components/shadcn/command.tsx
@@ -6,8 +6,11 @@ import { Search } from "lucide-react"
 import { cn } from "../libs/utils"
 import { Dialog, DialogContent } from "./dialog"
 
-const Command = React.forwardRef<
-  React.ComponentRef<typeof CommandPrimitive>,
+const Command: React.ForwardRefExoticComponent<
+  React.RefAttributes<HTMLDivElement> &
+  React.PropsWithoutRef<React.ComponentPropsWithoutRef<typeof CommandPrimitive>>
+> = React.forwardRef<
+  HTMLDivElement,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive>
 >(({ className, ...props }, ref) => (
   <CommandPrimitive
@@ -19,6 +22,7 @@ const Command = React.forwardRef<
     {...props}
   />
 ))
+
 Command.displayName = CommandPrimitive.displayName
 
 const CommandDialog = ({ children, ...props }: DialogProps) => {
@@ -33,8 +37,11 @@ const CommandDialog = ({ children, ...props }: DialogProps) => {
   )
 }
 
-const CommandInput = React.forwardRef<
-  React.ComponentRef<typeof CommandPrimitive.Input>,
+const CommandInput: React.ForwardRefExoticComponent<
+  React.RefAttributes<HTMLInputElement> &
+  React.PropsWithoutRef<React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>>
+> = React.forwardRef<
+  HTMLInputElement,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 >(({ className, ...props }, ref) => (
   <div className="flex items-center px-3 border-b" cmdk-input-wrapper="">
@@ -53,8 +60,11 @@ const CommandInput = React.forwardRef<
 
 CommandInput.displayName = CommandPrimitive.Input.displayName
 
-const CommandList = React.forwardRef<
-  React.ComponentRef<typeof CommandPrimitive.List>,
+const CommandList: React.ForwardRefExoticComponent<
+  React.RefAttributes<HTMLDivElement> &
+  React.PropsWithoutRef<React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>>
+> = React.forwardRef<
+  HTMLDivElement,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.List
@@ -66,8 +76,11 @@ const CommandList = React.forwardRef<
 
 CommandList.displayName = CommandPrimitive.List.displayName
 
-const CommandEmpty = React.forwardRef<
-  React.ComponentRef<typeof CommandPrimitive.Empty>,
+const CommandEmpty: React.ForwardRefExoticComponent<
+  React.RefAttributes<HTMLDivElement> &
+  React.PropsWithoutRef<React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>>
+> = React.forwardRef<
+  HTMLDivElement,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
 >((props, ref) => (
   <CommandPrimitive.Empty
@@ -79,8 +92,11 @@ const CommandEmpty = React.forwardRef<
 
 CommandEmpty.displayName = CommandPrimitive.Empty.displayName
 
-const CommandGroup = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Group>,
+const CommandGroup: React.ForwardRefExoticComponent<
+  React.RefAttributes<HTMLDivElement> &
+  React.PropsWithoutRef<React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group>>
+> = React.forwardRef<
+  HTMLDivElement,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.Group
@@ -96,8 +112,11 @@ const CommandGroup = React.forwardRef<
 
 CommandGroup.displayName = CommandPrimitive.Group.displayName
 
-const CommandSeparator = React.forwardRef<
-  React.ComponentRef<typeof CommandPrimitive.Separator>,
+const CommandSeparator: React.ForwardRefExoticComponent<
+  React.RefAttributes<HTMLDivElement> &
+  React.PropsWithoutRef<React.ComponentPropsWithoutRef<typeof CommandPrimitive.Separator>>
+> = React.forwardRef<
+  HTMLDivElement,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Separator>
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.Separator
@@ -106,10 +125,14 @@ const CommandSeparator = React.forwardRef<
     {...props}
   />
 ))
+
 CommandSeparator.displayName = CommandPrimitive.Separator.displayName
 
-const CommandItem = React.forwardRef<
-  React.ComponentRef<typeof CommandPrimitive.Item>,
+const CommandItem: React.ForwardRefExoticComponent<
+  React.RefAttributes<HTMLDivElement> &
+  React.PropsWithoutRef<React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>>
+> = React.forwardRef<
+  HTMLDivElement,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.Item

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageItem.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageItem.tsx
@@ -259,7 +259,7 @@ export default function MessageItem({ message, showPulsatingCircle = false }: Me
                 <Markdown
                     remarkPlugins={[remarkGfm]}
                     components={{
-                        a: ({ node, ...props }: { node?: any; href?: string; children?: React.ReactNode }) => {
+                        a: ({ node, ref, ...props }: { node?: any; ref?: any; href?: string; children?: React.ReactNode }) => {
                             const href = props.href || "";
                             if (href.includes("/store/objects")) {
                                 return (
@@ -279,7 +279,7 @@ export default function MessageItem({ message, showPulsatingCircle = false }: Me
                                 />
                             );
                         },
-                        img: ({ node, ...props }: { node?: any; src?: string; alt?: string }) => {
+                        img: ({ node, ref, ...props }: { node?: any; ref?: any; src?: string; alt?: string }) => {
                             return (
                                 <img
                                     {...props}
@@ -291,11 +291,13 @@ export default function MessageItem({ message, showPulsatingCircle = false }: Me
                         },
                         code: ({
                             node,
+                            ref,
                             className,
                             children,
                             ...props
                         }: {
                             node?: any;
+                            ref?: any;
                             className?: string;
                             children?: React.ReactNode;
                         }) => {
@@ -317,21 +319,22 @@ export default function MessageItem({ message, showPulsatingCircle = false }: Me
                                 </>
                             );
                         },
-                        p: (props) => <p {...props} />,
-                        strong: (props) => <strong {...props} />,
-                        em: (props) => <em {...props} />,
-                        pre: (props) => <pre {...props} />,
-                        h1: (props) => <h1 {...props} />,
-                        h2: (props) => <h2 {...props} />,
-                        h3: (props) => <h3 {...props} />,
-                        li: (props) => <li {...props} />,
-                        ul: (props) => <ul {...props} />,
-                        ol: (props) => <ol {...props} />,
-                        blockquote: (props) => <blockquote {...props} />,
-                        hr: (props) => <hr {...props} />,
-                        table: (props) => <div className="overflow-x-auto"><table {...props} /></div>,
-                        th: (props) => <th {...props} />,
-                        td: (props) => <td {...props} />,
+                        // Remove 'node' and 'ref' from props
+                        p: ({ node, ref, ...props }) => <p {...props} />, 
+                        strong: ({ node, ref, ...props }) => <strong {...props} />,
+                        em: ({ node, ref, ...props }) => <em {...props} />,
+                        pre: ({ node, ref, ...props }) => <pre {...props} />,
+                        h1: ({ node, ref, ...props }) => <h1 {...props} />,
+                        h2: ({ node, ref, ...props }) => <h2 {...props} />,
+                        h3: ({ node, ref, ...props }) => <h3 {...props} />,
+                        li: ({ node, ref, ...props }) => <li {...props} />,
+                        ul: ({ node, ref, ...props }) => <ul {...props} />,
+                        ol: ({ node, ref, ...props }) => <ol {...props} />,
+                        blockquote: ({ node, ref, ...props }) => <blockquote {...props} />,
+                        hr: ({ node, ref, ...props }) => <hr {...props} />,
+                        table: ({ node, ref, ...props }) => <div className="overflow-x-auto"><table {...props} /></div>,
+                        th: ({ node, ref, ...props }) => <th {...props} />,
+                        td: ({ node, ref, ...props }) => <td {...props} />,
                     }}
                 >
                     {content as string}


### PR DESCRIPTION
Some errors only show when using turbo build --force , these are some of them.

Should be no or minimal (positive) impact.

1) react markdown has more props then react.

2) Explicit typing for portability with ref types inferred from cmdk.