### PR TITLE
Fix: when clear the filter the default value 

### DIFF
--- a/packages/ui/src/features/facets/RunsFacetsNav.tsx
+++ b/packages/ui/src/features/facets/RunsFacetsNav.tsx
@@ -105,11 +105,13 @@ export function useRunsFilterGroups(facets: RunsFacetsNavProps['facets']): Filte
 export function useRunsFilterHandler(search: SearchInterface) {
     return (newFilters: BaseFilter[]) => {
         if (newFilters.length === 0) {
-            search.clearFilters();
+            // Clear filters without applying defaults - user wants to remove all filters
+            search.clearFilters(true, false);
             return;
         }
 
-        search.clearFilters(false);
+        // Clear all filters first without defaults, then apply new ones
+        search.clearFilters(false, false);
 
         newFilters.forEach(filter => {
             if (filter.value && filter.value.length > 0) {

--- a/packages/ui/src/features/facets/VFacetsNav.tsx
+++ b/packages/ui/src/features/facets/VFacetsNav.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 export interface SearchInterface {
     getFilterValue(name: string): any;
     setFilterValue(name: string, value: any): void;
-    clearFilters(autoSearch?: boolean): void;
+    clearFilters(autoSearch?: boolean, applyDefaults?: boolean): void;
     search(): Promise<boolean | undefined>;
     readonly isRunning: boolean;
     query: Record<string, any>;


### PR DESCRIPTION
## Description
### Problem found
- The filter applies a 7-day range by default, and when the filter is removed, there are still no runs showing in the table
- There is no option in the filter 

### Cause 
- In the Previous implementation, the `clearFilter` function will apply a 7-day range by default
- The response generates the filter option, since the 7-day range is applied, there are no runs to generate the options

### Solution
- This PR adds an option to decide whether to apply the default value when clearing the filter.
- Also, use the new option to apply the default when the page first loads