### PR TITLE
feat: Add markdown workflow support for PDF documents

### DIFF
--- a/packages/ui/src/features/magic-pdf/DownloadPopover.tsx
+++ b/packages/ui/src/features/magic-pdf/DownloadPopover.tsx
@@ -1,4 +1,4 @@
-import { ContentObject } from "@vertesia/common";
+import { ContentObject, DocumentMetadata } from "@vertesia/common";
 import { useUserSession } from "@vertesia/ui/session";
 import { Popover } from "@vertesia/ui/widgets";
 import { CloudDownload } from "lucide-react";
@@ -12,18 +12,51 @@ export function DownloadPopover({ object }: DownloadPopoverProps) {
     const onDownload = (name: string) => {
         getResourceUrl(client, object.id, name).then(url => window.open(url, '_blank'));
     }
+    
+    const getProcessorType = (): string => {
+        if (object.metadata?.type === "document") {
+            const docMetadata = object.metadata as DocumentMetadata;
+            return docMetadata.content_processor?.type || "xml";
+        }
+        return "xml"; // default
+    };
+    
+    const processorType = getProcessorType();
+    
+    const renderDownloadOptions = () => {
+        if (processorType === "markdown") {
+            return (
+                <button className="p-2 cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-100" onClick={() => onDownload("document.md")}>
+                    document.md
+                </button>
+            );
+        }
+        
+        // Default XML processor options
+        return (
+            <>
+                <button className="p-2 cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-100" onClick={() => onDownload("annotated.pdf")}>
+                    annotated.pdf
+                </button>
+                <button className="p-2 cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-100" onClick={() => onDownload("document.xml")}>
+                    document.xml
+                </button>
+                <button className="p-2 cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-100" onClick={() => onDownload("analyzed-pages.json")}>
+                    analyzed-pages.json
+                </button>
+            </>
+        );
+    };
+    
     return (
         <div className="absolute bottom-[58px] right-[20px] w-[36px] h-[36px] cursor-pointer text-indigo-400 border-indigo-400 hover:border-indigo-500 hover:text-indigo-500 border-2 rounded-full shadow-xs flex items-center justify-center">
             <Popover strategy='absolute' placement='top-end' zIndex={100} offset={20}>
                 <Popover.Trigger click>
                     <CloudDownload className='size-6' />
-
                 </Popover.Trigger>
                 <Popover.Content>
                     <div className="rounded-md shadow-md border border-gray-100 bg-white dark:bg-slate-50 dark:border-slate-100 min-w-[200px] flex flex-col divide-y">
-                        <button className="p-2 cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-100" onClick={() => onDownload("annotated.pdf")}>annotated.pdf</button>
-                        <button className="p-2 cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-100" onClick={() => onDownload("document.xml")}>document.xml</button>
-                        <button className="p-2 cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-100" onClick={() => onDownload("analyzed-pages.json")}>analyzed-pages.json</button>
+                        {renderDownloadOptions()}
                     </div>
                 </Popover.Content>
             </Popover>

--- a/packages/ui/src/features/magic-pdf/MagicPdfView.tsx
+++ b/packages/ui/src/features/magic-pdf/MagicPdfView.tsx
@@ -70,7 +70,7 @@ function MagicPdfViewImpl({ object, onClose }: _MagicPdfViewProps) {
     return (
         <>
             <div ref={left} className={`absolute top-0 left-0 bottom-0 w-[50%] bg-gray-100 dark:bg-slate-800 flex items-stretch justify-stretch py-2`}>
-                <PageSlider className="flex-1" currentPage={pageNumber} onChange={setPageNumber} />
+                <PageSlider className="flex-1" currentPage={pageNumber} onChange={setPageNumber} object={object} />
                 <div ref={handler} className='w-[2px] p-[2px] m-0 bg-slate-300 cursor-ew-resize'></div>
             </div>
             <div ref={right} className={`absolute top-0 left-[50%] right-0 bottom-0 flex items-stretch justify-stretch overflow-auto p-2`}>

--- a/packages/ui/src/features/magic-pdf/MagicPdfView.tsx
+++ b/packages/ui/src/features/magic-pdf/MagicPdfView.tsx
@@ -1,4 +1,4 @@
-import { ContentObject } from "@vertesia/common";
+import { ContentObject, DocumentMetadata } from "@vertesia/common";
 import { ErrorBox, useFetch } from "@vertesia/ui/core";
 import { useUserSession } from "@vertesia/ui/session";
 import { X } from "lucide-react";
@@ -39,8 +39,27 @@ interface _MagicPdfViewProps {
     onClose?: () => void;
 }
 function MagicPdfViewImpl({ object, onClose }: _MagicPdfViewProps) {
-    const [viewType, setViewType] = useState<ViewType>("xml");
+    const getInitialViewType = (): ViewType => {
+        if (object.metadata?.type === "document") {
+            const docMetadata = object.metadata as DocumentMetadata;
+            const processorType = docMetadata.content_processor?.type;
+            if (processorType === "markdown") return "markdown";
+            if (processorType === "xml") return "xml";
+        }
+        return "xml"; // default
+    };
+    
+    const getProcessorType = (): string => {
+        if (object.metadata?.type === "document") {
+            const docMetadata = object.metadata as DocumentMetadata;
+            return docMetadata.content_processor?.type || "xml";
+        }
+        return "xml"; // default
+    };
+    
+    const [viewType, setViewType] = useState<ViewType>(getInitialViewType());
     const [pageNumber, setPageNumber] = useState(1);
+    const processorType = getProcessorType();
     const handler = useRef<HTMLDivElement>(null);
     const left = useRef<HTMLDivElement>(null);
     const right = useRef<HTMLDivElement>(null);
@@ -58,7 +77,7 @@ function MagicPdfViewImpl({ object, onClose }: _MagicPdfViewProps) {
                 <TextPageView pageNumber={pageNumber} viewType={viewType} />
             </div>
             <DownloadPopover object={object} />
-            <ContentSwitcher type={viewType} onSwitch={setViewType} />
+            {processorType === "xml" && <ContentSwitcher type={viewType} onSwitch={setViewType} />}
             {!!onClose &&
                 <div className="absolute top-6 right-7 w-9 h-9 cursor-pointer text-red-400 border-red-400 hover:border-red-500 hover:text-red-500 border-2 rounded-full shadow-xs flex items-center justify-center"
                     onClick={onClose}>
@@ -80,6 +99,8 @@ function ContentSwitcher({ type = "xml", onSwitch }: ContentSwitcherProps) {
         if (type === "xml") {
             onSwitch("json");
         } else if (type === "json") {
+            onSwitch("markdown");
+        } else if (type === "markdown") {
             onSwitch("xml");
         }
     }
@@ -87,7 +108,8 @@ function ContentSwitcher({ type = "xml", onSwitch }: ContentSwitcherProps) {
         <div className="absolute bottom-[16px] right-[20px] w-[36px] h-[36px] cursor-pointer text-indigo-400 border-indigo-400 hover:border-indigo-500 hover:text-indigo-500 border-2 rounded-full shadow-xs flex items-center justify-center"
             onClick={_onSwitch}>
             {type === "xml" && JSON}
-            {type === "json" && XML}
+            {type === "json" && MARKDOWN}
+            {type === "markdown" && XML}
         </div>
     )
 
@@ -99,4 +121,8 @@ const JSON = <svg width="16px" height="16px" viewBox="0 0 16 16" xmlns="http://w
 
 const XML = <svg width="16px" height="16px" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
     <path d="M4.708 5.578L2.061 8.224l2.647 2.646-.708.708-3-3V7.87l3-3 .708.708zm7-.708L11 5.578l2.647 2.646L11 10.87l.708.708 3-3V7.87l-3-3zM4.908 13l.894.448 5-10L9.908 3l-5 10z" />
+</svg>
+
+const MARKDOWN = <svg width="16px" height="16px" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+    <path d="M14.85 3H1.15C.52 3 0 3.52 0 4.15v7.69C0 12.48.52 13 1.15 13h13.69c.64 0 1.15-.52 1.15-1.15v-7.7C16 3.52 15.48 3 14.85 3zM9 11H7.5L5.5 9l-1 1.5H3V5h1.5l1 2 2-2H9v6zm2.99.5L9.5 8H11V5h1v3h1.5l-2.51 3.5z"/>
 </svg>

--- a/packages/ui/src/features/magic-pdf/PdfPageProvider.tsx
+++ b/packages/ui/src/features/magic-pdf/PdfPageProvider.tsx
@@ -143,7 +143,7 @@ function getLayoutJsonPath(objectId: string, pageNumber: number) {
 }
 
 function getMarkdownPath(objectId: string, pageNumber: number) {
-    return `${getBasePath(objectId)}/pages/page-${pageNumber}.mpx:ConvertPageToMarkdown.txt`;
+    return `${getBasePath(objectId)}/pages/page-${pageNumber}.md`;
 }
 
 export function getResourceUrl(

--- a/packages/ui/src/features/magic-pdf/TextPageView.tsx
+++ b/packages/ui/src/features/magic-pdf/TextPageView.tsx
@@ -1,5 +1,7 @@
 import { JSONCode, Theme, XMLViewer } from '@vertesia/ui/widgets';
 import { useEffect, useLayoutEffect, useState } from "react";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { usePdfPagesInfo } from "./PdfPageProvider";
 import { ViewType } from "./types";
 
@@ -19,7 +21,14 @@ interface TextPageViewProps {
     viewType: ViewType;
 }
 export function TextPageView({ viewType, pageNumber }: TextPageViewProps) {
-    return viewType === "json" ? <JsonPageLayoutView pageNumber={pageNumber} /> : <XmlPageView pageNumber={pageNumber} />
+    switch (viewType) {
+        case "json":
+            return <JsonPageLayoutView pageNumber={pageNumber} />;
+        case "markdown":
+            return <MarkdownPageView pageNumber={pageNumber} />;
+        default:
+            return <XmlPageView pageNumber={pageNumber} />;
+    }
 }
 
 interface XmlPageViewProps {
@@ -60,5 +69,24 @@ function JsonPageLayoutView({ pageNumber }: JsonPageLayoutViewProps) {
     }, [pageNumber]);
     return (
         content && <JSONCode className="w-full" data={content} />
+    )
+}
+
+interface MarkdownPageViewProps {
+    pageNumber: number;
+}
+function MarkdownPageView({ pageNumber }: MarkdownPageViewProps) {
+    const [content, setContent] = useState<string>();
+    const { markdownProvider } = usePdfPagesInfo();
+    useEffect(() => {
+        markdownProvider.getPageMarkdown(pageNumber).then(setContent).catch((err: any) => {
+            console.error(err);
+            setContent(undefined);
+        });
+    }, [pageNumber]);
+    return (
+        <div className="px-4 py-2 prose prose-sm max-w-none dark:prose-invert">
+            {content ? <Markdown remarkPlugins={[remarkGfm]}>{content}</Markdown> : <div>No markdown content available</div>}
+        </div>
     )
 }

--- a/packages/ui/src/features/magic-pdf/types.ts
+++ b/packages/ui/src/features/magic-pdf/types.ts
@@ -1,1 +1,1 @@
-export type ViewType = "xml" | "json";
+export type ViewType = "xml" | "json" | "markdown";

--- a/packages/ui/src/features/store/objects/layout/documentLayout.tsx
+++ b/packages/ui/src/features/store/objects/layout/documentLayout.tsx
@@ -28,7 +28,7 @@ export function DocumentTableView({ objects, selection, isLoading, onRowClick, c
                     ))}
                 </tr>
             </thead>
-            <TBody isLoading={isLoading} columns={columns.length}>
+            <TBody isLoading={isLoading} columns={columns.length + 1}>
                 {
                     objects?.map((obj: ContentObjectItem) => {
                         return (

--- a/packages/workflow/src/activities/identifyTextSections.ts
+++ b/packages/workflow/src/activities/identifyTextSections.ts
@@ -55,11 +55,16 @@ export async function identifyTextSections(
         return;
     }
 
+    const existingMetadata = doc.metadata as DocumentMetadata | undefined;
+    const updatedMetadata: DocumentMetadata = {
+        type: "document",
+        ...existingMetadata,
+        generation_runs: existingMetadata?.generation_runs ?? [],
+        sections: parts
+    };
+
     await client.objects.update(doc.id, {
-        metadata: {
-            type: "document",
-            sections: parts
-        } as DocumentMetadata
+        metadata: updatedMetadata,
     });
 
     return { status: "completed" };


### PR DESCRIPTION
## Summary
- Added markdown display support for PDF documents processed with markdown processor
- Enhanced MagicPdfView to detect processor type and show appropriate view options
- Updated DownloadPopover to offer markdown download for markdown-processed documents
- Modified PageSlider to show original images instead of annotated ones for markdown workflow
- Added markdown page view with proper formatting and GitHub Flavored Markdown support
- Fixed column count issue in document table layout
- Preserved existing metadata when updating document sections

## Test plan
- [ ] Test PDF document processing with markdown processor
- [ ] Verify markdown view displays correctly in MagicPdfView
- [ ] Confirm download options show markdown file for markdown-processed documents
- [ ] Test page slider shows original images for markdown workflow
- [ ] Verify document table displays with correct column count
- [ ] Test that existing metadata is preserved during section updates

🤖 Generated with [Claude Code](https://claude.ai/code)