### PR TITLE
Feat: add account level of apikeys with project name

### DIFF
--- a/packages/client/src/ApiKeysApi.ts
+++ b/packages/client/src/ApiKeysApi.ts
@@ -13,8 +13,8 @@ export class ApiKeysApi extends ApiTopic {
      * List all keys for account without values
      * @returns ApiKey[]
      */
-    list(): Promise<ApiKey[]> {
-        return this.get('/');
+    list(level: 'account' | 'project' = 'account'): Promise<ApiKey[]> {
+        return this.get('/', { query: { level } });
     }
 
     /**

--- a/packages/common/src/apikey.ts
+++ b/packages/common/src/apikey.ts
@@ -13,7 +13,7 @@ export interface ApiKey {
     role: ProjectRoles;
     maskedValue?: string; //masked value
     account: string; // the account id
-    project: string; // the project id if any
+    project: ProjectRef; // the project id if any
     enabled: boolean;
     created_by: string,
     updated_by: string,

--- a/packages/ui/src/features/user/UserInfo.tsx
+++ b/packages/ui/src/features/user/UserInfo.tsx
@@ -180,7 +180,7 @@ export function ApiKeyAvatar({ keyId, showTitle = false, size = "md" }: ApiKeyAv
             </tr>
             <tr>
                 <td className="font-semibold w-20">Project:</td>
-                <td className="truncate max-w-0">{data?.project}</td>
+                <td className="truncate max-w-0">{data?.project.name}</td>
             </tr>
         </Table>
     );
@@ -189,7 +189,7 @@ export function ApiKeyAvatar({ keyId, showTitle = false, size = "md" }: ApiKeyAv
         <UserPopoverPanel title={title} description={description}>
             <div className="flex flex-row items-center gap-2">
                 {avatar}
-                {showTitle && <div className="text-sm font-semibold">{data?.name || data?.account || data?.project || "unknown"}</div>}
+                {showTitle && <div className="text-sm font-semibold">{data?.name || data?.account || data?.project.name || "unknown"}</div>}
             </div>
         </UserPopoverPanel >
     )


### PR DESCRIPTION
## Description
- Project setting 
  - restrict the API key listing to the current project
- Organization setting
  - list out all the api keys from all the projects that the user has access to in the organization  

