### PR TITLE
feat: add endpoint to update app installation settings

### DIFF
--- a/packages/client/src/AppsApi.ts
+++ b/packages/client/src/AppsApi.ts
@@ -113,5 +113,13 @@ export default class AppsApi extends ApiTopic {
         return this.get('/installations/refs');
     }
 
+    updateInstallationSettings(settingsPayload: AppInstallationPayload): Promise<AppInstallationWithManifest> {
+        return this.put(`/installations/settings/${settingsPayload.app_id}`, {
+            payload: {
+                app_id: settingsPayload.app_id,
+                settings: settingsPayload.settings
+            } satisfies AppInstallationPayload
+        });
+    }
 
 }


### PR DESCRIPTION
Settings are stored outside the app manifest, and app installations did not have any update endpoints.

For studio pr [#2519](https://github.com/vertesia/studio/pull/2519)