### PR TITLE
feat: add reusable markdown renderer widget

### DIFF
--- a/packages/ui/externals.js
+++ b/packages/ui/externals.js
@@ -31,6 +31,7 @@ export const EXTERNALS = [
     "ts-md5",
     "react-markdown",
     "remark-gfm",
+    "unist-util-visit",
     "@monaco-editor/react",
     "monaco-editor",
     "motion",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -66,7 +66,8 @@
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.3.0",
-        "ts-md5": "^1.3.1"
+        "ts-md5": "^1.3.1",
+        "unist-util-visit": "^5.0.0"
     },
     "devDependencies": {
         "@eslint/js": "^9.27.0",

--- a/packages/ui/src/features/magic-pdf/TextPageView.tsx
+++ b/packages/ui/src/features/magic-pdf/TextPageView.tsx
@@ -1,7 +1,5 @@
-import { JSONCode, Theme, XMLViewer } from '@vertesia/ui/widgets';
+import { JSONCode, Theme, XMLViewer, MarkdownRenderer } from '@vertesia/ui/widgets';
 import { useEffect, useLayoutEffect, useState } from "react";
-import Markdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import { usePdfPagesInfo } from "./PdfPageProvider";
 import { ViewType } from "./types";
 
@@ -15,6 +13,7 @@ const darkTheme: Theme = {
     commentColor: "#BEBEBE",
     cdataColor: "#33CC66",
 }
+
 
 interface TextPageViewProps {
     pageNumber: number;
@@ -86,7 +85,7 @@ function MarkdownPageView({ pageNumber }: MarkdownPageViewProps) {
     }, [pageNumber]);
     return (
         <div className="px-4 py-2 prose prose-sm max-w-none dark:prose-invert">
-            {content ? <Markdown remarkPlugins={[remarkGfm]}>{content}</Markdown> : <div>No markdown content available</div>}
+            {content ? <MarkdownRenderer>{content}</MarkdownRenderer> : <div>No markdown content available</div>}
         </div>
     )
 }

--- a/packages/ui/src/features/store/objects/DocumentPreviewPanel.tsx
+++ b/packages/ui/src/features/store/objects/DocumentPreviewPanel.tsx
@@ -16,8 +16,7 @@ import {
   X,
 } from "lucide-react";
 import { useEffect, useState } from "react";
-import Markdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { MarkdownRenderer } from "@vertesia/ui/widgets";
 
 interface DocumentPreviewPanelProps {
   objectId: string | null;
@@ -233,7 +232,7 @@ export function DocumentPreviewPanel({
                   <div className="shadow rounded-md p-4 border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
                     {seemsMarkdown ? (
                       <div className="prose prose-sm max-w-none prose-p:my-2 prose-pre:bg-gray-800 prose-pre:my-2 prose-headings:text-indigo-700 dark:prose-invert dark:prose-headings:text-indigo-300">
-                        <Markdown remarkPlugins={[remarkGfm]}>{text}</Markdown>
+                        <MarkdownRenderer>{text}</MarkdownRenderer>
                       </div>
                     ) : (
                       <pre className="text-wrap whitespace-pre-wrap dark:text-gray-200">

--- a/packages/ui/src/features/store/objects/components/ContentOverview.tsx
+++ b/packages/ui/src/features/store/objects/components/ContentOverview.tsx
@@ -1,10 +1,8 @@
 import { useEffect, useState } from "react";
-import Markdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 
 import { useUserSession } from "@vertesia/ui/session";
 import { Button, Spinner, useToast } from "@vertesia/ui/core";
-import { JSONDisplay } from "@vertesia/ui/widgets";
+import { JSONDisplay, MarkdownRenderer } from "@vertesia/ui/widgets";
 import { ContentObject, ImageRenditionFormat } from "@vertesia/common";
 import { Copy, Download, SquarePen } from "lucide-react";
 import { PropertiesEditorModal } from "./PropertiesEditorModal";
@@ -314,8 +312,7 @@ export function ContentOverview({
                         <div className="border shadow-xs rounded-xs max-w-7xl">
                             {seemsMarkdown ? (
                                 <div className="vprose prose-sm p-1">
-                                    <Markdown
-                                        remarkPlugins={[remarkGfm]}
+                                    <MarkdownRenderer
                                         components={{
                                             a: ({ node, ...props }: { node?: any; href?: string; children?: React.ReactNode }) => {
                                                 const href = props.href || "";
@@ -378,7 +375,7 @@ export function ContentOverview({
                                         }}
                                     >
                                         {text}
-                                    </Markdown>
+                                    </MarkdownRenderer>
                                 </div>
                             ) : (
                                 <pre className="text-wrap bg-muted text-muted p-2">

--- a/packages/ui/src/widgets/index.ts
+++ b/packages/ui/src/widgets/index.ts
@@ -1,6 +1,7 @@
 export * from "./codemirror/index.js";
 export * from "./form/index.js";
 export * from "./json-view/index.js";
+export * from "./markdown/index.js";
 export * from "./popover/index.js";
 export * from "./Progress.js";
 export * from "./properties/index.js";

--- a/packages/ui/src/widgets/markdown/MarkdownRenderer.tsx
+++ b/packages/ui/src/widgets/markdown/MarkdownRenderer.tsx
@@ -1,0 +1,45 @@
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { visit, SKIP } from 'unist-util-visit';
+
+function remarkRemoveComments() {
+    return (tree: any) => {
+        visit(tree, 'html', (node: any, index: number | undefined, parent: any) => {
+            if (node.value && /<!--[\s\S]*?-->/.test(node.value)) {
+                if (parent && typeof index === 'number' && parent.children) {
+                    parent.children.splice(index, 1);
+                    return [SKIP, index];
+                }
+            }
+        });
+    };
+}
+
+interface MarkdownRendererProps {
+    children: string;
+    components?: any;
+    remarkPlugins?: any[];
+    removeComments?: boolean;
+}
+
+export function MarkdownRenderer({ 
+    children, 
+    components, 
+    remarkPlugins = [], 
+    removeComments = true
+}: MarkdownRendererProps) {
+    const plugins = [remarkGfm, ...remarkPlugins];
+    
+    if (removeComments) {
+        plugins.push(remarkRemoveComments);
+    }
+
+    return (
+        <Markdown 
+            remarkPlugins={plugins}
+            components={components}
+        >
+            {children}
+        </Markdown>
+    );
+}

--- a/packages/ui/src/widgets/markdown/index.ts
+++ b/packages/ui/src/widgets/markdown/index.ts
@@ -1,0 +1,1 @@
+export { MarkdownRenderer } from './MarkdownRenderer';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -634,6 +634,9 @@ importers:
       ts-md5:
         specifier: ^1.3.1
         version: 1.3.1
+      unist-util-visit:
+        specifier: ^5.0.0
+        version: 5.0.0
     devDependencies:
       '@eslint/js':
         specifier: ^9.27.0


### PR DESCRIPTION
## Summary
- Created a reusable `MarkdownRenderer` component in `@vertesia/ui/widgets`
- Automatically removes HTML comments from markdown content using a custom remark plugin
- Includes remarkGfm by default for GitHub Flavored Markdown support
- Updated existing components to use the new renderer: TextPageView, ContentOverview, DocumentPreviewPanel

## Features
- HTML comment removal via custom remark plugin using `unist-util-visit`
- Configurable through props (components, remarkPlugins, removeComments)
- Type-safe implementation with proper TypeScript support
- Consistent markdown rendering across the application

## Test plan
- [ ] Verify markdown renders correctly in PDF text view
- [ ] Verify HTML comments are stripped from content in ContentOverview
- [ ] Verify HTML comments are stripped from content in DocumentPreviewPanel
- [ ] Test with various markdown content including HTML comments
- [ ] Verify build process works correctly with new external dependency

🤖 Generated with [Claude Code](https://claude.ai/code)