### PR TITLE
fix: disable 'enter' keyboard key when making a collection

### DIFF
--- a/packages/ui/src/features/store/collections/CreateCollection.tsx
+++ b/packages/ui/src/features/store/collections/CreateCollection.tsx
@@ -74,7 +74,7 @@ export function CreateCollectionForm({ onClose, redirect = true, onAddToCollecti
     };
 
     return (
-        <form>
+        <form onSubmit={(e) => e.preventDefault()}>
             <VModalBody>
                 <FormItem label="Name" required>
                     <Input type="text" value={payload.name || ""} onChange={(value) => setPayloadProp("name", value)} />


### PR DESCRIPTION
If you hit the "enter" key while typing in the new collection modal, it closes the modal without creating the collection or saving the work. 

For example, if you fill out the modal and hit "enter", it actually closes and clears the modal instead of creating the collection.

Fix: remove default form handling to disable enter key.

Studio PR: https://github.com/vertesia/studio/pull/2573