### PR TITLE
feat: persist generated images

### DIFF
--- a/packages/client/src/InteractionsApi.ts
+++ b/packages/client/src/InteractionsApi.ts
@@ -1,5 +1,5 @@
 import { ApiTopic, ClientBase, ServerError } from "@vertesia/api-fetch-client";
-import { AsyncExecutionPayload, ComputeInteractionFacetPayload, ExecutionRun, GenerateInteractionPayload, GenerateTestDataPayload, ImprovePromptPayload, Interaction, InteractionCreatePayload, InteractionEndpointQuery, InteractionExecutionPayload, InteractionExecutionResult, InteractionForkPayload, InteractionPublishPayload, InteractionRef, InteractionRefWithSchema, InteractionSearchPayload, InteractionSearchQuery, InteractionUpdatePayload, InteractionsExportPayload } from "@vertesia/common";
+import { AsyncExecutionPayload, ComputeInteractionFacetPayload, ExecutionRun, GenerateInteractionPayload, GenerateTestDataPayload, ImprovePromptPayload, Interaction, InteractionCreatePayload, InteractionEndpoint, InteractionEndpointQuery, InteractionExecutionPayload, InteractionExecutionResult, InteractionForkPayload, InteractionPublishPayload, InteractionRef, InteractionRefWithSchema, InteractionSearchPayload, InteractionSearchQuery, InteractionUpdatePayload, InteractionsExportPayload } from "@vertesia/common";
 import { VertesiaClient } from "./client.js";
 import { executeInteraction, executeInteractionAsync, executeInteractionByName } from "./execute.js";
 
@@ -35,7 +35,7 @@ export default class InteractionsApi extends ApiTopic {
      * Find interactions given a mongo match query.
      * You can also specify if prompts schemas are included in the result
      */
-    listEndpoints(payload: InteractionEndpointQuery): Promise<InteractionRef[]> {
+    listEndpoints(payload: InteractionEndpointQuery): Promise<InteractionEndpoint[]> {
         return this.post("/endpoints", {
             payload
         });

--- a/packages/common/src/interaction.ts
+++ b/packages/common/src/interaction.ts
@@ -77,6 +77,7 @@ export interface InteractionEndpoint {
     visibility?: InteractionVisibility;
     version: number;
     tags: string[];
+    output_modality?: Modalities;
     result_schema?: JSONSchema;
     params_schema?: JSONSchema;
 }

--- a/packages/workflow/src/activities/executeInteraction.ts
+++ b/packages/workflow/src/activities/executeInteraction.ts
@@ -183,7 +183,7 @@ export async function executeInteraction(payload: DSLActivityExecutionPayload<Ex
         return projectResult(payload, params, res, {
             runId: res.id,
             status: res.status,
-            result: res,
+            result: res.result,
         });
 
     } catch (error: any) {


### PR DESCRIPTION
## Summary
- Persist images generated with interactions instead of storing large base64 payload in workflow history
- Add output modality to endpoint description  
- use same type as server side API for /endpoints

## Test plan
- [ ] Verify image persistence improvements reduce workflow history size
- [ ] Test output modality endpoint description
- [ ] Confirm API type consistency

🤖 Generated with [Claude Code](https://claude.ai/code)