### PR TITLE
Fix: update log and add metadata

### DIFF
--- a/packages/workflow/src/activities/executeInteraction.ts
+++ b/packages/workflow/src/activities/executeInteraction.ts
@@ -190,7 +190,7 @@ export async function executeInteraction(payload: DSLActivityExecutionPayload<Ex
         if (error.message.includes("Failed to validate merged prompt schema")) {
             log.error("Failed to validate merged prompt schema", { 
                 error, 
-                "@metadata": { "error.code": "validation_error" }
+                "error.code": "validation_error"
             });
             //issue with the input data, don't retry
             throw new ActivityParamInvalidError("Failed to validate merged prompt schema", payload.activity, error.message);

--- a/packages/workflow/src/activities/executeInteraction.ts
+++ b/packages/workflow/src/activities/executeInteraction.ts
@@ -187,14 +187,22 @@ export async function executeInteraction(payload: DSLActivityExecutionPayload<Ex
         });
 
     } catch (error: any) {
-        log.error("Failed to execute interaction", { error });
         if (error.message.includes("Failed to validate merged prompt schema")) {
+            log.error("Failed to validate merged prompt schema", { 
+                error, 
+                "@metadata": { "error.code": "validation_error" }
+            });
             //issue with the input data, don't retry
-            throw new ActivityParamInvalidError("prompt_data", payload.activity, error.message);
+            throw new ActivityParamInvalidError("Failed to validate merged prompt schema", payload.activity, error.message);
         } else if (error.message.includes("modelId: Path `modelId` is required")) {
+            log.error("Model ID validation failed", { 
+                error,
+                "@metadata": { "error.code": "validation_error" }
+            });
             //issue with the input data, don't retry
-            throw new ActivityParamInvalidError("model", payload.activity, error.message);
+            throw new ActivityParamInvalidError("Model ID is required", payload.activity, error.message);
         } else {
+            log.error("Failed to execute interaction", { error });
             throw error;
         }
     }

--- a/packages/workflow/src/activities/executeInteraction.ts
+++ b/packages/workflow/src/activities/executeInteraction.ts
@@ -197,7 +197,7 @@ export async function executeInteraction(payload: DSLActivityExecutionPayload<Ex
         } else if (error.message.includes("modelId: Path `modelId` is required")) {
             log.error("Model ID validation failed", { 
                 error,
-                "@metadata": { "error.code": "validation_error" }
+                "error.code": "validation_error"
             });
             //issue with the input data, don't retry
             throw new ActivityParamInvalidError("Model ID is required", payload.activity, error.message);


### PR DESCRIPTION
## Alert
### High number of Temporal activity errors on @metadata.activityType:executeInteraction
More than 100 log events matched in the last 30m against the monitored query:
```
Time | @Metadata.Activitytype | Message
-----------------------------
17:25:51 UTC | executeInteraction | Failed to execute interaction
-----------------------------
17:25:28 UTC | executeInteraction | Failed to execute interaction
```

## Solution 

After investigating, the errors are mostly coming from the following log
```
500 - Error executing interaction DynamicMetadataFork (6838de4b28a2ce9e8f8aa814) with model arn:aws:bedrock:us-east-1:716085231028:inference-profile/us.anthropic.claude-3-5-sonnet-20241022-v2:0: Failed to validate merged prompt schema.
[#/properties/dictionaries/type]: must be string
```
When running an execution like this, the endpoint should return 4xx with validation_error rather than 500 since its a client error, and with the fix, it should be excluded  from the alert
