### PR TITLE
fix: use snake_case full_text instead of camelCase fullText

### DIFF
--- a/packages/common/src/payload.ts
+++ b/packages/common/src/payload.ts
@@ -12,6 +12,13 @@ import {
 
 export interface SearchPayload {
     facets?: FacetSpec[];
+    /**
+     * If the facets should respect "limit"
+     * If true, the facet count be limited to the number of results in the query.
+     * If false, the facet count will be calculated over all objects.
+     * Default is true.
+     */
+    limit_facets?: boolean;
     query?: SimpleSearchQuery;
     limit?: number;
     offset?: number;

--- a/packages/common/src/query.ts
+++ b/packages/common/src/query.ts
@@ -104,9 +104,9 @@ export interface ComplexSearchQuery extends ObjectSearchQuery {
     vector?: VectorSearchQuery;
 
     /**
-     * If present, do a full text search.
+     * If present, do a full text search (snake_case version).
      */
-    fullText?: string;
+    full_text?: string;
 
     weights?: Record<SearchTypes, number>;
 

--- a/packages/ui/src/features/store/objects/DocumentSearchResults.tsx
+++ b/packages/ui/src/features/store/objects/DocumentSearchResults.tsx
@@ -116,7 +116,7 @@ export function DocumentSearchResults({ layout, onUpload, allowFilter = true, al
     const handleVectorSearch = (query?: ComplexSearchQuery) => {
         if (query && query.vector) {
             search.query.vector = query.vector;
-            search.query.fullText = query.fullText;
+            search.query.full_text = query.full_text;
             search.query.weights = query.weights;
             search.query.score_aggregation = query.score_aggregation;
             search.query.dynamic_scaling = query.dynamic_scaling;

--- a/packages/ui/src/features/store/objects/components/VectorSearchWidget.tsx
+++ b/packages/ui/src/features/store/objects/components/VectorSearchWidget.tsx
@@ -34,7 +34,7 @@ export function VectorSearchWidget({ onChange, isLoading, refresh, searchTypes }
         if (searchTypes) setSelectedTypes(searchTypes);
     }, [searchTypes]);
 
-    // Always derive embeddingSearchTypes and fullText from selectedTypes
+    // Always derive embeddingSearchTypes and full_text from selectedTypes
     const embeddingSearchTypes: Record<string, boolean> = {};
     let fullTextEnabled = false;
     selectedTypes.forEach(type => {
@@ -75,7 +75,7 @@ export function VectorSearchWidget({ onChange, isLoading, refresh, searchTypes }
                 text: searchText,
                 config: embeddingSearchTypes,
             },
-            fullText: fullTextEnabled ? searchText : undefined,
+            full_text: fullTextEnabled ? searchText : undefined,
             limit: limit
         };
         onChange(query);


### PR DESCRIPTION
## Summary
- Update field naming to use snake_case (`full_text`) instead of camelCase (`fullText`)
- Ensures API consistency with snake_case naming convention

## Changes
- Update ComplexSearchQuery type to only have `full_text` field
- Update DocumentSearchResults to use `full_text`
- Update VectorSearchWidget to use `full_text`

## Related
- Part of the effort to standardize API field naming across the platform
- Companion to studio PR that updates backend to use `full_text`

🤖 Generated with [Claude Code](https://claude.ai/code)