### PR TITLE
fix: recalculate embeddings respects requested type 

### DIFF
--- a/packages/workflow/src/system/recalculateEmbeddingsWorkflow.ts
+++ b/packages/workflow/src/system/recalculateEmbeddingsWorkflow.ts
@@ -21,7 +21,9 @@ export async function recalculateEmbeddingsWorkflow(payload: WorkflowExecutionPa
 
     const embeddings = [];
 
-    for (const type of Object.values(SupportedEmbeddingTypes)) {
+    const types = payload.vars?.type || Object.values(SupportedEmbeddingTypes);
+
+    for (const type of types) {
         embeddings.push(generateEmbeddings(payload, {
             force: true,
             type

--- a/packages/workflow/src/system/recalculateEmbeddingsWorkflow.ts
+++ b/packages/workflow/src/system/recalculateEmbeddingsWorkflow.ts
@@ -21,8 +21,8 @@ export async function recalculateEmbeddingsWorkflow(payload: WorkflowExecutionPa
 
     const embeddings = [];
     const payloadType = payload.vars?.type as SupportedEmbeddingTypes;
-    
-    if (!Object.values(SupportedEmbeddingTypes).includes(payloadType)) {
+
+    if (payloadType && !Object.values(SupportedEmbeddingTypes).includes(payloadType)) {
         throw new Error("Embedding type must be text, image, or properties");
     }
     const types = payloadType ? [payloadType] : Object.values(SupportedEmbeddingTypes);

--- a/packages/workflow/src/system/recalculateEmbeddingsWorkflow.ts
+++ b/packages/workflow/src/system/recalculateEmbeddingsWorkflow.ts
@@ -20,8 +20,12 @@ const {
 export async function recalculateEmbeddingsWorkflow(payload: WorkflowExecutionPayload) {
 
     const embeddings = [];
-
-    const types = payload.vars?.type || Object.values(SupportedEmbeddingTypes);
+    const payloadType = payload.vars?.type as SupportedEmbeddingTypes;
+    
+    if (!Object.values(SupportedEmbeddingTypes).includes(payloadType)) {
+        throw new Error("Embedding type must be text, image, or properties");
+    }
+    const types = payloadType ? [payloadType] : Object.values(SupportedEmbeddingTypes);
 
     for (const type of types) {
         embeddings.push(generateEmbeddings(payload, {


### PR DESCRIPTION
The recalculate embeddings workflow was going through all embedding types regardless of what was specified in the payload.

This significantly increases the traffic when re-embeddings, especially due to image embeddings triggering many generateRenditions