### PR TITLE
Feat; rename project_admin to manager

### DIFF
--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -10,7 +10,7 @@ export interface ICreateProjectPayload {
 export enum ProjectRoles {
     owner = "owner", // all permissions
     admin = "admin", // all permissions
-    project_admin = "project_admin", // all permissions but manage_account, manage_billing
+    manager = "manager", // all permissions but manage_account, manage_billing
     developer = "developer", // all permissions but manage_account, manage_billing, manage_roles, delete
     application = "application", // executor + request_pk
     consumer = "consumer", // required permissions for users of micro apps


### PR DESCRIPTION
## Description

After discussion, the `project_admin` is confusing with the `admin` role, therefore, the `project_admin` will be renamed to `manager` as the reference for the project manager