### PR TITLE
feat: add low priority processing queue support

### DIFF
--- a/packages/client/src/store/ObjectsApi.ts
+++ b/packages/client/src/store/ObjectsApi.ts
@@ -4,6 +4,7 @@ import {
     ComputeObjectFacetPayload,
     ContentObject,
     ContentObjectItem,
+    ContentObjectProcessingPriority,
     ContentSource,
     CreateContentObjectPayload,
     Embedding,
@@ -218,6 +219,7 @@ export class ObjectsApi extends ApiTopic {
         payload: UploadContentObjectPayload,
         options?: {
             collection_id?: string;
+            processing_priority?: ContentObjectProcessingPriority;
         },
     ): Promise<ContentObject> {
         const createPayload: CreateContentObjectPayload = {
@@ -281,6 +283,7 @@ export class ObjectsApi extends ApiTopic {
         options?: {
             createRevision?: boolean;
             revisionLabel?: string;
+            processing_priority?: ContentObjectProcessingPriority;
         },
     ): Promise<ContentObject> {
         const updatePayload: Partial<CreateContentObjectPayload> = {

--- a/packages/common/src/store/store.ts
+++ b/packages/common/src/store/store.ts
@@ -378,3 +378,8 @@ export interface GetFileUrlResponse {
     mime_type: string;
     path: string;
 }
+
+export enum ContentObjectProcessingPriority {
+    normal = "normal",
+    low = "low",
+}

--- a/packages/common/src/store/workflow.ts
+++ b/packages/common/src/store/workflow.ts
@@ -405,3 +405,5 @@ export interface Plan {
     plan: PlanTask[];
     comment?: string;
 }
+
+export const LOW_PRIORITY_TASK_QUEUE = "low_priority";


### PR DESCRIPTION
## Summary
- Add ContentObjectProcessingPriority enum to support normal and low priority processing
- Add processing_priority parameter to upload and update object methods
- Add LOW_PRIORITY_TASK_QUEUE constant for queue management

## Changes
- Added ContentObjectProcessingPriority enum in packages/common/src/store/store.ts
- Updated ObjectsApi to support processing_priority option in upload and update methods
- Added LOW_PRIORITY_TASK_QUEUE constant in workflow.ts

## Test plan
- [ ] Verify enum exports correctly
- [ ] Test upload with processing_priority parameter  
- [ ] Test update with processing_priority parameter
- [ ] Confirm LOW_PRIORITY_TASK_QUEUE constant is accessible

🤖 Generated with [Claude Code](https://claude.ai/code)