### PR TITLE
feat: add task_queue parameter to AsyncExecutionPayloadBase

### DIFF
--- a/packages/common/src/interaction.ts
+++ b/packages/common/src/interaction.ts
@@ -291,6 +291,8 @@ interface AsyncExecutionPayloadBase extends Omit<NamedInteractionExecutionPayloa
      * An array of endpoint URLs to be notified upon execution
      */
     notify_endpoints?: string[];
+
+    task_queue?: string;
 }
 
 export type ConversationVisibility = 'private' | 'project';


### PR DESCRIPTION
## Summary
- Add task_queue parameter to AsyncExecutionPayloadBase interface to support routing execution requests to specific task queues

## Changes
- Added optional task_queue parameter to AsyncExecutionPayloadBase interface in packages/common/src/interaction.ts

## Test plan
- [ ] Verify the interface change doesn't break existing functionality
- [ ] Test task queue parameter is properly passed through in execution requests

🤖 Generated with [Claude Code](https://claude.ai/code)