### PR TITLE
feat: Add API key support to access control system

### DIFF
--- a/packages/common/src/access-control.ts
+++ b/packages/common/src/access-control.ts
@@ -60,6 +60,7 @@ export enum AccessControlResourceType {
 export enum AccessControlPrincipalType {
     user = "user",
     group = "group",
+    apikey = "apikey",
 }
 
 


### PR DESCRIPTION
## Summary
- Add `apikey` to `AccessControlPrincipalType` enum to support API keys as principals in the access control system

## Changes Made
- **packages/common/src/access-control.ts**: Added `apikey` principal type to enable API key permissions in the access control system

## Test Plan
- [x] Build passes for common package
- [x] Type definitions are properly exported

🤖 Generated with [Claude Code](https://claude.ai/code)