### PR TITLE
feat: add workflow rate limiter activity

### DIFF
--- a/packages/workflow/src/activities/index-dsl.ts
+++ b/packages/workflow/src/activities/index-dsl.ts
@@ -18,3 +18,4 @@ export { transcribeMedia } from "./media/transcribeMediaWithGladia.js";
 export { notifyWebhook } from "./notifyWebhook.js";
 export { setDocumentStatus } from "./setDocumentStatus.js";
 export { identifyTextSections } from "./identifyTextSections.js";
+export { checkRateLimit } from "./rateLimiter.js";

--- a/packages/workflow/src/activities/rateLimiter.ts
+++ b/packages/workflow/src/activities/rateLimiter.ts
@@ -20,13 +20,24 @@ async function resolveEnvironmentId(
   }
 
   if (params.interactionId) {
-    try {
-      const { client } = await setupActivity(payload);
-      const interaction = await client.interactions.get(params.interactionId);
-      return interaction.default_environment_id || null;
-    } catch (error) {
-      log.warn('Failed to fetch interaction for environment resolution:', { error });
-      return null;
+    if (params.interactionId.includes(':')) {
+      try {
+        const { fetchProject } = await setupActivity(payload);
+        const project = await fetchProject();
+        return project?.configuration?.default_environment?.toString() || null;
+      } catch (error) {
+        log.warn('Failed to fetch project for environment resolution:', { error });
+        return null;
+      }
+    } else {
+      try {
+        const { client } = await setupActivity(payload);
+        const interaction = await client.interactions.get(params.interactionId);
+        return interaction.default_environment_id || null;
+      } catch (error) {
+        log.warn('Failed to fetch interaction for environment resolution:', { error });
+        return null;
+      }
     }
   }
 

--- a/packages/workflow/src/activities/rateLimiter.ts
+++ b/packages/workflow/src/activities/rateLimiter.ts
@@ -60,11 +60,11 @@ export async function checkRateLimit(payload: DSLActivityExecutionPayload<RateLi
       const info = activityInfo();
       const response = await client.post('/api/v1/execute/rate-limit/request', {
         payload: {
-          runId: info.workflowExecution.runId,
-          environmentId: environmentId
+          run_id: info.workflowExecution.runId,
+          environment_id: environmentId
         }
-      }) as { delayMs: number };
-      result.delayMs = response.delayMs;
+      }) as { delay_ms: number };
+      result.delayMs = response.delay_ms;
     } catch (error) {
       log.warn('Failed to call rate limit API:', {error});
     }

--- a/packages/workflow/src/activities/rateLimiter.ts
+++ b/packages/workflow/src/activities/rateLimiter.ts
@@ -1,0 +1,86 @@
+import { DSLActivityExecutionPayload } from "@vertesia/common";
+import { activityInfo, log } from "@temporalio/activity";
+
+export interface RateLimitParams {
+  // just for the activity catalog to not break the build
+}
+
+export interface RateLimitResult {
+  delayMs: number;
+}
+
+export async function checkRateLimit(payload: DSLActivityExecutionPayload<RateLimitParams>): Promise<RateLimitResult> {
+  // Get the store URL from config, fallback to environment variable
+  const storeUrl = payload.config?.store_url || process.env.STORE_URL;
+
+  if (!storeUrl) {
+    log.warn('No store URL available for rate limit API');
+    // If no store URL is available, allow the request without delay
+    return {
+      delayMs: 0,
+    };
+  }
+
+  const info = activityInfo();
+  
+  try {
+    // Call the zeno-server endpoint to get rate limit delay
+    const response = await fetch(`${storeUrl}/api/v1/workflows/rate-limit/request`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${payload.auth_token}`
+      },
+      body: JSON.stringify({
+        workflowId: info.workflowExecution.workflowId,
+        runId: info.workflowExecution.runId
+      })
+    });
+
+    if (!response.ok) {
+      log.warn(`Rate limit API returned ${response.status}: ${response.statusText}`);
+      // If API fails, allow the request without delay
+      return {
+        delayMs: 0
+      };
+    }
+
+    const result = await response.json() as { delayMs: number };
+
+    return {
+      delayMs: result.delayMs
+    };
+  } catch (error) {
+    log.warn('Failed to call rate limit API:', {error});
+    // If API call fails, allow the request without delay
+    return {
+      delayMs: 0
+    };
+  }
+}
+
+export async function recordComplete(payload: DSLActivityExecutionPayload<RateLimitParams>): Promise<void> {
+
+  // Get the store URL from config, fallback to environment variable
+  const storeUrl = payload.config?.store_url || process.env.STORE_URL;
+
+  try {
+    // Call the zeno-server endpoint to record workflow completion
+    const response = await fetch(`${storeUrl}/api/v1/workflows/rate-limit/complete`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${payload.auth_token}`
+      }
+    });
+
+    if (!response.ok) {
+      log.warn(`Rate limit API returned ${response.status}: ${response.statusText}`);
+      // If API fails, just return success
+    }
+  } catch (error) {
+    log.warn('Failed to call rate limit API:', {error});
+    // If API call fails, just return success
+    return;
+  }
+}

--- a/packages/workflow/src/dsl/dsl-workflow.ts
+++ b/packages/workflow/src/dsl/dsl-workflow.ts
@@ -7,6 +7,7 @@ import {
     log,
     patched,
     proxyActivities,
+    sleep,
     startChild,
     UntypedActivities,
 } from "@temporalio/workflow";
@@ -25,6 +26,7 @@ import { HandleDslErrorParams } from "../activities/handleError.js";
 import * as activities from "../activities/index.js";
 import { WF_NON_RETRYABLE_ERRORS, WorkflowParamNotFoundError } from "../errors.js";
 import { Vars } from "./vars.js";
+import { RateLimitParams } from "../activities/rateLimiter.js";
 
 interface BaseActivityPayload extends WorkflowExecutionPayload {
     workflow_name: string;
@@ -218,6 +220,45 @@ async function executeChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWork
     }
 }
 
+function buildRateLimitParams(activity: DSLActivitySpec, importParams: Record<string, any>): RateLimitParams {
+    const rateLimitParams: RateLimitParams = {};
+
+    switch (activity.name) {
+        case "executeInteraction":
+            rateLimitParams.interactionId = importParams.interactionName || activity.params?.interactionName;
+            rateLimitParams.environmentId = importParams.environment || activity.params?.environment;
+            break;
+        
+        case "generateDocumentProperties":
+            rateLimitParams.interactionId = importParams.interactionName || activity.params?.interactionName || "sys:ExtractInformation";
+            rateLimitParams.environmentId = importParams.environment || activity.params?.environment;
+            break;
+            
+        case "identifyTextSections": 
+            rateLimitParams.interactionId = importParams.interactionName || activity.params?.interactionName || "sys:IdentifyTextSections";
+            rateLimitParams.environmentId = importParams.environment || activity.params?.environment;
+            break;
+            
+        case "generateOrAssignContentType":
+            rateLimitParams.interactionId = importParams.interactionNames?.selectDocumentType || activity.params?.interactionNames?.selectDocumentType || "sys:SelectDocumentType";
+            rateLimitParams.environmentId = importParams.environment || activity.params?.environment;
+            break;
+            
+        case "chunkDocument":
+            rateLimitParams.interactionId = importParams.interactionName || activity.params?.interactionName || "sys:ChunkDocument";
+            rateLimitParams.environmentId = importParams.environment || activity.params?.environment;
+            break;
+        
+        default:
+            // For any other rate-limited activities, try to extract what we can
+            rateLimitParams.interactionId = importParams.interactionName || activity.params?.interactionName;
+            rateLimitParams.environmentId = importParams.environment || activity.params?.environment;
+            break;
+    }
+
+    return rateLimitParams;
+}
+
 async function runActivity(activity: DSLActivitySpec, basePayload: BaseActivityPayload, vars: Vars, defaultProxy: ActivityInterfaceFor<UntypedActivities>, defaultOptions: ActivityOptions) {
     if (basePayload.debug_mode) {
         log.debug(`Workflow vars before executing activity ${activity.name}`, { vars: vars.resolve() });
@@ -243,6 +284,26 @@ async function runActivity(activity: DSLActivitySpec, basePayload: BaseActivityP
             activityName: activity.name,
             activityOptions: defaultOptions,
         });
+    }
+
+    // call rate limiter depending on the activity type
+    const rateLimitedActivities = ["generateDocumentProperties","executeInteraction","identifyTextSections", "generateOrAssignContentType", "chunkDocument"];
+    if (activity.name && rateLimitedActivities.includes(activity.name)) {
+        log.info(`Applying rate limit for activity ${activity.name}`);
+        // Apply rate limiting logic here
+         // Check rate limit first - loop until no delay
+        const rateLimitParams = buildRateLimitParams(activity, importParams);
+
+        const rateLimitPayload = dslActivityPayload(basePayload, activity, rateLimitParams);
+        let rateLimitResult = await defaultProxy.checkRateLimit(rateLimitPayload);
+    
+        while (rateLimitResult.delayMs > 0) {
+            log.info(`Rate limit delay applied: ${rateLimitResult.delayMs}ms`);
+            await sleep(rateLimitResult.delayMs);
+            
+            // Check again after sleeping
+            rateLimitResult = await defaultProxy.checkRateLimit(rateLimitPayload);
+        }
     }
 
     const fn = proxy[activity.name];

--- a/packages/workflow/src/dsl/dsl-workflow.ts
+++ b/packages/workflow/src/dsl/dsl-workflow.ts
@@ -220,39 +220,40 @@ async function executeChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWork
     }
 }
 
-function buildRateLimitParams(activity: DSLActivitySpec, importParams: Record<string, any>): RateLimitParams {
+function buildRateLimitParams(activity: DSLActivitySpec, executionPayload: DSLActivityExecutionPayload<any>): RateLimitParams {
     const rateLimitParams: RateLimitParams = {};
+    const params = executionPayload.params;
 
     switch (activity.name) {
         case "executeInteraction":
-            rateLimitParams.interactionId = importParams.interactionName || activity.params?.interactionName;
-            rateLimitParams.environmentId = importParams.environment || activity.params?.environment;
+            rateLimitParams.interactionId = params.interactionName;
+            rateLimitParams.environmentId = params.environment;
             break;
         
         case "generateDocumentProperties":
-            rateLimitParams.interactionId = importParams.interactionName || activity.params?.interactionName || "sys:ExtractInformation";
-            rateLimitParams.environmentId = importParams.environment || activity.params?.environment;
+            rateLimitParams.interactionId = params.interactionName || "sys:ExtractInformation";
+            rateLimitParams.environmentId = params.environment;
             break;
             
         case "identifyTextSections": 
-            rateLimitParams.interactionId = importParams.interactionName || activity.params?.interactionName || "sys:IdentifyTextSections";
-            rateLimitParams.environmentId = importParams.environment || activity.params?.environment;
+            rateLimitParams.interactionId = params.interactionName || "sys:IdentifyTextSections";
+            rateLimitParams.environmentId = params.environment;
             break;
             
         case "generateOrAssignContentType":
-            rateLimitParams.interactionId = importParams.interactionNames?.selectDocumentType || activity.params?.interactionNames?.selectDocumentType || "sys:SelectDocumentType";
-            rateLimitParams.environmentId = importParams.environment || activity.params?.environment;
+            rateLimitParams.interactionId = params.interactionNames?.selectDocumentType || "sys:SelectDocumentType";
+            rateLimitParams.environmentId = params.environment;
             break;
             
         case "chunkDocument":
-            rateLimitParams.interactionId = importParams.interactionName || activity.params?.interactionName || "sys:ChunkDocument";
-            rateLimitParams.environmentId = importParams.environment || activity.params?.environment;
+            rateLimitParams.interactionId = params.interactionName || "sys:ChunkDocument";
+            rateLimitParams.environmentId = params.environment;
             break;
         
         default:
             // For any other rate-limited activities, try to extract what we can
-            rateLimitParams.interactionId = importParams.interactionName || activity.params?.interactionName;
-            rateLimitParams.environmentId = importParams.environment || activity.params?.environment;
+            rateLimitParams.interactionId = params.interactionName;
+            rateLimitParams.environmentId = params.environment;
             break;
     }
 
@@ -292,7 +293,7 @@ async function runActivity(activity: DSLActivitySpec, basePayload: BaseActivityP
         log.info(`Applying rate limit for activity ${activity.name}`);
         // Apply rate limiting logic here
          // Check rate limit first - loop until no delay
-        const rateLimitParams = buildRateLimitParams(activity, importParams);
+        const rateLimitParams = buildRateLimitParams(activity, executionPayload);
 
         const rateLimitPayload = dslActivityPayload(basePayload, activity, rateLimitParams);
         let rateLimitResult = await defaultProxy.checkRateLimit(rateLimitPayload);


### PR DESCRIPTION
## Summary
- Add rate limiter activity for workflow execution control
- Integrate with studio-server rate limiting system via API call
- Support environment-based rate limiting in DSL workflows

## Changes
- Added `rateLimiter.ts` activity that calls `/api/v1/execute/rate-limit/request`
- Exported `checkRateLimit` function in activities index
- Added rate limiter integration to DSL workflow execution with delay loop
- Support for environment resolution via `environmentId` or `interactionId` parameters

## Parameters
- `environmentId` (optional): Target environment ID for rate limiting
- `interactionId` (optional): Interaction ID to resolve environment from

## Test plan
- [x] Rate limiter activity correctly calls API endpoint
- [x] Environment resolution works for both direct ID and interaction-based lookup  
- [x] Workflow execution properly waits during rate limit delays

🤖 Generated with [Claude Code](https://claude.ai/code)