### PR TITLE
fix: use -strip when making renditions

### DIFF
--- a/packages/workflow/src/conversion/image.ts
+++ b/packages/workflow/src/conversion/image.ts
@@ -78,6 +78,12 @@ export async function imageResizer(
         const command = `convert`
         let args = [inputPath];
 
+        // Add JPEG shrink-on-load optimization
+        args.push("-define", `jpeg:size=${max_hw * 3}x${max_hw * 3}`);
+
+        // Remove metadata
+        args.push("-strip");
+
         // https://usage.imagemagick.org/filter/nicolas/#downsample
         // Add colorspace correction if enabled
         if (colorspaceCorrection) {
@@ -109,9 +115,6 @@ export async function imageResizer(
                     break;
             }
         }
-
-        // Add JPEG shrink-on-load optimization
-        args.push("-define", `jpeg:size=${max_hw * 3}x${max_hw * 3}`);
 
         // Resize operation
         args.push("-resize", `${max_hw}x${max_hw}>`);


### PR DESCRIPTION
Also move -strip and the jpeg loading optimisation to the top of the convert command, in case it has an effect on memory usage of the colorspace command.