### PR TITLE
Feat: add run id as query option

### DIFF
--- a/packages/common/src/query.ts
+++ b/packages/common/src/query.ts
@@ -86,7 +86,8 @@ export interface RunSearchQuery extends SimpleSearchQuery {
     end?: string;
     finish_reason?: string;
     created_by?: string;
-    workflow_run_ids?: string[];
+    workflow_run_ids?: string[] | string;
+    run_ids?: string[] | string;
 }
 
 export interface WorkflowExecutionSearchQuery extends SimpleSearchQuery {

--- a/packages/ui/src/features/facets/RunsFacetsNav.tsx
+++ b/packages/ui/src/features/facets/RunsFacetsNav.tsx
@@ -24,6 +24,14 @@ interface RunsFacetsNavProps {
 export function useRunsFilterGroups(facets: RunsFacetsNavProps['facets']): FilterGroup[] {
     const customFilterGroups: FilterGroup[] = [];
 
+    const runIdFilterGroup = {
+        name: 'run_ids',
+        placeholder: 'Run ID',
+        type: 'text' as const,
+        multiple: false
+    };
+    customFilterGroups.push(runIdFilterGroup);
+
     if (facets.interactions) {
         const interactionFilterGroup = VInteractionFacet({
             buckets: facets.interactions || [],
@@ -107,6 +115,14 @@ export function useRunsFilterGroups(facets: RunsFacetsNavProps['facets']): Filte
         multiple: false
     };
     customFilterGroups.push(dateBeforeFilterGroup);
+
+    const workflowRunIdFilterGroup = {
+        name: 'workflow_run_ids',
+        placeholder: 'Workflow Run ID',
+        type: 'text' as const,
+        multiple: false
+    };
+    customFilterGroups.push(workflowRunIdFilterGroup);
 
     return customFilterGroups;
 }


### PR DESCRIPTION
in runs serach, 
- Add `run_ids` as search query option, it can take `string | string[]`
- Update `workflow_run_ids` to take `string | string[]`