### PR TITLE
fix: url handling for array format

### DIFF
--- a/packages/ui/src/features/facets/DocumentsFacetsNav.tsx
+++ b/packages/ui/src/features/facets/DocumentsFacetsNav.tsx
@@ -124,9 +124,12 @@ export function useDocumentFilterHandler(search: SearchInterface) {
                         }
                     }
                 } else if (filter.multiple) {
-                    filterValue = Array.isArray(filter.value)
-                        ? filter.value.map((v: any) => typeof v === 'object' && v.value ? v.value : v)
-                        : [typeof filter.value === 'object' && (filter.value as any).value ? (filter.value as any).value : filter.value];
+                    if (Array.isArray(filter.value)) {
+                        filterValue = filter.value.map((v: any) => typeof v === 'object' && v.value ? v.value : v);
+                    } else {
+                        const singleValue = typeof filter.value === 'object' && (filter.value as any).value ? (filter.value as any).value : filter.value;
+                        filterValue = [singleValue];
+                    }
                 } else {
                     // Single value - don't wrap in array
                     filterValue = Array.isArray(filter.value) && filter.value[0] && typeof filter.value[0] === 'object'

--- a/packages/ui/src/features/facets/utils/VTypeFacet.tsx
+++ b/packages/ui/src/features/facets/utils/VTypeFacet.tsx
@@ -33,10 +33,13 @@ export function VTypeFacet({ buckets, typeRegistry, type = 'select', multiple = 
     });
 
     const options = buckets.map((bucket) => {
-        const typeId = bucket._id || "Document";
+        const actualId = bucket._id;
+        const displayKey = actualId || "Document";
+        const typeData = typeDataMap.get(displayKey);
+        
         return {
-            value: typeId,
-            label: `(${bucket.count})`
+            value: actualId,
+            label: typeData ? `${typeData.name} (${typeData.count})` : `Unknown (${bucket.count})`
         };
     });
 


### PR DESCRIPTION
## Description
- Current filter stores the value in the URL, to keep the filter while navigating, and there is an error if an object type filter is applied.
- The cause is coming from the URL decoding. If there is only one value for types, it would be treated as a string, but the backend is expecting an array
- The fix is to keep the bracket in the URL, so when decoding from the URL, it would still apply the corresponding format