### PR TITLE
fix: facet response total, use total: number

### DIFF
--- a/packages/client/src/store/ObjectsApi.ts
+++ b/packages/client/src/store/ObjectsApi.ts
@@ -49,7 +49,7 @@ export interface ComputeFacetsResponse {
     type?: { _id: string; count: number }[];
     location?: { _id: string; count: number }[];
     status?: { _id: string; count: number }[];
-    total?: { count: number }[];
+    total?: number;
 }
 
 export interface SearchResponse {


### PR DESCRIPTION
The existing ComputeFacetResponse.total is `total?: { count: number }[];`

However this is not actually respected we use `total: number`.

Changing the type to reflect this.