### PR TITLE
Feat: add loading status view for thumbnail

### DIFF
--- a/packages/ui/src/core/components/table/index.tsx
+++ b/packages/ui/src/core/components/table/index.tsx
@@ -23,7 +23,7 @@ export function RowSkeleton({ columns }: { columns: number }) {
         <tr className="hover:bg-muted">
             {Array(columns).fill(0).map((_, index) =>
                 <td key={index}>
-                    <div className="animate-pulse rounded-xs h-5 bg-gray-200 dark:bg-gray-600"></div>
+                    <div className="animate-pulse rounded-xs h-5 bg-muted"></div>
                 </td>
             )}
         </tr>

--- a/packages/ui/src/features/store/objects/components/DocumentIcon.tsx
+++ b/packages/ui/src/features/store/objects/components/DocumentIcon.tsx
@@ -15,6 +15,36 @@ interface DocumentIconProps {
     selection: DocumentSelection;
     onRowClick?: (object: ContentObjectItem) => void;
 }
+
+export function DocumentIconSkeleton({ isLoading = false, counts = 6 }: { isLoading?: boolean, counts?: number }) {
+    if (!isLoading) {
+        return null
+    }
+    return (
+        <div className='flex flex-wrap gap-2 justify-between'>
+            {Array(counts).fill(0).map((_, index) =>
+                <div key={index} className="w-[15vw] animate-pulse">
+                    <Card className="relative flex flex-col border h-fit">
+                        <div className="h-48 bg-muted rounded-t-xl flex items-center justify-center text-muted">
+                            &nbsp;
+                        </div>
+                        <Separator className='bg-muted h-[2px]' />
+                        <CardContent className="p-2 flex flex-col">
+                            <div className="flex flex-col overflow-hidden">
+                                <div className="h-5 bg-muted rounded w-3/4 mb-2"></div>
+                                <div className="h-4 bg-muted rounded w-1/2"></div>
+                            </div>
+                            <div className="text-xs text-muted w-full flex justify-end mt-2">
+                                <div className="h-3 bg-muted rounded w-1/4"></div>
+                            </div>
+                        </CardContent>
+                    </Card>
+                </div>
+            )}
+        </div>
+    )
+}
+
 export function DocumentIcon({ selection, document, onSelectionChange, onRowClick }: Readonly<DocumentIconProps>) {
     const { client } = useUserSession()
 
@@ -95,7 +125,7 @@ export function DocumentIcon({ selection, document, onSelectionChange, onRowClic
                     }
                 </div>
                 {document.score && (
-                    <div className="text-xs text-muted w-full flex justify-end">    
+                    <div className="text-xs text-muted w-full flex justify-end">
                         Score: {(document.score).toFixed(4) ?? "-"}
                     </div>
                 )}

--- a/packages/ui/src/features/store/objects/layout/documentLayout.tsx
+++ b/packages/ui/src/features/store/objects/layout/documentLayout.tsx
@@ -1,8 +1,7 @@
-import { Table, TBody, Spinner } from "@vertesia/ui/core";
+import { Table, TBody } from "@vertesia/ui/core";
 import { ContentObjectItem, ColumnLayout } from "@vertesia/common";
-import clsx from "clsx";
 import { ChangeEvent } from "react";
-import { DocumentIcon } from "../components/DocumentIcon";
+import { DocumentIcon, DocumentIconSkeleton } from "../components/DocumentIcon";
 import { DocumentSelection } from "../DocumentSelectionProvider";
 import { DocumentTableColumn } from "./DocumentTableColumn";
 
@@ -53,12 +52,9 @@ export function DocumentTableView({ objects, selection, isLoading, onRowClick, c
 }
 
 export function DocumentGridView({ objects, selection, isLoading, onSelectionChange, onRowClick }: ViewProps) {
-
     return (
         <>
-            <div className={clsx("bg-white opacity-40 absolute inset-0 z-50 flex justify-center items-center", isLoading ? "block" : "hidden")}>
-                <Spinner size='xl' />
-            </div>
+            <DocumentIconSkeleton isLoading={isLoading} />
             <div className="w-full gap-2 grid lg:grid-cols-6">
                 {objects.map((document) => (
                     <DocumentIcon key={document.id} document={document} selection={selection} onSelectionChange={onSelectionChange} onRowClick={onRowClick} />


### PR DESCRIPTION
## Description 
Add loading status view for thumbnail, to prevent double spinner view

<img width="1512" height="982" alt="Screenshot 2025-09-17 at 14 25 29" src="https://github.com/user-attachments/assets/20b73518-6b8d-44c1-ba59-f4d726612636" />

## Screenshot
<img width="1512" height="982" alt="Screenshot 2025-09-17 at 14 20 50" src="https://github.com/user-attachments/assets/96aa6f17-e159-461c-9962-6fab202d4d20" />
