### PR TITLE
fix: optimize embeddings status API by removing unused count queries

### DIFF
--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -142,9 +142,7 @@ export interface EmbeddingsStatusResponse {
     status: string;
     embeddingRunsInProgress: number;
     totalRunsInProgress: number;
-    totalIndexableObjects: number;
     embeddingsModels: string[];
-    objectsWithEmbeddings: number;
     vectorIndex: {
         status: "READY" | "PENDING" | "DELETING" | "ABSENT",
         name?: string,


### PR DESCRIPTION
## Summary
- Remove totalIndexableObjects and objectsWithEmbeddings from EmbeddingsStatusResponse
- These fields were causing expensive MongoDB collection scans (4.2M+ documents)
- UI does not display these counts, only uses vectorIndex.status

## Changes
- Updated EmbeddingsStatusResponse interface in packages/common/src/project.ts
- Removed unused fields from API response

## Performance Impact
- Eliminates 2 expensive countDocuments() queries per status check
- No breaking changes to UI - fields were not being used

## Related
Part of query performance optimization work. Paired with studio repo changes to remove the backend queries.

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>