### PR TITLE
feat: publish dev packages on main

### DIFF
--- a/.github/workflows/publish-npm-dev.yaml
+++ b/.github/workflows/publish-npm-dev.yaml
@@ -17,7 +17,7 @@ jobs:
           node-version: 22
           cache: "pnpm"
       - run: pnpm install
-      - name: Change version
+      - name: Publish packages to NPM
         run: |
           set +x
           current_version=$(pnpm pkg get version | tr -d '"')

--- a/.github/workflows/publish-npm-dev.yaml
+++ b/.github/workflows/publish-npm-dev.yaml
@@ -1,0 +1,28 @@
+name: publish-npm-dev-packages
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+      - run: pnpm install
+      - name: Change version
+        run: |
+          set +x
+          CURRENT_VERSION=$(pnpm pkg get version | tr -d '"')
+          DEV_VERSION="${CURRENT_VERSION}-dev-${GITHUB_SHA::7}"
+          pnpm version ${DEV_VERSION} --recursive --no-git-tag-version
+          pnpm publish --recursive --tag dev
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-npm-dev.yaml
+++ b/.github/workflows/publish-npm-dev.yaml
@@ -20,9 +20,9 @@ jobs:
       - name: Change version
         run: |
           set +x
-          CURRENT_VERSION=$(pnpm pkg get version | tr -d '"')
-          DEV_VERSION="${CURRENT_VERSION}-dev-${GITHUB_SHA::7}"
-          pnpm version ${DEV_VERSION} --recursive --no-git-tag-version
-          pnpm publish --recursive --tag dev
+          current_version=$(pnpm pkg get version | tr -d '"')
+          dev_version="${current_version}-dev-${GITHUB_SHA::7}"
+          pnpm -r --filter "./packages/*" exec npm version ${dev_version} --no-git-tag-version
+          pnpm -r --filter "./packages/*" exec npm publish --tag dev
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-npm-dev.yaml
+++ b/.github/workflows/publish-npm-dev.yaml
@@ -3,6 +3,9 @@ name: publish-npm-dev-packages
 on:
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-npm-dev.yaml
+++ b/.github/workflows/publish-npm-dev.yaml
@@ -23,6 +23,6 @@ jobs:
           current_version=$(pnpm pkg get version | tr -d '"')
           dev_version="${current_version}-dev-${GITHUB_SHA::7}"
           pnpm -r --filter "./packages/*" exec npm version ${dev_version} --no-git-tag-version
-          pnpm -r --filter "./packages/*" exec npm publish --tag dev
+          pnpm -r --filter "./packages/*" exec npm publish --access public --tag dev
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-npm-dev.yaml
+++ b/.github/workflows/publish-npm-dev.yaml
@@ -1,7 +1,8 @@
 name: publish-npm-dev-packages
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs: {}
 
 permissions:
   contents: read

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
         "release": "pnpm -r publish --access public",
         "build": "pnpm -r build",
         "test": "pnpm -r test",
-        "clean": "rimraf ./node_modules && pnpm -r clean"
+        "clean": "rimraf ./node_modules && pnpm -r clean",
+        "prepublishOnly": "pnpm build"
     },
     "devDependencies": {
         "eslint": "^9.32.0",


### PR DESCRIPTION
## Description

When merging a new commit to the `main` branch, we would like to create a snapshot (dev) version of all the packages to the NPM registry, which may facilitate the development of our users. For example, if someone wants to develop a Vertesia Plugin. Right now, they have to use the release version, which is 0.78.0, released one month ago. With the new mechanism, users can use the latest version.

## Testing

I ran the script locally and published a new dev version for the memory pack:

<img width="779" height="480" alt="image" src="https://github.com/user-attachments/assets/4797f8e9-d005-4a37-8710-0b268960b537" />
