### PR TITLE
feat: enhance CLI with STS authentication and improved configuration

### DIFF
--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -4,24 +4,49 @@ import { config, Profile } from "./profiles/index.js";
 
 
 let _client: VertesiaClient | undefined;
-//TODO remove program?
-export function getClient(_program?: Command) {
-    //TODO use program -p option to get the profile?
+
+export function getClient(program?: Command) {
     if (!_client) {
-        _client = createClient(config.current);
+        _client = createClient(config.current, program);
     }
     return _client;
 }
 
-function createClient(profile: Profile | undefined) {
-    const env = {
-        apikey: profile?.apikey || process.env.COMPOSABLE_PROMPTS_APIKEY,
-        serverUrl: profile?.studio_server_url || process.env.COMPOSABLE_PROMPTS_SERVER_URL!,
-        storeUrl: profile?.zeno_server_url || process.env.ZENO_SERVER_URL!,
-        projectId: profile?.project || process.env.COMPOSABLE_PROMPTS_PROJECT_ID || undefined,
-        sessionTags: profile?.session_tags ? profile.session_tags.split(/\s*,\s*/) : 'cli',
+function createClient(profile: Profile | undefined, program?: Command) {
+    // Get options from CLI flags (highest priority), then profile, then environment variables
+    const opts = program?.opts() || {};
+
+    const apikey = opts.apikey || profile?.apikey || process.env.COMPOSABLE_PROMPTS_APIKEY;
+    const studioUrl = opts.studioUrl || profile?.studio_server_url || process.env.COMPOSABLE_PROMPTS_SERVER_URL;
+    const storeUrl = opts.storeUrl || profile?.zeno_server_url || process.env.ZENO_SERVER_URL;
+    const stsUrl = opts.stsUrl || profile?.sts_server_url || process.env.STS_SERVER_URL;
+    const site = opts.site || process.env.VERTESIA_SITE;
+    const sessionTags = profile?.session_tags ? profile.session_tags.split(/\s*,\s*/) : 'cli';
+
+    // Ensure we have either site or studioUrl to avoid client initialization error
+    if (!studioUrl && !site) {
+        throw new Error(
+            "No server configuration found. Please set up a profile with 'vertesia profiles add', " +
+            "use --site or --studio-url options, or set COMPOSABLE_PROMPTS_SERVER_URL environment variable."
+        );
     }
 
-    return new VertesiaClient(env)
+    const env: any = {
+        apikey,
+        sessionTags,
+    };
 
+    if (studioUrl) {
+        env.serverUrl = studioUrl;
+        if (storeUrl) {
+            env.storeUrl = storeUrl;
+        }
+        if (stsUrl) {
+            env.stsUrl = stsUrl;
+        }
+    } else if (site) {
+        env.site = site;
+    }
+
+    return new VertesiaClient(env);
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -20,6 +20,14 @@ const program = new Command();
 
 program.version(getVersion());
 
+// Global options for API configuration
+program
+    .option('--site <site>', 'Vertesia site (e.g., api.vertesia.io, api-preview.vertesia.io, api-staging.vertesia.io)')
+    .option('--studio-url <url>', 'Custom Studio server URL (overrides site)')
+    .option('--store-url <url>', 'Custom Store server URL (overrides site)')
+    .option('--sts-url <url>', 'Custom STS (Security Token Service) server URL (overrides site)')
+    .option('--apikey <key>', 'API key for authentication');
+
 program.command("upgrade")
     .description("Upgrade to the latest version of the CLI")
     .option("-y, --yes", "Skip the confirmation prompt")

--- a/packages/cli/src/profiles/commands.ts
+++ b/packages/cli/src/profiles/commands.ts
@@ -134,10 +134,7 @@ export async function createProfile(name?: string, options: CreateProfileOptions
     }
 
     if (options.apikey) {
-        if (!options.account || !options.project) {
-            console.error("When using --apikey you must provide the project and account IDs");
-            process.exit(1);
-        }
+        // Account and project are optional - the VertesiaClient will extract them from the API key automatically
         config.add({
             account: options.account,
             project: options.project,

--- a/packages/cli/src/profiles/index.ts
+++ b/packages/cli/src/profiles/index.ts
@@ -35,23 +35,42 @@ export function getConfigUrl(value: ConfigUrlRef) {
     }
 }
 const getServiceUrl = (service: string, env: string) => `https://${service}-server-${env}.api.vertesia.io`;
+const getStsUrl = (env: string) => {
+    if (env === "prod" || env === "production") {
+        return "https://sts.vertesia.io";
+    } else if (env === "preview") {
+        return "https://sts-preview.vertesia.io";
+    } else {
+        // staging and all other environments
+        return "https://sts-staging.vertesia.io";
+    }
+};
+
 export function getServerUrls(value: ConfigUrlRef) {
     switch (value) {
         case "local":
             return {
                 studio_server_url: "http://localhost:8091",
                 zeno_server_url: "http://localhost:8092",
+                sts_server_url: "https://sts-staging.vertesia.io",
             };
         case "staging":
+            return {
+                studio_server_url: getServiceUrl("studio", value),
+                zeno_server_url: getServiceUrl("zeno", value),
+                sts_server_url: getStsUrl("staging"),
+            };
         case "preview":
             return {
                 studio_server_url: getServiceUrl("studio", value),
                 zeno_server_url: getServiceUrl("zeno", value),
+                sts_server_url: getStsUrl("preview"),
             };
         case "prod":
             return {
                 studio_server_url: getServiceUrl("studio", "production"),
                 zeno_server_url: getServiceUrl("zeno", "production"),
+                sts_server_url: getStsUrl("prod"),
             };
         default:
             throw new Error("Unable to detect server urls from custom target.");
@@ -75,10 +94,11 @@ export interface Profile {
     name: string;
     config_url: string;
     apikey: string;
-    account: string;
-    project: string;
+    account?: string;
+    project?: string;
     studio_server_url: string;
     zeno_server_url: string;
+    sts_server_url: string;
     session_tags?: string;
 }
 


### PR DESCRIPTION
## Summary
- Add support for STS (Security Token Service) for API key authentication
- Add global CLI options for flexible server configuration
- Improve API key handling with auto-extraction of project/account IDs
- Fix authentication to use proper Authorization Bearer header with POST request

## Changes

### CLI Enhancements
- **Global Options**: Added `--site`, `--studio-url`, `--store-url`, `--sts-url`, `--apikey` options
- **Environment Variables**: Support `VERTESIA_SITE`, `STS_SERVER_URL` 
- **Simplified Auth**: Removed requirement for `--project` and `--account` when using `--apikey`

### STS Integration
- Added STS server URL configuration with proper environment-based URLs:
  - Production: `https://sts.vertesia.io`
  - Preview: `https://sts-preview.vertesia.io`
  - Staging: `https://sts-staging.vertesia.io` (default for branch environments)
- Updated `getAuthToken()` to use `/token/issue` endpoint
- Changed from GET with query params to POST with Authorization Bearer header

### Client Improvements
- Added `stsUrl` parameter to `VertesiaClientProps`
- Made `account` and `project` optional in Profile interface
- Improved error messages to include STS URL for debugging

## Test Plan
- [x] Build client and CLI packages successfully
- [x] Test with different site configurations
- [x] Verify Authorization Bearer header authentication
- [ ] Test with actual API keys in staging/preview/production environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)