### PR TITLE
Fix: refresh token after accept

### DIFF
--- a/packages/ui/src/shell/login/InviteAcceptModal.tsx
+++ b/packages/ui/src/shell/login/InviteAcceptModal.tsx
@@ -39,6 +39,7 @@ export function InviteAcceptModal() {
 
     const accept = async (invite: TransientToken<UserInviteTokenData>) => {
         await client.account.acceptInvite(invite.id);
+        await session.authCallback;
         await session.fetchAccounts();
         await session.fetchProjects(invite.data.account.id);
         const remainingInvites = invites.filter(i => i.id !== invite.id)


### PR DESCRIPTION
After a user accepts an account invitation via PUT /api/v1/account/invites/:id, the server updates the database (adds ACE entry) but does NOT issue a new JWT. The composable token (JWT) caches the user's account membership list (accounts[]) at issuance time — typically valid for ~1 hour.

When the UI immediately calls GET /api/v1/projects?account=<newAccountId>, the projects endpoint
First checks:
```
     if (accountId && !principal.accounts.some(account => account.id === accountId)) {
         ctx.throw(403, 'Access denied');
     }
```
principal. accounts come from the stale JWT, which doesn't include the newly accepted account → `403 Forbidden`. A page refresh works because it forces a full token re-issuance from STS.


