### PR TITLE
[codex] make CLI auth token script-safe

### DIFF
--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -1,6 +1,6 @@
 import { VertesiaClient } from "@vertesia/client";
 import { Command } from "commander";
-import { config, Profile } from "./profiles/index.js";
+import { config, getProfileToken, Profile } from "./profiles/index.js";
 
 
 let _client: VertesiaClient | undefined;
@@ -30,7 +30,7 @@ async function createClient(profile: Profile | undefined): Promise<VertesiaClien
     // Priority 2: Profile config or individual env vars
     // Support both new VERTESIA_* and legacy COMPOSABLE_PROMPTS_* env vars
     const env = {
-        apikey: profile?.apikey
+        apikey: getProfileToken(profile)
             || process.env.VERTESIA_APIKEY
             || process.env.COMPOSABLE_PROMPTS_APIKEY,
         serverUrl: profile?.studio_server_url

--- a/packages/cli/src/profiles/commands.ts
+++ b/packages/cli/src/profiles/commands.ts
@@ -1,7 +1,6 @@
 import colors from 'ansi-colors';
 import enquirer from "enquirer";
-import jwt from 'jsonwebtoken';
-import { AVAILABLE_REGIONS, DEFAULT_REGION, Region, config, getConfigUrl, getServerUrls, shouldRefreshProfileToken } from "./index.js";
+import { AVAILABLE_REGIONS, DEFAULT_REGION, Profile, Region, config, getConfigUrl, getProfileToken, getProfileTokenPayload, getServerUrls, shouldRefreshProfileToken } from "./index.js";
 import { ConfigResult } from './server/index.js';
 const { prompt } = enquirer;
 
@@ -42,13 +41,13 @@ export function showProfile(name?: string) {
         } else {
             console.log(JSON.stringify({
                 default: config.current?.name,
-                profiles: config.profiles,
+                profiles: config.profiles.map(profileForDisplay),
             }, undefined, 4));
         }
     } else {
         const profile = config.getProfile(name);
         if (profile) {
-            console.log(JSON.stringify(profile, undefined, 4));
+            console.log(JSON.stringify(profileForDisplay(profile), undefined, 4));
         } else {
             console.error(`Profile ${name} not found`);
         }
@@ -57,19 +56,29 @@ export function showProfile(name?: string) {
 
 export function showActiveAuthToken() {
     if (config.profiles.length === 0) {
-        console.log('No profiles are defined. Run `vertesia profiles create` to add a new profile.');
-        return;
+        console.error('No profiles are defined. Run `vertesia profiles create` to add a new profile.');
+        process.exit(1);
     } else if (config.current) {
-        const token = jwt.decode(config.current.apikey, { json: true });
-        if (token?.exp && token.exp * 1000 < Date.now()) {
-            console.log("Authentication token expired. Create a new one ");
-            _doRefreshToken(config.current.name);
-        } else {
-            console.log(config.current.apikey);
+        const rawToken = getProfileToken(config.current);
+        const token = getProfileTokenPayload(config.current);
+        if (!rawToken || !token?.exp) {
+            console.error("Authentication token is missing or invalid. Run `vertesia auth refresh` to renew it.");
+            process.exit(1);
         }
+        if (token.exp * 1000 < Date.now()) {
+            console.error("Authentication token expired. Run `vertesia auth refresh` to renew it.");
+            process.exit(1);
+        }
+        console.log(rawToken);
     } else {
-        console.log('No profile is selected. Run `vertesia auth refresh` to refresh the token');
+        console.error('No profile is selected. Run `vertesia profiles use <name>` to select one, or set VERTESIA_PROFILE.');
+        process.exit(1);
     }
+}
+
+function profileForDisplay(profile: Profile) {
+    const { apikey: _apikey, ...safeProfile } = profile;
+    return safeProfile;
 }
 
 

--- a/packages/cli/src/profiles/index.ts
+++ b/packages/cli/src/profiles/index.ts
@@ -1,8 +1,8 @@
-import { existsSync, mkdirSync, statSync } from "fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from "fs";
 import jwt from 'jsonwebtoken';
 import os from "node:os";
 import { join } from "path";
-import { readJsonFile, writeJsonFile } from "../utils/stdio.js";
+import { readJsonFile } from "../utils/stdio.js";
 import { ConfigPayload, ConfigResult, startConfigSession } from "./server/index.js";
 import { OnResultCallback } from "./commands.js";
 
@@ -88,7 +88,8 @@ export function getCloudTypeFromConfigUrl(url: string) {
 export interface Profile {
     name: string;
     config_url: string;
-    apikey: string;
+    apikey?: string;
+    token_ref?: string;
     account: string;
     project: string;
     studio_server_url: string;
@@ -103,12 +104,106 @@ interface ProfilesData {
     profiles: Profile[];
 }
 
-export function shouldRefreshProfileToken(profile: Profile, thresholdInSeconds = 1) {
-    if (profile.apikey) {
-        const token = jwt.decode(profile.apikey, { json: true });
-        if (token && token.exp) {
-            return (token.exp - thresholdInSeconds) * 1000 < Date.now();
+interface TokenData {
+    token: string;
+    created_at?: number;
+    expires_at?: number;
+}
+
+const ACTIVE_PROFILE_ENV_VAR = 'VERTESIA_PROFILE';
+const TOKENS_DIR = 'tokens';
+
+function ensurePrivateDir(dir: string) {
+    if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true, mode: 0o700 });
+    }
+    chmodSync(dir, 0o700);
+}
+
+function writePrivateJsonFile(file: string, data: object) {
+    const tmpFile = `${file}.${process.pid}.tmp`;
+    writeFileSync(tmpFile, JSON.stringify(data, null, 4), { encoding: 'utf8', mode: 0o600 });
+    chmodSync(tmpFile, 0o600);
+    renameSync(tmpFile, file);
+}
+
+function safeTokenFileName(profileName: string) {
+    return `${encodeURIComponent(profileName)}.json`;
+}
+
+function defaultTokenRef(profileName: string) {
+    return `${TOKENS_DIR}/${safeTokenFileName(profileName)}`;
+}
+
+function isSafeTokenRef(tokenRef: string | undefined) {
+    return !!tokenRef
+        && tokenRef.startsWith(`${TOKENS_DIR}/`)
+        && !tokenRef.startsWith('/')
+        && !tokenRef.split(/[\\/]/).includes('..');
+}
+
+function getProfileTokenRef(profile: Pick<Profile, 'name' | 'token_ref'>) {
+    return isSafeTokenRef(profile.token_ref) ? profile.token_ref! : defaultTokenRef(profile.name);
+}
+
+function getTokenFile(profile: Pick<Profile, 'name' | 'token_ref'>) {
+    return getConfigFile(getProfileTokenRef(profile));
+}
+
+function readTokenFile(profile: Profile): TokenData | undefined {
+    try {
+        return JSON.parse(readFileSync(getTokenFile(profile), 'utf8')) as TokenData;
+    } catch (err: any) {
+        if (err.code === 'ENOENT') {
+            return undefined;
         }
+        throw err;
+    }
+}
+
+function writeTokenFile(profile: Profile, token: string) {
+    const tokenDir = getConfigFile(TOKENS_DIR);
+    ensurePrivateDir(tokenDir);
+    const decoded = jwt.decode(token, { json: true });
+    writePrivateJsonFile(getTokenFile(profile), {
+        token,
+        created_at: Math.floor(Date.now() / 1000),
+        expires_at: decoded?.exp,
+    });
+}
+
+function removeTokenFile(profile: Profile) {
+    try {
+        unlinkSync(getTokenFile(profile));
+    } catch (err: any) {
+        if (err.code !== 'ENOENT') {
+            throw err;
+        }
+    }
+}
+
+export function getProfileToken(profile: Profile | undefined) {
+    if (!profile) {
+        return undefined;
+    }
+    if (profile.apikey) {
+        return profile.apikey;
+    }
+    return readTokenFile(profile)?.token;
+}
+
+export function getProfileTokenPayload(profile: Profile | undefined) {
+    const token = getProfileToken(profile);
+    if (!token) {
+        return undefined;
+    }
+    return jwt.decode(token, { json: true }) || undefined;
+}
+
+export function shouldRefreshProfileToken(profile: Profile, thresholdInSeconds = 1) {
+    const token = getProfileTokenPayload(profile);
+    if (token?.exp) {
+        return (token.exp - thresholdInSeconds) * 1000 < Date.now();
     }
     // if no token or no expiration set then refresh auth token
     return true;
@@ -143,6 +238,7 @@ export class ConfigureProfile {
         this.data.studio_server_url = result.studio_server_url;
         this.data.zeno_server_url = result.zeno_server_url;
         this.data.apikey = result.token;
+        this.data.token_ref = defaultTokenRef(result.profile);
         this.config.remove(oldName);
         this.config.add(this.data as Profile);
         if (this.isNew) {
@@ -230,6 +326,7 @@ export class Config {
     remove(name: string) {
         const i = this.profiles.findIndex(p => p.name === name);
         if (i > -1) {
+            removeTokenFile(this.profiles[i]);
             this.profiles.splice(i, 1);
             if (this.current?.name === name) {
                 this.current = undefined;
@@ -271,13 +368,20 @@ export class Config {
 
     save() {
         const dir = getConfigFile();
-        if (!existsSync(dir)) {
-            mkdirSync(dir, { recursive: true });
-        }
+        ensurePrivateDir(dir);
         const file = getConfigFile('profiles.json');
-        writeJsonFile(file, {
+        const profiles = this.profiles.map(profile => {
+            const token = profile.apikey;
+            const token_ref = getProfileTokenRef(profile);
+            if (token) {
+                writeTokenFile({ ...profile, token_ref }, token);
+            }
+            const { apikey: _apikey, ...storedProfile } = profile;
+            return { ...storedProfile, token_ref };
+        });
+        writePrivateJsonFile(file, {
             default: this.current?.name,
-            profiles: this.profiles,
+            profiles,
         });
         return this;
     }
@@ -295,9 +399,13 @@ export class Config {
         }
         try {
             const data = readJsonFile(getConfigFile('profiles.json')) as ProfilesData;
-            this.profiles = data.profiles;
-            if (data.default) {
-                this.use(data.default)
+            this.profiles = (data.profiles || []).map(profile => ({
+                ...profile,
+                token_ref: profile.token_ref || defaultTokenRef(profile.name),
+            }));
+            const selectedProfile = process.env[ACTIVE_PROFILE_ENV_VAR] || data.default;
+            if (selectedProfile) {
+                this.use(selectedProfile)
             } else {
                 this.current = undefined;
             }


### PR DESCRIPTION
## Summary

- Make `vertesia auth token` safe for command substitution by printing only a valid token or exiting nonzero with an error on stderr.
- Add `VERTESIA_PROFILE` support for selecting a profile without changing the saved default.
- Split token material out of `profiles.json` into private `~/.vertesia/tokens/<profile>.json` files, with backward compatibility for existing inline `apikey` profiles.
- Redact token material from `profiles show` output.

## Root Cause

When a stored CLI token was expired, `vertesia auth token` printed status text to stdout and entered the interactive browser-refresh flow. Inside `TOKEN="$(vertesia auth token)"`, stdout is captured and the parent shell waits for the child process, so users see an apparent hang before `curl --max-time` can run.

## Impact

Scripts can now safely use `TOKEN="$(vertesia auth token)"`: valid tokens are emitted to stdout; missing, malformed, or expired tokens fail fast and tell the user to run `vertesia auth refresh`.

## Validation

- `pnpm --prefix packages/cli build`
- Smoke-tested `auth token` with a temporary HOME: expired default profile exits `1`; `VERTESIA_PROFILE=valid` prints the selected token.