### PR TITLE
Fix: styling on radioGroup selected item

### DIFF
--- a/packages/ui/src/core/components/shadcn/radioGroup.tsx
+++ b/packages/ui/src/core/components/shadcn/radioGroup.tsx
@@ -52,7 +52,7 @@ function RadioGroup<T = RadioGroupOption>({ onSelect, selected, options, adapter
   const getId = (o: T) => adapter ? adapter.idOf(o) : (o as unknown as RadioGroupOption).id
   const getLabel = (o: T) => adapter ? adapter.labelOf(o) : (o as unknown as RadioGroupOption).label
   const getDescription = (o: T) => adapter ? adapter.descriptionOf(o) : (o as unknown as RadioGroupOption).description
-  const getSelectedClass = (o: T) => adapter ? adapter.selectedClassName(o) : 'border-accent-foreground'
+  const getSelectedClass = (o: T) => adapter ? adapter.selectedClassName(o) : 'border-primary'
 
   return (
     <RadioGroupPrimitive.Root


### PR DESCRIPTION
## Description

- Before
  - When the user selects a value, there is no visual indicator to show which one is being selected
 
- After
<img width="482" height="323" alt="Screenshot 2026-04-13 at 16 37 03" src="https://github.com/user-attachments/assets/273af1d7-79f2-497a-9818-e528fa1a5ed7" />
