### PR TITLE
Show restart action for completed agent runs

### DIFF
--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
@@ -759,7 +759,7 @@ function ModernAgentConversationInner({
         debugChunkFlash,
         addOptimisticMessage,
         removeOptimisticMessages,
-        workflowStatus,
+        agentRunStatus,
         workflowRunId,
         serverFileUpdates,
     } = useAgentStream(client, agentRunId);
@@ -822,13 +822,32 @@ function ModernAgentConversationInner({
     const hasProcessingFilesRef = useRef(hasProcessingFiles);
     hasProcessingFilesRef.current = hasProcessingFiles;
 
-    // Derive effective workflow status — only main workstream TERMINATED overrides API status.
-    const effectiveWorkflowStatus = useMemo(() => {
+    const lastMainMessage = useMemo(() => {
         const mainMessages = messages.filter(m => (m.workstream_id || 'main') === 'main');
-        const lastMain = mainMessages[mainMessages.length - 1];
-        if (lastMain?.type === AgentMessageType.TERMINATED) return "TERMINATED";
-        return workflowStatus;
-    }, [messages, workflowStatus]);
+        return mainMessages[mainMessages.length - 1];
+    }, [messages]);
+
+    // Derive effective status from AgentRun state; main workstream terminal events cover live-stream races.
+    const effectiveWorkflowStatus = useMemo(() => {
+        if (lastMainMessage?.type === AgentMessageType.TERMINATED) return "TERMINATED";
+        if (
+            lastMainMessage?.type === AgentMessageType.COMPLETE &&
+            (!agentRunStatus || agentRunStatus === "RUNNING")
+        ) {
+            return "COMPLETED";
+        }
+        return agentRunStatus;
+    }, [lastMainMessage, agentRunStatus]);
+
+    const isWorkflowTerminal = useMemo(() => {
+        const normalizedStatus = effectiveWorkflowStatus?.toUpperCase();
+        return normalizedStatus === "COMPLETED"
+            || normalizedStatus === "FAILED"
+            || normalizedStatus === "CANCELED"
+            || normalizedStatus === "CANCELLED"
+            || normalizedStatus === "TERMINATED"
+            || normalizedStatus === "TIMED_OUT";
+    }, [effectiveWorkflowStatus]);
 
     console.debug("[ModernAgentConversation] render", {
         agentRunId,
@@ -1385,6 +1404,7 @@ const handleCloseRightPanel = useCallback(() => {
                     <Header
                         title={actualTitle}
                         isCompleted={isCompleted}
+                        isTerminal={isWorkflowTerminal}
                         onClose={onClose}
                         isModal={isModal}
                         agentRunId={agentRunId}

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/Header.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/Header.tsx
@@ -62,6 +62,7 @@ export default function Header({
     className,
 }: HeaderProps) {
     const { t } = useUITranslation();
+    const restartWorkflow = useRestartWorkflow(agentRunId, onRestart);
     return (
         <PayloadBuilderProvider>
             <div className={cn("flex flex-wrap items-end justify-between py-1.5 px-2 border-b shadow-sm flex-shrink-0", className)}>
@@ -111,6 +112,19 @@ export default function Header({
                         </div>
                     )}
 
+                    {onRestart && isTerminal && (
+                        <Button
+                            size="sm"
+                            variant="secondary"
+                            onClick={restartWorkflow}
+                            className="transition-all duration-200 rounded-md"
+                            title={t('agent.restartConversation')}
+                        >
+                            <RefreshCcw className="size-4 mr-1.5" />
+                            <span className="font-medium text-xs">{t('agent.restartConversation')}</span>
+                        </Button>
+                    )}
+
                     {/* More actions */}
                     <MoreDropdown
                         agentRunId={agentRunId}
@@ -134,6 +148,30 @@ export default function Header({
             </div>
         </PayloadBuilderProvider>
     );
+}
+
+function useRestartWorkflow(agentRunId: string, onRestart?: (newRun: AgentRun) => void) {
+    const { t } = useUITranslation();
+    const toast = useToast();
+    const { client } = useUserSession();
+
+    return async () => {
+        try {
+            const newRun = await client.agents.restart(agentRunId);
+            toast({
+                status: "success",
+                title: t('agent.conversationRestarted'),
+                duration: 2000,
+            });
+            onRestart?.(newRun);
+        } catch (_error) {
+            toast({
+                status: "error",
+                title: t('agent.failedToRestartConversation'),
+                duration: 2000,
+            });
+        }
+    };
 }
 
 function MoreDropdown({
@@ -166,6 +204,7 @@ function MoreDropdown({
     const toast = useToast();
     const { client } = useUserSession();
     const builder = usePayloadBuilder();
+    const restartWorkflow = useRestartWorkflow(agentRunId, onRestart);
 
     const cancelWorkflow = async () => {
         try {
@@ -188,24 +227,6 @@ function MoreDropdown({
                 duration: 2000,
             });
             return false;
-        }
-    };
-
-    const restartWorkflow = async () => {
-        try {
-            const newRun = await client.agents.restart(agentRunId);
-            toast({
-                status: "success",
-                title: t('agent.conversationRestarted'),
-                duration: 2000,
-            });
-            onRestart?.(newRun);
-        } catch (_error) {
-            toast({
-                status: "error",
-                title: t('agent.failedToRestartConversation'),
-                duration: 2000,
-            });
         }
     };
 
@@ -305,9 +326,11 @@ function MoreDropdown({
                         <GitFork className="size-3.5 text-muted" /> {t('agent.forkConversation')}
                     </MenuItem>
                 )}
-                <MenuItem onClick={cancelWorkflow} variant="destructive">
-                    <XIcon className="size-3.5" /> {t('agent.cancelWorkflow')}
-                </MenuItem>
+                {!isTerminal && (
+                    <MenuItem onClick={cancelWorkflow} variant="destructive">
+                        <XIcon className="size-3.5" /> {t('agent.cancelWorkflow')}
+                    </MenuItem>
+                )}
             </MenuGroup>
         </Dropdown>
     );

--- a/packages/ui/src/features/agent/chat/hooks/useAgentStream.ts
+++ b/packages/ui/src/features/agent/chat/hooks/useAgentStream.ts
@@ -28,8 +28,8 @@ export interface UseAgentStreamResult {
     addOptimisticMessage: (msg: AgentMessage) => void;
     /** Remove optimistic messages matching a predicate */
     removeOptimisticMessages: (predicate: (msg: AgentMessage) => boolean) => void;
-    /** Workflow status fetched from API (RUNNING, COMPLETED, FAILED, etc.) */
-    workflowStatus: string | null;
+    /** AgentRun status fetched from API (RUNNING, COMPLETED, FAILED, etc.) */
+    agentRunStatus: string | null;
     /** Temporal workflow run ID (first_workflow_run_id from AgentRun) */
     workflowRunId: string | null;
     /** Server-side file processing status updates (from SYSTEM messages) */
@@ -57,7 +57,7 @@ export function useAgentStream(
 ): UseAgentStreamResult {
     const [messages, setMessages] = useState<AgentMessage[]>([]);
     const [isCompleted, setIsCompleted] = useState(false);
-    const [workflowStatus, setWorkflowStatus] = useState<string | null>(null);
+    const [agentRunStatus, setAgentRunStatus] = useState<string | null>(null);
     const [workflowRunId, setWorkflowRunId] = useState<string | null>(null);
 
     // Server-side file processing status updates
@@ -106,7 +106,7 @@ export function useAgentStream(
         // Reset all state when agentRunId changes (new agent)
         console.debug('[useAgentStream] effect:start', { agentRunId });
         setMessages([]);
-        setWorkflowStatus(null);
+        setAgentRunStatus(null);
         setWorkflowRunId(null);
         setStreamingMessages(new Map());
         setServerFileUpdates(new Map());
@@ -116,7 +116,7 @@ export function useAgentStream(
         client.agents.getInternals(agentRunId)
             .then((agentRun) => {
                 if (!abortController.signal.aborted) {
-                    setWorkflowStatus(agentRun.status?.toUpperCase() ?? null);
+                    setAgentRunStatus(agentRun.status?.toUpperCase() ?? null);
                     setWorkflowRunId(agentRun.first_workflow_run_id ?? null);
                 }
             })
@@ -299,7 +299,7 @@ export function useAgentStream(
         debugChunkFlash,
         addOptimisticMessage,
         removeOptimisticMessages,
-        workflowStatus,
+        agentRunStatus,
         workflowRunId,
         serverFileUpdates,
     };


### PR DESCRIPTION
## Summary

- Derive terminal agent state from the AgentRun status returned by `getInternals`, including lowercase persisted values like `completed`.
- Pass that terminal state into the agent conversation header so restart actions are visible for completed, failed, canceled, terminated, and timed out runs.
- Add a visible `Restart Conversation` button in the header and hide `Cancel Workflow` after the run is already terminal.

## Root Cause

The header already had restart support, but `ModernAgentConversation` never passed `isTerminal`, so the prop defaulted to `false` and the restart menu item stayed hidden even when the AgentRun was completed.

## Validation

- `pnpm --prefix composableai/packages/ui exec tsc --noEmit`
- `pnpm --prefix apps/composable-ui exec tsc --noEmit`
- `git diff --check`
- `git -C composableai diff --check`