### PR TITLE
feat: extend cost analytics query options

### DIFF
--- a/packages/client/src/store/CostApi.ts
+++ b/packages/client/src/store/CostApi.ts
@@ -8,7 +8,7 @@ export class CostApi extends ApiTopic {
 
     /**
      * Get cost analytics for the current project.
-     * Returns cost breakdown by model/environment with pricing from billing export.
+     * Returns cost breakdown by model/environment using billing-export pricing.
      * Covers all inference types: direct, agent, embedding.
      */
     getAnalytics(
@@ -57,10 +57,13 @@ export class CostApi extends ApiTopic {
     /**
      * Get the CSV export URL for raw inference audit events.
      */
-    getExportUrl(params?: { from?: string | number; to?: string | number }): string {
+    getExportUrl(params?: Pick<CostAnalyticsQuery, 'from' | 'to' | 'scope' | 'project_id' | 'workflow_id'>): string {
         const searchParams = new URLSearchParams();
         if (params?.from) searchParams.set('from', typeof params.from === 'number' ? new Date(params.from).toISOString() : params.from);
         if (params?.to) searchParams.set('to', typeof params.to === 'number' ? new Date(params.to).toISOString() : params.to);
+        if (params?.scope) searchParams.set('scope', params.scope);
+        if (params?.project_id) searchParams.set('project_id', params.project_id);
+        if (params?.workflow_id) searchParams.set('workflow_id', params.workflow_id);
         const qs = searchParams.toString();
         return `${this.baseUrl}/export${qs ? `?${qs}` : ''}`;
     }

--- a/packages/common/src/cost-analytics.ts
+++ b/packages/common/src/cost-analytics.ts
@@ -20,7 +20,7 @@ export interface CostAnalyticsQuery {
     /** End time (ISO string or epoch ms) */
     to?: string | number;
     /** Group results by this dimension */
-    group_by?: 'model' | 'environment' | 'account' | 'project' | 'project_tag' | 'provider' | 'interaction' | 'workflow';
+    group_by?: 'model' | 'environment' | 'account' | 'project' | 'project_tag' | 'provider' | 'interaction' | 'workflow' | 'usage_type';
     /** Time series resolution */
     resolution?: 'hour' | 'day' | 'week' | 'month';
     /** Filter by model pattern */
@@ -33,6 +33,8 @@ export interface CostAnalyticsQuery {
     project_id?: string;
     /** Filter by workflow / agent run ID */
     workflow_id?: string;
+    /** Filter by interaction ID */
+    interaction_id?: string;
     /** Filter by Temporal workflow run ID */
     workflow_run_id?: string;
     /** Filter by interaction execution run ID */
@@ -45,6 +47,8 @@ export interface CostAnalyticsQuery {
     scope?: 'project' | 'org';
     /** Pricing source: 'list' (latest daily prices) or 'historical' (daily effective prices over the query range). Default: 'list' */
     pricing_source?: 'list' | 'historical';
+    /** Include the full pricing catalog in the response. Defaults to false. */
+    include_pricing?: boolean;
     /** Skip cache and force fresh query */
     no_cache?: boolean;
 }
@@ -73,6 +77,10 @@ export interface CostByDimension {
     cache_write_input_tokens?: number;
     output_tokens: number;
     calls: number;
+    input_price_per_m_tokens?: number;
+    cached_input_price_per_m_tokens?: number;
+    cache_write_input_price_per_m_tokens?: number;
+    output_price_per_m_tokens?: number;
     periods?: CostTimeSeriesPoint[];
 }
 
@@ -125,7 +133,7 @@ export interface CostAnalyticsResponse {
     summary: CostSummary;
     by_dimension: CostByDimension[];
     time_series: CostTimeSeriesPoint[];
-    pricing: ModelPricing[];
+    pricing?: ModelPricing[];
     query_range: { from: string; to: string };
     cached: boolean;
 }


### PR DESCRIPTION
## Summary
- Add `usage_type`, `interaction_id`, and `include_pricing` to the shared cost analytics query contract.
- Make the full pricing catalog optional on cost analytics responses while keeping per-dimension price fields available.
- Extend the cost export URL helper with scope, project, and workflow filters.

## Test Plan
- `pnpm --prefix composableai/packages/common build`
- `pnpm --prefix composableai/packages/client build`
