### PR TITLE
feat: add can_retrieve_value flag to ApiKey

### DIFF
--- a/packages/common/src/apikey.ts
+++ b/packages/common/src/apikey.ts
@@ -11,6 +11,7 @@ export interface ApiKey {
     type: ApiKeyTypes;
     role: ProjectRoles;
     maskedValue?: string; //masked value
+    can_retrieve_value?: boolean;
     account: string; // the account id
     project: ProjectRef; // the project id if any
     enabled: boolean;


### PR DESCRIPTION
## Summary
- Add `can_retrieve_value?: boolean` to the `ApiKey` interface in `@vertesia/common` to let clients know whether a given key's raw value can still be retrieved from the server

## Test Plan
- [ ] Consumed by studio PR — see parent for end-to-end test plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>