### PR TITLE
Fix/filter modal

### DIFF
--- a/packages/ui/src/core/components/shadcn/filters/filterBar.tsx
+++ b/packages/ui/src/core/components/shadcn/filters/filterBar.tsx
@@ -25,6 +25,7 @@ interface FilterProviderProps {
   setFilters: Dispatch<SetStateAction<Filter[]>>;
   filterGroups: FilterGroup[];
   children: React.ReactNode;
+  inModal?: boolean;
 }
 
 // Syncs filters ↔ URL. On mount, captures the initial URL param and restores matching filters
@@ -33,14 +34,15 @@ interface FilterProviderProps {
 // (prevents cross-page URL contamination, e.g. a modal inheriting a parent page's filters).
 
 // Parse format with array indicators: filterName:value or filterName:[value1,value2]
-const FilterProvider = ({ filters, setFilters, filterGroups, children }: FilterProviderProps) => {
+const FilterProvider = ({ filters, setFilters, filterGroups, children, inModal }: FilterProviderProps) => {
   const url = new URL(window.location.href);
   const searchParams = url.searchParams;
   const [initialFiltersParam] = React.useState(() => new URLSearchParams(window.location.search).get('filters'));
   const processedUrlFilters = React.useRef<Set<string>>(new Set());
-  const hasRestoredFromUrl = React.useRef(!initialFiltersParam);
+  const hasRestoredFromUrl = React.useRef(inModal || !initialFiltersParam);
 
   useEffect(() => {
+    if (inModal) return;
     if (!hasRestoredFromUrl.current) return;
     try {
       const params = new URLSearchParams(searchParams.toString());
@@ -82,7 +84,7 @@ const FilterProvider = ({ filters, setFilters, filterGroups, children }: FilterP
   }, [filters]);
 
   useEffect(() => {
-    if (!initialFiltersParam || filterGroups.length === 0) return;
+    if (inModal || !initialFiltersParam || filterGroups.length === 0) return;
     try {
       const filterPairs = initialFiltersParam.split(';');
       const newFilters: Filter[] = [];

--- a/packages/ui/src/features/facets/DocumentsFacetsNav.tsx
+++ b/packages/ui/src/features/facets/DocumentsFacetsNav.tsx
@@ -1,4 +1,4 @@
-import { Filter as BaseFilter, FilterProvider, FilterBtn, FilterBar, FilterClear, FilterGroup } from '@vertesia/ui/core';
+import { Filter as BaseFilter, FilterProvider, FilterBtn, FilterBar, FilterClear, FilterGroup, useIsInModal } from '@vertesia/ui/core';
 import { useState } from 'react';
 import { useTypeRegistry } from '../store/types/TypeRegistryProvider.js';
 import { VStringFacet } from './utils/VStringFacet';
@@ -161,6 +161,7 @@ export function DocumentsFacetsNav({
     const [filters, setFilters] = useState<BaseFilter[]>([]);
     const filterGroups = useDocumentFilterGroups(facets);
     const handleFilterLogic = useDocumentFilterHandler(search);
+    const inModal = useIsInModal();
 
     const handleFilterChange: React.Dispatch<React.SetStateAction<BaseFilter[]>> = (value) => {
         const newFilters = typeof value === 'function' ? value(filters) : value;
@@ -173,6 +174,7 @@ export function DocumentsFacetsNav({
             filterGroups={filterGroups}
             filters={filters}
             setFilters={handleFilterChange}
+            inModal={inModal}
         >
             <div className="flex gap-2 items-center">
                 <FilterBtn />

--- a/packages/ui/src/widgets/form/Form.tsx
+++ b/packages/ui/src/widgets/form/Form.tsx
@@ -154,7 +154,7 @@ function ListField({ object }: ListFieldProps) {
                 })
             }
             <div>
-                <Button variant='secondary' onClick={addItem} disabled={disabled}><Plus className="size-6" /> Add</Button>
+                <Button variant='outline' onClick={addItem} disabled={disabled}><Plus className="size-6" /> Add</Button>
             </div>
         </div>
     )
@@ -174,7 +174,7 @@ function ListItem({ list, object, onDelete, disabled }: ListItemProps) {
                     renderItemProperty(object, list.schema.arraySchema.editor)
                 }
             </div>
-            <Button variant='secondary' onClick={onDelete} disabled={disabled}><Trash2 className='size-4' /></Button>
+            <Button variant='ghost' onClick={onDelete} disabled={disabled} alt="Delete"><Trash2 className='size-4 text-destructive' /></Button>
         </div>
     )
 }


### PR DESCRIPTION
## Issue
- When opening the input document selection, the object store is filtered for "RUNNING," which is not an object but a workflow property
- 
<img width="1661" height="258" alt="Screenshot 2026-04-16 at 12 44 17" src="https://github.com/user-attachments/assets/42f54d05-e0ee-4bbd-af0a-cbe3fc2b14da" />


## Cause
- The filter will apply the value from the URL by default, but if there are two different filters on the page and in the modal, there will be a conflict

## Solution
- Since the modal is more temporary, if the filter is in the modal, then we will skip the URL-altering part
- 
<img width="1672" height="257" alt="Screenshot 2026-04-16 at 12 44 49" src="https://github.com/user-attachments/assets/1f7982f3-abf9-469a-99c2-78e76fb9a9ba" />
