### PR TITLE
fix: add version field to ResourceRef for interaction name resolution

### DIFF
--- a/packages/common/src/refs.ts
+++ b/packages/common/src/refs.ts
@@ -27,4 +27,5 @@ export interface ResourceRef {
     name: string
     type: string
     description?: string
+    version?: number
 }


### PR DESCRIPTION
## Summary
- Adds optional `version?: number` field to `ResourceRef` interface so the refs API can return version alongside interaction names

## Test Plan
- [ ] Used by studio-server refs endpoint to return interaction version
- [ ] Enables interaction names in analytics to show `name v{version}` format

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>