### PR TITLE
feat: add StandardMediaContainerIntake — fix audio-only MP4 intake crash

### DIFF
--- a/packages/workflow/src/activities/handleError.ts
+++ b/packages/workflow/src/activities/handleError.ts
@@ -12,6 +12,7 @@ export async function handleDslError(payload: DSLActivityExecutionPayload<Handle
     const isIntake = [
         "StandardDocumentIntake",
         "StandardImageIntake",
+        "StandardMediaContainerIntake",
         "StandardVideoIntake",
         "StandardAudioIntake",
         "StandardDocPartIntake",

--- a/packages/workflow/src/activities/index-dsl.ts
+++ b/packages/workflow/src/activities/index-dsl.ts
@@ -16,6 +16,8 @@ export { getObjectFromStore } from "./getObjectFromStore.js";
 export { handleDslError } from "./handleError.js";
 export { prepareAudio } from "./media/prepareAudio.js";
 export { prepareVideo } from "./media/prepareVideo.js";
+export { probeMediaStreams } from "./media/probeMediaStreams.js";
+export type { ProbeMediaStreamsResult } from "./media/probeMediaStreams.js";
 export { convertPdfToStructuredText } from "./media/processPdfWithTextract.js";
 export { saveGladiaTranscription } from "./media/saveGladiaTranscription.js";
 export { transcribeMedia } from "./media/transcribeMediaWithGladia.js";
@@ -26,4 +28,5 @@ export { checkRateLimit } from "./rateLimiter.js";
 export { generateImageRendition } from "./renditions/generateImageRendition.js";
 export { generateVideoRendition } from "./renditions/generateVideoRendition.js";
 export { setDocumentStatus } from "./setDocumentStatus.js";
+export { loadChildWorkflowSpec } from "./loadChildWorkflowSpec.js";
 

--- a/packages/workflow/src/activities/loadChildWorkflowSpec.ts
+++ b/packages/workflow/src/activities/loadChildWorkflowSpec.ts
@@ -1,0 +1,21 @@
+import { DSLActivityExecutionPayload, DSLWorkflowSpec } from '@vertesia/common';
+import { setupActivity } from '../dsl/setup/ActivityContext.js';
+
+export interface LoadChildWorkflowSpecParams {
+    workflowName: string;
+}
+
+export async function loadChildWorkflowSpec(
+    payload: DSLActivityExecutionPayload<LoadChildWorkflowSpecParams>,
+): Promise<DSLWorkflowSpec> {
+    const { client, params } = await setupActivity<LoadChildWorkflowSpecParams>(payload);
+    const { workflowName } = params;
+
+    const refs = await client.store.workflows.definitions.list();
+    const ref = refs.find(r => r.name === workflowName);
+    if (!ref) {
+        throw new Error(`Workflow definition not found: ${workflowName}`);
+    }
+
+    return client.store.workflows.definitions.retrieve(ref.id) as Promise<DSLWorkflowSpec>;
+}

--- a/packages/workflow/src/activities/media/prepareAudio.ts
+++ b/packages/workflow/src/activities/media/prepareAudio.ts
@@ -221,11 +221,12 @@ export async function prepareAudio(
         throw new DocumentNotFoundError(`Document ${objectId} has no source`, [objectId]);
     }
 
-    if (!inputObject.content.type || !inputObject.content.type.startsWith('audio/')) {
+    if (!inputObject.content.type ||
+        (!inputObject.content.type.startsWith('audio/') && !inputObject.content.type.startsWith('video/'))) {
         log.error(`Document ${objectId} is not an audio file: ${inputObject.content.type}`);
         throw new InvalidContentTypeError(
             objectId,
-            'audio/*',
+            'audio/* or video/*',
             inputObject.content.type || 'unknown',
         );
     }

--- a/packages/workflow/src/activities/media/probeMediaStreams.test.ts
+++ b/packages/workflow/src/activities/media/probeMediaStreams.test.ts
@@ -1,0 +1,126 @@
+import { MockActivityEnvironment } from '@temporalio/testing';
+import type { VertesiaClient } from '@vertesia/client';
+import { ContentEventName, DSLActivityExecutionPayload } from '@vertesia/common';
+import type { ActivityContext } from '@vertesia/workflow';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { probeMediaStreams, ProbeMediaStreamsParams, ProbeMediaStreamsResult } from './probeMediaStreams.js';
+
+vi.mock('../../dsl/setup/ActivityContext.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../dsl/setup/ActivityContext.js')>();
+    return { ...actual, setupActivity: vi.fn() };
+});
+
+// child_process.exec uses util.promisify.custom to return { stdout, stderr }.
+// vi.hoisted ensures these are defined before the vi.mock factory runs.
+const { execMock, execCustom } = vi.hoisted(() => {
+    const custom = vi.fn();
+    const mock = Object.assign(vi.fn(), { [Symbol.for('nodejs.util.promisify.custom')]: custom });
+    return { execMock: mock, execCustom: custom };
+});
+vi.mock('child_process', () => ({ exec: execMock }));
+
+let testEnv: MockActivityEnvironment;
+
+beforeAll(async () => {
+    testEnv = new MockActivityEnvironment();
+});
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+const createPayload = (objectId = 'test-object-id'): DSLActivityExecutionPayload<ProbeMediaStreamsParams> => ({
+    auth_token: 'mock-token',
+    account_id: 'test-account',
+    project_id: 'test-project',
+    params: {},
+    config: { studio_url: 'http://mock-studio', store_url: 'http://mock-store' },
+    workflow_name: 'test-workflow',
+    event: ContentEventName.create,
+    objectIds: [objectId],
+    input: { inputType: 'objectIds', objectIds: [objectId] },
+    vars: {},
+    activity: { name: 'probeMediaStreams', params: {} },
+});
+
+function mockExec(stdout: string) {
+    execCustom.mockResolvedValue({ stdout, stderr: '' });
+}
+
+async function setupMockContext(objectId: string, signedUrl: string): Promise<void> {
+    const { setupActivity } = await import('../../dsl/setup/ActivityContext.js');
+    const mockClient = {
+        objects: {
+            retrieve: vi.fn().mockResolvedValue({
+                content: { source: 'gs://bucket/file.mp4', type: 'video/mp4' },
+            }),
+        },
+        files: {
+            getDownloadUrl: vi.fn().mockResolvedValue({ url: signedUrl }),
+        },
+    } as unknown as VertesiaClient;
+    vi.mocked(setupActivity).mockResolvedValue({
+        client: mockClient,
+        objectId,
+        inputType: 'objectIds',
+        params: {},
+    } as unknown as ActivityContext<ProbeMediaStreamsParams>);
+}
+
+describe('probeMediaStreams', () => {
+    it('returns hasVideo=true and hasAudio=true for a video+audio container', async () => {
+        await setupMockContext('test-object-id', 'https://storage.example.com/file.mp4?token=abc');
+        mockExec(JSON.stringify({ streams: [{ codec_type: 'video' }, { codec_type: 'audio' }] }));
+
+        const result: ProbeMediaStreamsResult = await testEnv.run(probeMediaStreams, createPayload());
+
+        expect(result).toEqual({ hasVideo: true, hasAudio: true });
+    });
+
+    it('returns hasVideo=true and hasAudio=false for a video-only container', async () => {
+        await setupMockContext('test-object-id', 'https://storage.example.com/file.mp4');
+        mockExec(JSON.stringify({ streams: [{ codec_type: 'video' }] }));
+
+        const result = await testEnv.run(probeMediaStreams, createPayload());
+
+        expect(result).toEqual({ hasVideo: true, hasAudio: false });
+    });
+
+    it('returns hasVideo=false and hasAudio=true for an audio-only container (the bug case)', async () => {
+        await setupMockContext('test-object-id', 'https://storage.example.com/audio-only.mp4');
+        mockExec(JSON.stringify({ streams: [{ codec_type: 'audio' }] }));
+
+        const result = await testEnv.run(probeMediaStreams, createPayload());
+
+        expect(result).toEqual({ hasVideo: false, hasAudio: true });
+    });
+
+    it('throws nonRetryable ApplicationFailure when no usable streams are found', async () => {
+        await setupMockContext('test-object-id', 'https://storage.example.com/bad.mp4');
+        mockExec(JSON.stringify({ streams: [] }));
+
+        await expect(testEnv.run(probeMediaStreams, createPayload())).rejects.toThrow(
+            'No audio or video streams found in container',
+        );
+    });
+
+    it('throws DocumentNotFoundError when the object has no source', async () => {
+        const { setupActivity } = await import('../../dsl/setup/ActivityContext.js');
+        const mockClient = {
+            objects: {
+                retrieve: vi.fn().mockResolvedValue({ content: {} }),
+            },
+            files: { getDownloadUrl: vi.fn() },
+        } as unknown as VertesiaClient;
+        vi.mocked(setupActivity).mockResolvedValue({
+            client: mockClient,
+            objectId: 'test-object-id',
+            inputType: 'objectIds',
+            params: {},
+        } as unknown as ActivityContext<ProbeMediaStreamsParams>);
+
+        await expect(testEnv.run(probeMediaStreams, createPayload())).rejects.toThrow(
+            'has no source',
+        );
+    });
+});

--- a/packages/workflow/src/activities/media/probeMediaStreams.test.ts
+++ b/packages/workflow/src/activities/media/probeMediaStreams.test.ts
@@ -63,7 +63,7 @@ async function setupMockContext(objectId: string, signedUrl: string): Promise<vo
         client: mockClient,
         objectId,
         inputType: 'objectIds',
-        params: {},
+        params: {} satisfies ProbeMediaStreamsParams,
     } as unknown as ActivityContext<ProbeMediaStreamsParams>);
 }
 
@@ -81,7 +81,7 @@ describe('probeMediaStreams', () => {
         await setupMockContext('test-object-id', 'https://storage.example.com/file.mp4');
         mockExec(JSON.stringify({ streams: [{ codec_type: 'video' }] }));
 
-        const result = await testEnv.run(probeMediaStreams, createPayload());
+        const result: ProbeMediaStreamsResult = await testEnv.run(probeMediaStreams, createPayload());
 
         expect(result).toEqual({ hasVideo: true, hasAudio: false });
     });
@@ -90,7 +90,7 @@ describe('probeMediaStreams', () => {
         await setupMockContext('test-object-id', 'https://storage.example.com/audio-only.mp4');
         mockExec(JSON.stringify({ streams: [{ codec_type: 'audio' }] }));
 
-        const result = await testEnv.run(probeMediaStreams, createPayload());
+        const result: ProbeMediaStreamsResult = await testEnv.run(probeMediaStreams, createPayload());
 
         expect(result).toEqual({ hasVideo: false, hasAudio: true });
     });

--- a/packages/workflow/src/activities/media/probeMediaStreams.ts
+++ b/packages/workflow/src/activities/media/probeMediaStreams.ts
@@ -1,0 +1,81 @@
+import { ApplicationFailure, log } from '@temporalio/activity';
+import { DSLActivityExecutionPayload, DSLActivitySpec } from '@vertesia/common';
+import { RequestError } from '@vertesia/api-fetch-client';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { setupActivity } from '../../dsl/setup/ActivityContext.js';
+import { DocumentNotFoundError } from '../../errors.js';
+
+const execAsync = promisify(exec);
+
+const FFPROBE_MAX_BUFFER = 1024 * 1024; // 1MB is more than enough for stream metadata JSON
+
+export interface ProbeMediaStreamsResult {
+    hasVideo: boolean;
+    hasAudio: boolean;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface ProbeMediaStreamsParams {}
+
+export interface ProbeMediaStreams extends DSLActivitySpec<ProbeMediaStreamsParams> {
+    name: 'probeMediaStreams';
+}
+
+interface FFProbeStream {
+    codec_type: string;
+}
+
+interface FFProbeOutput {
+    streams: FFProbeStream[];
+}
+
+export async function probeMediaStreams(payload: DSLActivityExecutionPayload<ProbeMediaStreamsParams>): Promise<ProbeMediaStreamsResult> {
+    const { client, objectId } = await setupActivity<ProbeMediaStreamsParams>(payload);
+
+    const inputObject = await client.objects.retrieve(objectId).catch((err: unknown) => {
+        log.error(`Failed to retrieve object ${objectId}`, { err });
+        if (err instanceof RequestError && err.status === 404) {
+            throw new DocumentNotFoundError(`Object ${objectId} not found`, [objectId]);
+        }
+        throw err;
+    });
+
+    const source = inputObject.content?.source;
+    if (!source) {
+        throw new DocumentNotFoundError(`Object ${objectId} has no source`, [objectId]);
+    }
+
+    const { url } = await client.files.getDownloadUrl(source);
+    if (!url) {
+        throw new DocumentNotFoundError(`Failed to get download URL for object ${objectId}`);
+    }
+
+    // ffprobe reads only the container headers via HTTP range requests.
+    // -probesize 32k caps the amount read from the network to ~32 KB.
+    let stdout: string;
+    try {
+        ({ stdout } = await execAsync(
+            `ffprobe -v quiet -probesize 32k -print_format json -show_streams "${url}"`,
+            { maxBuffer: FFPROBE_MAX_BUFFER },
+        ));
+    } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.error(`ffprobe failed for object ${objectId}: ${message}`);
+        throw new Error(`Failed to probe media streams for object ${objectId}: ${message}`);
+    }
+
+    const { streams } = JSON.parse(stdout) as FFProbeOutput;
+    const hasVideo = streams.some(s => s.codec_type === 'video');
+    const hasAudio = streams.some(s => s.codec_type === 'audio');
+
+    log.info(`Media probe result for object ${objectId}`, { hasVideo, hasAudio });
+
+    if (!hasVideo && !hasAudio) {
+        throw ApplicationFailure.nonRetryable(
+            `No audio or video streams found in container for object ${objectId}`,
+        );
+    }
+
+    return { hasVideo, hasAudio };
+}

--- a/packages/workflow/src/dsl/dsl-workflow.ts
+++ b/packages/workflow/src/dsl/dsl-workflow.ts
@@ -245,7 +245,10 @@ async function startChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWorkfl
         const workflowName = step.name.slice(4);
         const specPayload = dslActivityPayload(basePayload, { name: 'loadChildWorkflowSpec' } as DSLActivitySpec, { workflowName });
         const spec = await proxy.loadChildWorkflowSpec(specPayload) as DSLWorkflowSpec;
-        step = { ...step, name: 'dslWorkflow', spec };
+        const humanName = spec.name.replace(/([A-Z])/g, ' $1').trim();
+        const objectIds = getDocumentIds(payload);
+        const workflowId = objectIds.length > 0 ? `${humanName}:${objectIds[0]}` : humanName;
+        step = { ...step, name: 'dslWorkflow', spec, options: { ...step.options, workflowId } };
     }
     const resolvedVars = vars.resolve();
     if (step.vars) {
@@ -289,7 +292,10 @@ async function executeChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWork
         const workflowName = step.name.slice(4);
         const specPayload = dslActivityPayload(basePayload, { name: 'loadChildWorkflowSpec' } as DSLActivitySpec, { workflowName });
         const spec = await proxy.loadChildWorkflowSpec(specPayload) as DSLWorkflowSpec;
-        step = { ...step, name: 'dslWorkflow', spec };
+        const humanName = spec.name.replace(/([A-Z])/g, ' $1').trim();
+        const objectIds = getDocumentIds(payload);
+        const workflowId = objectIds.length > 0 ? `${humanName}:${objectIds[0]}` : humanName;
+        step = { ...step, name: 'dslWorkflow', spec, options: { ...step.options, workflowId } };
     }
     const resolvedVars = vars.resolve();
     if (step.vars) {

--- a/packages/workflow/src/dsl/dsl-workflow.ts
+++ b/packages/workflow/src/dsl/dsl-workflow.ts
@@ -183,9 +183,9 @@ async function executeSteps(definition: DSLWorkflowSpec, payload: DSLWorkflowExe
             if (stepType === 'workflow') {
                 const childWorkflowStep = step as DSLChildWorkflowStep;
                 if (childWorkflowStep.async) {
-                    await startChildWorkflow(childWorkflowStep, payload, vars, basePayload.debug_mode);
+                    await startChildWorkflow(childWorkflowStep, payload, vars, basePayload.debug_mode, defaultProxy, basePayload);
                 } else {
-                    await executeChildWorkflow(childWorkflowStep, payload, vars, basePayload.debug_mode);
+                    await executeChildWorkflow(childWorkflowStep, payload, vars, basePayload.debug_mode, defaultProxy, basePayload);
                 }
             } else { // activity
                 await runActivity(step as DSLActivitySpec, basePayload, vars, defaultProxy, defaultOptions, remoteActivities);
@@ -236,10 +236,16 @@ async function handleError(originalError: any, basePayload: BaseActivityPayload,
     throw originalError;
 }
 
-async function startChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWorkflowExecutionPayload, vars: Vars, debug_mode?: boolean) {
+async function startChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWorkflowExecutionPayload, vars: Vars, debug_mode?: boolean, proxy?: ActivityInterfaceFor<UntypedActivities>, basePayload?: BaseActivityPayload) {
     if (step.condition && !vars.match(step.condition)) {
         log.info("Child workflow skipped: condition not satisfied", { workflow: step.name, condition: step.condition });
         return;
+    }
+    if (step.name.startsWith('dsl:') && !step.spec && proxy && basePayload) {
+        const workflowName = step.name.slice(4);
+        const specPayload = dslActivityPayload(basePayload, { name: 'loadChildWorkflowSpec' } as DSLActivitySpec, { workflowName });
+        const spec = await proxy.loadChildWorkflowSpec(specPayload) as DSLWorkflowSpec;
+        step = { ...step, name: 'dslWorkflow', spec };
     }
     const resolvedVars = vars.resolve();
     if (step.vars) {
@@ -274,10 +280,16 @@ async function startChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWorkfl
     }
 }
 
-async function executeChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWorkflowExecutionPayload, vars: Vars, debug_mode?: boolean) {
+async function executeChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWorkflowExecutionPayload, vars: Vars, debug_mode?: boolean, proxy?: ActivityInterfaceFor<UntypedActivities>, basePayload?: BaseActivityPayload) {
     if (step.condition && !vars.match(step.condition)) {
         log.info("Child workflow skipped: condition not satisfied", { workflow: step.name, condition: step.condition });
         return;
+    }
+    if (step.name.startsWith('dsl:') && !step.spec && proxy && basePayload) {
+        const workflowName = step.name.slice(4);
+        const specPayload = dslActivityPayload(basePayload, { name: 'loadChildWorkflowSpec' } as DSLActivitySpec, { workflowName });
+        const spec = await proxy.loadChildWorkflowSpec(specPayload) as DSLWorkflowSpec;
+        step = { ...step, name: 'dslWorkflow', spec };
     }
     const resolvedVars = vars.resolve();
     if (step.vars) {


### PR DESCRIPTION
## Summary

Fixes a crash where audio-only MP4 files (MIME type `video/mp4`) are processed by `StandardVideoIntake`, which calls `prepareVideo`, finds no video stream via ffprobe, and throws a non-retryable error.

- **New `probeMediaStreams` activity**: runs `ffprobe` against a signed URL (no full download, capped at 32 KB header read), returns `{ hasVideo, hasAudio }`. Throws `ApplicationFailure.nonRetryable` if no usable streams found.
- **New `loadChildWorkflowSpec` activity**: fetches a DSL workflow definition by name, enabling the new `dsl:WorkflowName` child step convention.
- **`dsl-workflow.ts`**: `executeChildWorkflow` / `startChildWorkflow` now resolve `dsl:WorkflowName` steps at runtime — calls `loadChildWorkflowSpec`, then rewrites the step to `dslWorkflow` + inline spec before `executeChild`.
- **`prepareAudio`**: relaxed MIME type check to accept `video/*` in addition to `audio/*` (audio-only containers have `video/mp4` content type).
- **`handleError`**: added `StandardMediaContainerIntake` to the `isIntake` list so probe failures correctly set status to `failed`.
- Exported new activities from `index-dsl.ts`.

## Test Plan
- [ ] Unit tests: `cd packages/workflow && vitest -- -t "probeMediaStreams"`
- [ ] Upload a normal video MP4 → should complete via StandardVideoIntake
- [ ] Upload an audio-only MP4 → should complete via StandardAudioIntake (no crash)
- [ ] Upload a container with no streams → workflow should fail cleanly (non-retryable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>