### PR TITLE
fix: stop infinite refetch loop in PDF content-object view

### DIFF
--- a/packages/ui/src/features/store/objects/components/ContentOverview.tsx
+++ b/packages/ui/src/features/store/objects/components/ContentOverview.tsx
@@ -382,6 +382,17 @@ function DataPanel({ object, loadText, handleCopyContent, refetch }: { object: C
         triggerConversion: triggerOfficePdfConversion,
     } = useOfficePdfConversion(object.id, isPreviewableAsPdfDoc);
 
+    // Reload the parent object once processing completes so object.status and text_etag are fresh.
+    // Use a ref to avoid including the unstable refetch function in the effect dependency array,
+    // which would cause the effect to re-run (and call refetch) on every render.
+    const refetchRef = useRef(refetch);
+    useEffect(() => { refetchRef.current = refetch; });
+    useEffect(() => {
+        if (processingComplete && pdfStatus === WorkflowExecutionStatus.COMPLETED) {
+            refetchRef.current?.();
+        }
+    }, [processingComplete, pdfStatus]);
+
     // Show processing panel when workflow is running (for both PDFs and Office documents)
     const showProcessingPanel = (isPdf || isPreviewableAsPdfDoc) && isCreatedOrProcessing && !processingComplete && pdfStatus === WorkflowExecutionStatus.RUNNING;
     const showPdfPreviewPanel = currentPanel === PanelView.Pdf && !showProcessingPanel;

--- a/packages/ui/src/features/store/objects/components/ContentOverview.tsx
+++ b/packages/ui/src/features/store/objects/components/ContentOverview.tsx
@@ -335,6 +335,13 @@ function DataPanel({ object, loadText, handleCopyContent, refetch }: { object: C
     };
 
     const [currentPanel, setCurrentPanel] = useState<PanelView>(getInitialView());
+    const [hasVisitedPdfPanel, setHasVisitedPdfPanel] = useState(currentPanel === PanelView.Pdf);
+
+    useEffect(() => {
+        if (currentPanel === PanelView.Pdf) {
+            setHasVisitedPdfPanel(true);
+        }
+    }, [currentPanel]);
 
     // Text editing state
     const [isEditing, setIsEditing] = useState(false);
@@ -356,8 +363,10 @@ function DataPanel({ object, loadText, handleCopyContent, refetch }: { object: C
         loadText: reloadText,
     } = useObjectText(object.id, object.text, loadText);
 
-    // Poll for PDF/document processing status when object is created or processing
-    const shouldPollProgress = (isPdf || isPreviewableAsPdfDoc) && isCreatedOrProcessing;
+    // Only poll while the active panel can actually surface processing progress.
+    const shouldPollProgress = (isPdf || isPreviewableAsPdfDoc)
+        && isCreatedOrProcessing
+        && (currentPanel === PanelView.Text || currentPanel === PanelView.Pdf);
     const {
         progress: pdfProgress,
         status: pdfStatus,
@@ -373,15 +382,11 @@ function DataPanel({ object, loadText, handleCopyContent, refetch }: { object: C
         triggerConversion: triggerOfficePdfConversion,
     } = useOfficePdfConversion(object.id, isPreviewableAsPdfDoc);
 
-    // Reload object when PDF processing completes
-    useEffect(() => {
-        if (processingComplete && pdfStatus === WorkflowExecutionStatus.COMPLETED) {
-            refetch?.();
-        }
-    }, [processingComplete, pdfStatus, refetch]);
-
     // Show processing panel when workflow is running (for both PDFs and Office documents)
     const showProcessingPanel = (isPdf || isPreviewableAsPdfDoc) && isCreatedOrProcessing && !processingComplete && pdfStatus === WorkflowExecutionStatus.RUNNING;
+    const showPdfPreviewPanel = currentPanel === PanelView.Pdf && !showProcessingPanel;
+    const showPdfProcessingPanel = showProcessingPanel && (currentPanel === PanelView.Text || currentPanel === PanelView.Pdf);
+    const keepPdfPreviewMounted = hasVisitedPdfPanel && !showProcessingPanel;
 
     const textContainerRef = useRef<HTMLDivElement | null>(null);
 
@@ -487,27 +492,33 @@ function DataPanel({ object, loadText, handleCopyContent, refetch }: { object: C
                     />
                 )}
             </div>
-            <div className={getPanelVisibility(currentPanel === PanelView.Image)}>
-                <ImagePanel object={object} />
-            </div>
-            <div className={getPanelVisibility(currentPanel === PanelView.Video)}>
-                <VideoPanel object={object} />
-            </div>
-            <div className={getPanelVisibility(currentPanel === PanelView.Audio)}>
-                <AudioPanel object={object} />
-            </div>
-            {hasTranscript && (
-                <div className={getPanelVisibility(currentPanel === PanelView.Transcript)}>
+            {currentPanel === PanelView.Image && (
+                <div className={getPanelVisibility(true)}>
+                    <ImagePanel object={object} />
+                </div>
+            )}
+            {currentPanel === PanelView.Video && (
+                <div className={getPanelVisibility(true)}>
+                    <VideoPanel object={object} />
+                </div>
+            )}
+            {currentPanel === PanelView.Audio && (
+                <div className={getPanelVisibility(true)}>
+                    <AudioPanel object={object} />
+                </div>
+            )}
+            {hasTranscript && currentPanel === PanelView.Transcript && (
+                <div className={getPanelVisibility(true)}>
                     <TranscriptPanel object={object} handleCopyContent={handleCopyContent} />
                 </div>
             )}
-            {isPdf && (
-                <div className={getPanelVisibility(currentPanel === PanelView.Pdf)}>
+            {isPdf && keepPdfPreviewMounted && (
+                <div className={getPanelVisibility(showPdfPreviewPanel)}>
                     <PdfPreviewPanel object={object} />
                 </div>
             )}
-            {isPreviewableAsPdfDoc && (
-                <div className={getPanelVisibility(currentPanel === PanelView.Pdf)}>
+            {isPreviewableAsPdfDoc && keepPdfPreviewMounted && (
+                <div className={getPanelVisibility(showPdfPreviewPanel)}>
                     <OfficePdfPreviewPanel
                         pdfRendition={pdfRendition}
                         officePdfUrl={officePdfUrl}
@@ -517,24 +528,28 @@ function DataPanel({ object, loadText, handleCopyContent, refetch }: { object: C
                     />
                 </div>
             )}
-            {showProcessingPanel && (
-                <div className={getPanelVisibility(currentPanel === PanelView.Text)}>
+            {showPdfProcessingPanel && (
+                <div className={getPanelVisibility(true)}>
                     <PdfProcessingPanel progress={pdfProgress} status={pdfStatus} outputFormat={pdfOutputFormat} />
                 </div>
             )}
-            <div className={getPanelVisibility(currentPanel === PanelView.Text && !showProcessingPanel && isLoadingText)}>
-                <div className="flex justify-center items-center flex-1">
-                    <Spinner size="lg" />
+            {currentPanel === PanelView.Text && !showProcessingPanel && isLoadingText && (
+                <div className={getPanelVisibility(true)}>
+                    <div className="flex justify-center items-center flex-1">
+                        <Spinner size="lg" />
+                    </div>
                 </div>
-            </div>
-            <div className={getPanelVisibility(currentPanel === PanelView.Text && !showProcessingPanel && !isLoadingText)}>
-                <TextPanel
-                    object={object}
-                    text={displayText}
-                    isTextCropped={isTextCropped}
-                    textContainerRef={textContainerRef}
-                />
-            </div>
+            )}
+            {currentPanel === PanelView.Text && !showProcessingPanel && !isLoadingText && (
+                <div className={getPanelVisibility(true)}>
+                    <TextPanel
+                        object={object}
+                        text={displayText}
+                        isTextCropped={isTextCropped}
+                        textContainerRef={textContainerRef}
+                    />
+                </div>
+            )}
             {isEditing && currentPanel === PanelView.Text && fullText != null && (
                 <TextEditorPanel
                     object={object}

--- a/packages/ui/src/features/store/objects/components/ContentOverview.tsx
+++ b/packages/ui/src/features/store/objects/components/ContentOverview.tsx
@@ -382,16 +382,13 @@ function DataPanel({ object, loadText, handleCopyContent, refetch }: { object: C
         triggerConversion: triggerOfficePdfConversion,
     } = useOfficePdfConversion(object.id, isPreviewableAsPdfDoc);
 
-    // Reload the parent object once processing completes so object.status and text_etag are fresh.
-    // Use a ref to avoid including the unstable refetch function in the effect dependency array,
-    // which would cause the effect to re-run (and call refetch) on every render.
-    const refetchRef = useRef(refetch);
-    useEffect(() => { refetchRef.current = refetch; });
+    // Load text once processing completes without triggering a full object refetch
+    // (which would flash the page-level loading spinner).
     useEffect(() => {
         if (processingComplete && pdfStatus === WorkflowExecutionStatus.COMPLETED) {
-            refetchRef.current?.();
+            reloadText();
         }
-    }, [processingComplete, pdfStatus]);
+    }, [processingComplete, pdfStatus, reloadText]);
 
     // Show processing panel when workflow is running (for both PDFs and Office documents)
     const showProcessingPanel = (isPdf || isPreviewableAsPdfDoc) && isCreatedOrProcessing && !processingComplete && pdfStatus === WorkflowExecutionStatus.RUNNING;

--- a/packages/ui/src/features/store/objects/components/useContentPanelHooks.ts
+++ b/packages/ui/src/features/store/objects/components/useContentPanelHooks.ts
@@ -83,52 +83,87 @@ export function useObjectText(objectId: string, initialText?: string, loadOnMoun
 export function usePdfProcessingStatus(objectId: string, shouldPoll: boolean) {
     const { client } = useUserSession();
 
-    const [progress, setProgress] = useState<DocAnalyzerProgress | undefined>();
-    const [status, setStatus] = useState<WorkflowExecutionStatus | undefined>();
-    const [outputFormat, setOutputFormat] = useState<DocProcessorOutputFormat | undefined>();
-    const [isComplete, setIsComplete] = useState(false);
+    const [state, setState] = useState<{
+        progress?: DocAnalyzerProgress;
+        status?: WorkflowExecutionStatus;
+        outputFormat?: DocProcessorOutputFormat;
+        isComplete: boolean;
+    }>({ isComplete: false });
 
     useEffect(() => {
         if (!shouldPoll) return;
 
         let interrupted = false;
+        let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+        const updateStateIfChanged = (
+            nextProgress: DocAnalyzerProgress | undefined,
+            nextStatus: WorkflowExecutionStatus | undefined,
+            nextOutputFormat: DocProcessorOutputFormat | undefined,
+            nextIsComplete: boolean,
+        ) => {
+            setState((prev) => {
+                const prevProgress = JSON.stringify(prev.progress ?? null);
+                const nextProgressSignature = JSON.stringify(nextProgress ?? null);
+
+                if (
+                    prev.status === nextStatus
+                    && prev.outputFormat === nextOutputFormat
+                    && prev.isComplete === nextIsComplete
+                    && prevProgress === nextProgressSignature
+                ) {
+                    return prev;
+                }
+
+                return {
+                    progress: nextProgress,
+                    status: nextStatus,
+                    outputFormat: nextOutputFormat,
+                    isComplete: nextIsComplete,
+                };
+            });
+        };
 
         function poll() {
             if (interrupted) return;
 
             client.objects.analyze(objectId).getStatus()
                 .then((r) => {
-                    setProgress(r.progress);
-                    setStatus(r.status);
-                    setOutputFormat(r.output_format ?? r.progress?.output_format);
+                    const nextOutputFormat = r.output_format ?? r.progress?.output_format;
 
                     if (r.status === WorkflowExecutionStatus.RUNNING) {
+                        updateStateIfChanged(r.progress, r.status, nextOutputFormat, false);
                         // Workflow is running, poll every 2 seconds for progress
                         if (!interrupted) {
-                            setTimeout(poll, 2000);
+                            timeoutId = setTimeout(poll, 2000);
                         }
                     } else {
                         // Workflow completed or terminal state
-                        setIsComplete(true);
+                        updateStateIfChanged(r.progress, r.status, nextOutputFormat, true);
                     }
                 })
                 .catch(() => {
                     // No workflow found yet, poll every 10 seconds to check if one starts
                     if (!interrupted) {
-                        setTimeout(poll, 10000);
+                        timeoutId = setTimeout(poll, 10000);
                     }
                 });
         }
 
         poll();
-        return () => { interrupted = true; };
+        return () => {
+            interrupted = true;
+            if (timeoutId) {
+                clearTimeout(timeoutId);
+            }
+        };
     }, [shouldPoll, objectId, client]);
 
     return {
-        progress,
-        status,
-        outputFormat,
-        isComplete,
+        progress: state.progress,
+        status: state.status,
+        outputFormat: state.outputFormat,
+        isComplete: state.isComplete,
     };
 }
 


### PR DESCRIPTION
## Summary
- Remove the `useEffect` that called `refetch()` when PDF processing completed — `refetch` was an unstable function reference in the dependency array, so the effect re-fired on every render while `processingComplete` was true, causing repeated `store.objects.retrieve` calls (the visible reload loop)
- Consolidate four separate `useState` calls in `usePdfProcessingStatus` into a single state object with an `updateStateIfChanged` guard, preventing spurious re-renders when poll results are identical
- Clear scheduled poll timers on cleanup to avoid state updates after unmount
- Gate polling to only run when the active inner panel is Text or Pdf (not from unrelated panels)
- Keep the PDF preview component mounted after first visit so switching tabs does not reload the viewer
- Replace always-mounted visibility-toggled panels (image/video/audio/transcript) with conditional rendering

## Test Plan
- [ ] Open a PDF content object — verify no infinite loading/flicker loop
- [ ] Switch between Text and PDF tabs — PDF viewer should not reload on return
- [ ] Switch to other tabs (Metadata, Versions, etc.) while a PDF is processing — polling should pause
- [ ] Replace a file on a content object — refetch still works correctly after close

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>