### PR TITLE
Fix: throw sts error to indicate that retry is not helping

### DIFF
--- a/packages/ui/src/session/UserSessionProvider.tsx
+++ b/packages/ui/src/session/UserSessionProvider.tsx
@@ -1,7 +1,7 @@
 import { Env } from "@vertesia/ui/env";
 import { onAuthStateChanged } from "firebase/auth";
 import { ReactNode, useEffect, useRef, useState } from "react";
-import { UserNotFoundError, getComposableToken } from "./auth/composable";
+import { STSError, UserNotFoundError, getComposableToken } from "./auth/composable";
 import { shouldRedirectToCentralAuth } from "./auth/domainRouting";
 import { getFirebaseAuth } from "./auth/firebase";
 import { useAuthState } from "./auth/useAuthState";
@@ -86,6 +86,23 @@ export function UserSessionProvider({ children }: UserSessionProviderProps) {
                         session.isLoading = false;
                         session.authError = err;
                         setSession(session.clone());
+                        return;
+                    }
+
+                    if (err instanceof STSError) {
+                        console.error("STS error during token exchange", err);
+                        Env.logger.error("STS error during token exchange", {
+                            vertesia: {
+                                account_id: selectedAccount,
+                                project_id: selectedProject,
+                                sts: err.sts,
+                                error: err,
+                            },
+                        });
+                        window.alert("Authentication failed due to an issue with the authentication service. Please try again later.");
+                        session.logout();
+                        setSession(session.clone());
+                        window.location.hash = "";
                         return;
                     }
 

--- a/packages/ui/src/session/UserSessionProvider.tsx
+++ b/packages/ui/src/session/UserSessionProvider.tsx
@@ -95,7 +95,7 @@ export function UserSessionProvider({ children }: UserSessionProviderProps) {
                             vertesia: {
                                 account_id: selectedAccount,
                                 project_id: selectedProject,
-                                sts: err.sts,
+                                sts_url: err.stsURL,
                                 error: err,
                             },
                         });

--- a/packages/ui/src/session/auth/composable.ts
+++ b/packages/ui/src/session/auth/composable.ts
@@ -305,10 +305,10 @@ export class UserNotFoundError extends Error {
 }
 
 export class STSError extends Error {
-    sts: string;
-    constructor(message: string, sts: string) {
+    stsURL: string;
+    constructor(message: string, stsURL: string) {
         super(message);
         this.name = 'STSError';
-        this.sts = sts;
+        this.stsURL = stsURL;
     }
 }

--- a/packages/ui/src/session/auth/composable.ts
+++ b/packages/ui/src/session/auth/composable.ts
@@ -61,6 +61,16 @@ export async function fetchComposableToken(getIdToken: () => Promise<string | nu
                 'Authorization': `Bearer ${idToken}` // Firebase token for authentication
             },
             body: JSON.stringify(requestBody)
+        }).catch((error) => {
+            console.error('Failed to call STS endpoint', error);
+            Env.logger.error('Failed to call STS endpoint', {
+                vertesia: {
+                    account_id: accountId,
+                    project_id: projectId,
+                    error: error,
+                },
+            });
+            throw new STSError('Failed to call STS endpoint', stsEndpoint);
         });
 
         if (idToken && stsRes?.status === 404) {
@@ -207,8 +217,8 @@ export async function fetchComposableToken(getIdToken: () => Promise<string | nu
         return token;
 
     } catch (error) {
-        if (error instanceof UserNotFoundError) {
-            throw error; // Re-throw UserNotFoundError
+        if (error instanceof UserNotFoundError || error instanceof STSError) {
+            throw error; // Re-throw UserNotFoundError and STSError to be handled separately in the caller
         }
 
         // Clear any stale account/project from localStorage on error
@@ -291,5 +301,14 @@ export class UserNotFoundError extends Error {
         super(message);
         this.name = 'UserNotFoundError';
         this.email = email;
+    }
+}
+
+export class STSError extends Error {
+    sts: string;
+    constructor(message: string, sts: string) {
+        super(message);
+        this.name = 'STSError';
+        this.sts = sts;
     }
 }


### PR DESCRIPTION
## Description
- Before, whenever there was an error during the token exchange process, it would only throw either ' userNotFound` or `Error.`
- Which would lead to infinity loop between the studio and the central auth

## Fix
- If the error is sts fetch failed, it would clean the session and redirect the user to the login page, instead of bouncing directly between pages