### PR TITLE
Feat: agent interaction info

### DIFF
--- a/packages/common/src/interaction.ts
+++ b/packages/common/src/interaction.ts
@@ -368,6 +368,8 @@ export enum InteractionStatus {
     draft = "draft",
     published = "published",
     archived = "archived",
+    code = "code", // for in-code interactions that are not stored in the database
+    unknown = "unknown", // for interactions with unknown status
 }
 
 export enum ExecutionRunStatus {

--- a/packages/common/src/refs.ts
+++ b/packages/common/src/refs.ts
@@ -28,4 +28,7 @@ export interface ResourceRef {
     type: string
     description?: string
     version?: number
+    status?: string
+    tags?: string[]
+    endpoint?: string
 }

--- a/packages/common/src/store/agent-run.ts
+++ b/packages/common/src/store/agent-run.ts
@@ -12,7 +12,7 @@
  * (workflowId, runId) are internal server concerns.
  */
 
-import { AgentSearchScope, ConversationVisibility, InteractionExecutionConfiguration, RunSource } from "../interaction.js";
+import { AgentSearchScope, ConversationVisibility, InteractionExecutionConfiguration, InteractionRef, RunSource } from "../interaction.js";
 import { UserChannel } from "../email.js";
 import { ContentObjectTypeRef } from "./store.js";
 import { ConversationActivityState } from "./workflow.js";
@@ -119,6 +119,8 @@ export interface AgentRun<TData = Record<string, any>, TProperties = Record<stri
 
     /** Human-readable interaction name */
     interaction_name?: string;
+
+    interaction_info: InteractionRef;
 
     // --- Lifecycle ---
 

--- a/packages/common/src/store/agent-run.ts
+++ b/packages/common/src/store/agent-run.ts
@@ -120,7 +120,7 @@ export interface AgentRun<TData = Record<string, any>, TProperties = Record<stri
     /** Human-readable interaction name */
     interaction_name?: string;
 
-    interaction_info: InteractionRef;
+    interactionRef: InteractionRef;
 
     // --- Lifecycle ---
 

--- a/packages/common/src/workflow-analytics.ts
+++ b/packages/common/src/workflow-analytics.ts
@@ -690,6 +690,10 @@ export interface AgentFilterOption {
     id: string;
     /** The display name (resolved from interaction) */
     name: string;
+    /** Interaction status (published, archived, code, etc.) */
+    status?: string;
+    /** Interaction version number */
+    version?: number;
 }
 
 /**

--- a/packages/ui/src/core/components/shadcn/tabs.tsx
+++ b/packages/ui/src/core/components/shadcn/tabs.tsx
@@ -153,7 +153,13 @@ const Tabs = ({
   );
 };
 
-const TabsBar = ({ className, sticky }: { className?: string; sticky?: boolean }) => {
+interface TabsBarProps {
+  className?: string;
+  sticky?: boolean;
+  direction?: "vertical" | "horizontal";
+}
+
+const TabsBar = ({ className, sticky, direction }: TabsBarProps) => {
   const { tabs, size, current, setTab, responsive, variant, updateHash } = React.useContext(TabsContext);
 
   const fullWidth = size !== 0;
@@ -194,10 +200,17 @@ const TabsBar = ({ className, sticky }: { className?: string; sticky?: boolean }
           />
         </div>
       )}
-      <TabsList size={size} variant={variant} className={cn((fullWidth ? "w-full" : ""), sticky && "sticky top-0 bg-background z-10", className, (responsive ? "hidden lg:flex" : ""))}>
+      <TabsList size={size} variant={variant}
+        className={cn((
+          fullWidth ? "w-full" : ""),
+          sticky && "sticky top-0 bg-background z-10",
+          direction === "vertical" ? "flex-col items-start" : "flex-row",
+          responsive ? "hidden lg:flex" : "",
+          className)}>
         {tabs.map((tab) => (
 
           <TabsTrigger
+            className={cn(direction === "vertical" ? "w-full" : "")}
             key={tab.name}
             value={tab.name}
             disabled={tab.disabled}

--- a/packages/ui/src/core/components/shadcn/tabs.tsx
+++ b/packages/ui/src/core/components/shadcn/tabs.tsx
@@ -210,7 +210,7 @@ const TabsBar = ({ className, sticky, direction }: TabsBarProps) => {
         {tabs.map((tab) => (
 
           <TabsTrigger
-            className={cn(direction === "vertical" ? "w-full" : "")}
+            className={cn(direction === "vertical" ? "w-full text-left" : "")}
             key={tab.name}
             value={tab.name}
             disabled={tab.disabled}

--- a/packages/ui/src/features/facets/index.ts
+++ b/packages/ui/src/features/facets/index.ts
@@ -3,6 +3,7 @@ export * from "./utils/SearchInterface";
 export { StringFacet } from "./utils/StringFacet";
 export { StringListFacet } from "./utils/StringListFacet";
 export { TypeFacet } from "./utils/TypeFacet";
+export { VInteractionFacet } from "./utils/VInteractionFacet";
 export { VStringFacet } from "./utils/VStringFacet";
 export { VTypeFacet } from "./utils/VTypeFacet";
 export { VUserFacet } from "./utils/VUserFacet";

--- a/packages/ui/src/features/facets/utils/VInteractionFacet.tsx
+++ b/packages/ui/src/features/facets/utils/VInteractionFacet.tsx
@@ -41,9 +41,6 @@ export function VInteractionFacet({ buckets, name, placeholder }: InteractionFac
                     case InteractionStatus.code:
                         badgeVariant = "info";
                         break;
-                    default:
-                        badgeVariant = "default";
-                        break;
                 }
             }
 
@@ -61,7 +58,7 @@ export function VInteractionFacet({ buckets, name, placeholder }: InteractionFac
                             </Badge>
                         )}
                     </div>
-                    <span className="ml-2 text-xs shrink-0">({bucket?.count || 0})</span>
+                    {(bucket?.count ?? 0) > 0 && <span className="ml-2 text-xs shrink-0">({bucket!.count})</span>}
                 </div>
             );
         },

--- a/packages/ui/src/features/facets/utils/VInteractionFacet.tsx
+++ b/packages/ui/src/features/facets/utils/VInteractionFacet.tsx
@@ -27,25 +27,28 @@ export function VInteractionFacet({ buckets, name, placeholder }: InteractionFac
         labelRenderer: (interactionId: string) => {
             const bucket = buckets.find(b => b._id === interactionId);
             const displayName = bucket?.name || interactionId;
-            
+
             // Determine badge variant based on status
-            let badgeVariant: "success" | "attention" | "destructive" = "success";
+            let badgeVariant: "success" | "info" | "destructive" | "default" = "success";
             if (bucket?.status) {
                 switch (bucket.status) {
-                    case InteractionStatus.published: 
-                        badgeVariant = "success"; 
+                    case InteractionStatus.published:
+                        badgeVariant = "success";
                         break;
-                    case InteractionStatus.archived: 
-                        badgeVariant = "destructive"; 
+                    case InteractionStatus.archived:
+                        badgeVariant = "destructive";
                         break;
-                    default: 
-                        badgeVariant = "attention"; 
+                    case InteractionStatus.code:
+                        badgeVariant = "info";
+                        break;
+                    default:
+                        badgeVariant = "default";
                         break;
                 }
             }
-            
-            const badgeText = bucket?.version && bucket?.status ? 
-                `v${bucket.version} ${bucket.status}` : 
+
+            const badgeText = (bucket?.version && bucket?.status) ?
+                `v${bucket.version} ${bucket.status != InteractionStatus.unknown ? bucket.status : ''}` :
                 bucket?.status || (bucket?.version ? `v${bucket.version}` : '');
 
             return (


### PR DESCRIPTION
## Description

### Agents Runs
- When fetching the agent's history run, we would need the full interaction information, rather than just the name 
- Update the ref to include the minimum requirement 

### Tabs
- add vertical possibility for tab bar, as an example below
<img width="1861" height="891" alt="Screenshot 2026-04-23 at 15 13 54" src="https://github.com/user-attachments/assets/29223dfe-241f-4879-9fb3-0ed9984ae5a0" />
