### PR TITLE
feat: add cursor pagination metadata to agent runs list

### DIFF
--- a/packages/client/src/store/AgentsApi.ts
+++ b/packages/client/src/store/AgentsApi.ts
@@ -15,6 +15,7 @@ import {
     FirstResponseBehaviorAnalyticsResponse,
     LatencyAnalyticsResponse,
     ListAgentRunsQuery,
+    ListAgentRunsResponse,
     ListWorkflowRunsResponse,
     parseMessage,
     PromptSizeAnalyticsResponse,
@@ -82,7 +83,7 @@ export class AgentsApi extends ApiTopic {
     /**
      * List agent runs with optional filters.
      */
-    list(query?: ListAgentRunsQuery): Promise<AgentRun[]> {
+    list(query?: ListAgentRunsQuery): Promise<ListAgentRunsResponse> {
         const params: Record<string, string> = {};
         if (query?.id) params.id = query.id;
         if (query?.status) {
@@ -96,6 +97,7 @@ export class AgentsApi extends ApiTopic {
         if (query?.type) params.type = query.type;
         if (query?.limit) params.limit = String(query.limit);
         if (query?.offset) params.offset = String(query.offset);
+        if (query?.cursor) params.cursor = query.cursor;
         if (query?.sort) params.sort = query.sort;
         if (query?.order) params.order = query.order;
         return this.get('/', { query: params });

--- a/packages/common/src/store/agent-run.ts
+++ b/packages/common/src/store/agent-run.ts
@@ -233,6 +233,9 @@ export interface ListAgentRunsQuery {
     /** Offset for pagination */
     offset?: number;
 
+    /** Cursor for stable pagination */
+    cursor?: string;
+
     /** Filter by schedule ID */
     schedule_id?: string;
 
@@ -244,6 +247,12 @@ export interface ListAgentRunsQuery {
 
     /** Sort order */
     order?: 'asc' | 'desc';
+}
+
+export interface ListAgentRunsResponse {
+    items: AgentRun[];
+    total_count: number;
+    next_cursor: string | null;
 }
 
 /**

--- a/templates/plugin-template/src/ui/PluginSidebar.tsx
+++ b/templates/plugin-template/src/ui/PluginSidebar.tsx
@@ -68,7 +68,7 @@ export function PluginSidebar() {
             limit: 20,
             sort: 'started_at',
             order: 'desc',
-        }).then(runs => setConversations(runs.map(r => ({
+        }).then(response => setConversations(response.items.map(r => ({
             run_id: r.id,
             workflow_id: r.workflow_id,
             started_at: r.started_at ? new Date(r.started_at).toISOString() : null,


### PR DESCRIPTION
## Summary
- add cursor-aware query and paged response types for agent runs listing
- update the client and plugin template to consume the paged agents.list() response

## Test Plan
- [x] pnpm --prefix composableai/packages/common build
- [x] pnpm --prefix composableai/packages/client build
