### PR TITLE
chore: update fast-xml-parser to 5.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
       "qs@>=6.0.0 <6.14.0": "^6.14.1",
       "lodash-es@<4.18.1": "^4.18.1",
       "lodash@<4.18.1": "^4.18.1",
-      "fast-xml-parser@<5.3.8": "^5.5.7",
+      "fast-xml-parser@<5.7.2": "^5.7.2",
       "@eslint/config-array": "^0.23.3",
       "minimatch@>=3.0.0 <4.0.0": "legacy-v3",
       "minimatch@>=5.0.0 <6.0.0": "legacy-v5",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -57,7 +57,7 @@
     "dayjs": "^1.11.19",
     "debounce": "^2.2.0",
     "dompurify": "^3.3.2",
-    "fast-xml-parser": "^5.5.7",
+    "fast-xml-parser": "^5.7.2",
     "firebase": "^10.12.2",
     "framer-motion": "^12.23.12",
     "i18next": "^26.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ overrides:
   qs@>=6.0.0 <6.14.0: ^6.14.1
   lodash-es@<4.18.1: ^4.18.1
   lodash@<4.18.1: ^4.18.1
-  fast-xml-parser@<5.3.8: ^5.5.7
+  fast-xml-parser@<5.7.2: ^5.7.2
   '@eslint/config-array': ^0.23.3
   minimatch@>=3.0.0 <4.0.0: legacy-v3
   minimatch@>=5.0.0 <6.0.0: legacy-v5
@@ -856,8 +856,8 @@ importers:
         specifier: ^3.4.0
         version: 3.4.0
       fast-xml-parser:
-        specifier: ^5.5.7
-        version: 5.5.7
+        specifier: ^5.7.2
+        version: 5.7.2
       firebase:
         specifier: ^10.12.2
         version: 10.14.1
@@ -2742,6 +2742,9 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
@@ -5510,11 +5513,11 @@ packages:
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
-  fast-xml-builder@1.1.4:
-    resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
+  fast-xml-builder@1.1.5:
+    resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
 
-  fast-xml-parser@5.5.7:
-    resolution: {integrity: sha512-LteOsISQ2GEiDHZch6L9hB0+MLoYVLToR7xotrzU0opCICBkxOPgHAy1HxAvtxfJNXDJpgAsQN30mkrfpO2Prg==}
+  fast-xml-parser@5.7.2:
+    resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
     hasBin: true
 
   faye-websocket@0.11.4:
@@ -6870,8 +6873,8 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
-  path-expression-matcher@1.1.3:
-    resolution: {integrity: sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==}
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
     engines: {node: '>=14.0.0'}
 
   path-is-absolute@1.0.1:
@@ -7465,8 +7468,8 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  strnum@2.2.1:
-    resolution: {integrity: sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==}
+  strnum@2.2.3:
+    resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -8872,7 +8875,7 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.5':
     dependencies:
       '@smithy/types': 4.12.0
-      fast-xml-parser: 5.5.7
+      fast-xml-parser: 5.7.2
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.3': {}
@@ -10052,6 +10055,8 @@ snapshots:
     optional: true
 
   '@noble/hashes@1.8.0': {}
+
+  '@nodable/entities@2.1.0': {}
 
   '@paralleldrive/cuid2@2.3.1':
     dependencies:
@@ -13157,15 +13162,16 @@ snapshots:
     dependencies:
       fast-string-width: 3.0.2
 
-  fast-xml-builder@1.1.4:
+  fast-xml-builder@1.1.5:
     dependencies:
-      path-expression-matcher: 1.1.3
+      path-expression-matcher: 1.5.0
 
-  fast-xml-parser@5.5.7:
+  fast-xml-parser@5.7.2:
     dependencies:
-      fast-xml-builder: 1.1.4
-      path-expression-matcher: 1.1.3
-      strnum: 2.2.1
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.1.5
+      path-expression-matcher: 1.5.0
+      strnum: 2.2.3
 
   faye-websocket@0.11.4:
     dependencies:
@@ -14950,7 +14956,7 @@ snapshots:
 
   path-exists@4.0.0: {}
 
-  path-expression-matcher@1.1.3: {}
+  path-expression-matcher@1.5.0: {}
 
   path-is-absolute@1.0.1: {}
 
@@ -15682,7 +15688,7 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  strnum@2.2.1: {}
+  strnum@2.2.3: {}
 
   style-to-js@1.1.21:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,3 +17,5 @@ minimumReleaseAgeExclude:
   - hono@4.12.12 || 4.12.14
   # Renovate security update: dompurify@3.4.0
   - dompurify@3.4.0
+  # Renovate security update: fast-xml-parser@5.7.2
+  - fast-xml-parser@5.7.2


### PR DESCRIPTION
## Summary

- Update `fast-xml-parser` usage in `packages/ui` to `^5.7.2`.
- Update the pnpm override from the older `5.5.7` floor to `^5.7.2`.
- Add a narrow `minimumReleaseAgeExclude` entry for `fast-xml-parser@5.7.2` so the security update can install before the global 3-day release-age window elapses.
- Refresh `pnpm-lock.yaml` for the resolved `5.7.2` dependency graph.

## Validation

- `pnpm install --no-frozen-lockfile` in `composableai`
- From the parent workspace, `pnpm exec tsc -v` returned `Version 6.0.2`