### PR TITLE
feat: add CLI data import commands

### DIFF
--- a/packages/cli/src/agent-context.ts
+++ b/packages/cli/src/agent-context.ts
@@ -1,0 +1,37 @@
+export function getAgentRunId(options: Record<string, unknown> = {}): string {
+    const runId =
+        getStringOption(options.runId)
+        || process.env.VERTESIA_AGENTRUN_ID
+        || process.env.VERTESIA_RUN_ID;
+
+    if (!runId) {
+        console.error(
+            "Error: Agent run ID not specified. Use --run-id or set VERTESIA_AGENTRUN_ID",
+        );
+        process.exit(1);
+    }
+
+    return runId;
+}
+
+export function getArtifactStorageId(options: Record<string, unknown> = {}): string {
+    const storageId =
+        getStringOption(options.runId)
+        || getStringOption(options.storageId)
+        || process.env.VERTESIA_ARTIFACT_STORAGE_ID
+        || process.env.VERTESIA_AGENTRUN_ID
+        || process.env.VERTESIA_RUN_ID;
+
+    if (!storageId) {
+        console.error(
+            "Error: Artifact storage ID not specified. Use --run-id or set VERTESIA_ARTIFACT_STORAGE_ID",
+        );
+        process.exit(1);
+    }
+
+    return storageId;
+}
+
+function getStringOption(value: unknown): string | undefined {
+    return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}

--- a/packages/cli/src/artifacts/commands.ts
+++ b/packages/cli/src/artifacts/commands.ts
@@ -4,6 +4,7 @@ import { basename } from "path";
 import { pipeline } from "stream/promises";
 import { Readable } from "stream";
 import { NodeStreamSource } from "@vertesia/client/node";
+import { getArtifactStorageId } from "../agent-context.js";
 import { getClient } from "../client.js";
 
 // Artifact storage prefix - matches the client's ARTIFACTS_PREFIX
@@ -13,12 +14,7 @@ const ARTIFACTS_PREFIX = "agents";
  * Get run ID from options or environment variable
  */
 function getRunId(options: Record<string, any>): string {
-    const runId = options.runId || process.env.VERTESIA_RUN_ID;
-    if (!runId) {
-        console.error("Error: Run ID not specified. Use --run-id or set VERTESIA_RUN_ID env var");
-        process.exit(1);
-    }
-    return runId;
+    return getArtifactStorageId(options);
 }
 
 export async function uploadArtifact(program: Command, file: string | undefined, options: Record<string, any>) {

--- a/packages/cli/src/artifacts/index.ts
+++ b/packages/cli/src/artifacts/index.ts
@@ -3,11 +3,11 @@ import { downloadArtifact, getArtifactUrl, listArtifacts, uploadArtifact } from 
 
 export function registerArtifactsCommand(program: Command) {
     const artifacts = program.command("artifacts")
-        .description("Manage agent artifacts. Run ID can be inferred from VERTESIA_RUN_ID env var.");
+        .description("Manage agent artifacts. Storage ID can be inferred from VERTESIA_ARTIFACT_STORAGE_ID, VERTESIA_AGENTRUN_ID, or VERTESIA_RUN_ID.");
 
     artifacts.command("upload [file]")
         .description("Upload an artifact to the current agent run. Use '-' or omit file to read from stdin.")
-        .option("--run-id [runId]", "Run ID (defaults to VERTESIA_RUN_ID env var)")
+        .option("--run-id [runId]", "Artifact storage ID (defaults to VERTESIA_ARTIFACT_STORAGE_ID, then VERTESIA_AGENTRUN_ID)")
         .option("--name [name]", "Artifact name (required for stdin, defaults to filename otherwise)")
         .option("--mime [mimeType]", "MIME type of the file")
         .action(async (file: string | undefined, options: Record<string, any>) => {
@@ -16,7 +16,7 @@ export function registerArtifactsCommand(program: Command) {
 
     artifacts.command("download <name>")
         .description("Download an artifact from an agent run")
-        .option("--run-id [runId]", "Run ID (defaults to VERTESIA_RUN_ID env var)")
+        .option("--run-id [runId]", "Artifact storage ID (defaults to VERTESIA_ARTIFACT_STORAGE_ID, then VERTESIA_AGENTRUN_ID)")
         .option("-o, --output [path]", "Output file path (defaults to stdout)")
         .action(async (name: string, options: Record<string, any>) => {
             await downloadArtifact(program, name, options);
@@ -24,14 +24,14 @@ export function registerArtifactsCommand(program: Command) {
 
     artifacts.command("list")
         .description("List artifacts for an agent run")
-        .option("--run-id [runId]", "Run ID (defaults to VERTESIA_RUN_ID env var)")
+        .option("--run-id [runId]", "Artifact storage ID (defaults to VERTESIA_ARTIFACT_STORAGE_ID, then VERTESIA_AGENTRUN_ID)")
         .action(async (options: Record<string, any>) => {
             await listArtifacts(program, options);
         });
 
     artifacts.command("url <name>")
         .description("Get download URL for an artifact")
-        .option("--run-id [runId]", "Run ID (defaults to VERTESIA_RUN_ID env var)")
+        .option("--run-id [runId]", "Artifact storage ID (defaults to VERTESIA_ARTIFACT_STORAGE_ID, then VERTESIA_AGENTRUN_ID)")
         .action(async (name: string, options: Record<string, any>) => {
             await getArtifactUrl(program, name, options);
         });

--- a/packages/cli/src/data/commands.ts
+++ b/packages/cli/src/data/commands.ts
@@ -1,0 +1,182 @@
+import { NodeStreamSource } from "@vertesia/client/node";
+import { DataStoreItem, ImportDataFormat, ImportDataPayload, ImportTableData } from "@vertesia/common";
+import { Command } from "commander";
+import mime from "mime";
+import { randomUUID } from "node:crypto";
+import { basename, resolve } from "node:path";
+import { createReadStream } from "node:fs";
+import { getArtifactStorageId } from "../agent-context.js";
+import { getClient } from "../client.js";
+
+const IMPORT_MODES = new Set(["append", "replace"]);
+const IMPORT_FORMATS = new Set<ImportDataFormat>(["csv", "json", "parquet"]);
+
+export async function listDataStores(program: Command, options: Record<string, any>) {
+    const client = await getClient(program);
+    const stores = await client.data.list();
+
+    if (options.json) {
+        console.log(JSON.stringify(stores, null, 2));
+        return;
+    }
+
+    console.log("id\tname\tstatus\ttables\trows\tbytes");
+    stores.forEach((store: DataStoreItem) => {
+        console.log(
+            [
+                store.id,
+                store.name,
+                store.status,
+                store.table_count,
+                store.total_rows,
+                store.storage_bytes,
+            ].join("\t"),
+        );
+    });
+}
+
+export async function importData(program: Command, storeId: string, tableName: string, input: string | undefined, options: Record<string, any>) {
+    const client = await getClient(program);
+    const mode = normalizeMode(options.mode);
+    const source = await resolveImportSource(client, input, options);
+    const message = buildImportMessage(tableName, source.original, options.message);
+    const payload: ImportDataPayload = {
+        mode,
+        message,
+        tables: {
+            [tableName]: source.tableData,
+        },
+    };
+
+    const job = await client.data.import(storeId, payload);
+
+    if (options.json) {
+        console.log(JSON.stringify(job, null, 2));
+        return;
+    }
+
+    console.log(
+        `Import completed for ${tableName}. Job: ${job.id}. Status: ${job.status}. Rows imported: ${job.rows_imported ?? 0}.`,
+    );
+    if (source.uploadedUri) {
+        console.log(`Source uploaded to: ${source.uploadedUri}`);
+    }
+}
+
+function normalizeMode(rawMode: unknown): "append" | "replace" {
+    if (typeof rawMode !== "string" || rawMode.trim() === "") {
+        return "append";
+    }
+
+    const mode = rawMode.trim().toLowerCase();
+    if (!IMPORT_MODES.has(mode)) {
+        console.error(`Error: Invalid import mode '${rawMode}'. Expected append or replace.`);
+        process.exit(1);
+    }
+
+    return mode as "append" | "replace";
+}
+
+function normalizeFormat(rawFormat: unknown, fallbackName?: string): ImportDataFormat {
+    if (typeof rawFormat === "string" && rawFormat.trim() !== "") {
+        const format = rawFormat.trim().toLowerCase();
+        if (IMPORT_FORMATS.has(format as ImportDataFormat)) {
+            return format as ImportDataFormat;
+        }
+        console.error(`Error: Invalid format '${rawFormat}'. Expected csv, json, or parquet.`);
+        process.exit(1);
+    }
+
+    const inferred = inferFormatFromName(fallbackName);
+    if (inferred) {
+        return inferred;
+    }
+
+    console.error("Error: Could not infer import format. Pass --format csv|json|parquet.");
+    process.exit(1);
+}
+
+function inferFormatFromName(name?: string): ImportDataFormat | undefined {
+    if (!name) return undefined;
+    const lower = name.toLowerCase();
+    if (lower.endsWith(".csv")) return "csv";
+    if (lower.endsWith(".json") || lower.endsWith(".jsonl") || lower.endsWith(".ndjson")) return "json";
+    if (lower.endsWith(".parquet")) return "parquet";
+    return undefined;
+}
+
+async function resolveImportSource(
+    client: Awaited<ReturnType<typeof getClient>>,
+    input: string | undefined,
+    options: Record<string, any>,
+): Promise<{ tableData: ImportTableData; original: string; uploadedUri?: string }> {
+    const normalizedInput = typeof input === "string" && input.trim() !== "" ? input.trim() : "-";
+
+    if (normalizedInput.startsWith("gs://") || normalizedInput.startsWith("s3://")) {
+        return {
+            original: normalizedInput,
+            tableData: {
+                source: "gcs",
+                uri: normalizedInput,
+                format: normalizeFormat(options.format, normalizedInput),
+            },
+        };
+    }
+
+    if (normalizedInput.startsWith("http://") || normalizedInput.startsWith("https://")) {
+        return {
+            original: normalizedInput,
+            tableData: {
+                source: "url",
+                uri: normalizedInput,
+                format: normalizeFormat(options.format, normalizedInput),
+            },
+        };
+    }
+
+    const uploadName = resolveUploadName(normalizedInput, options.name);
+    const format = normalizeFormat(options.format, uploadName);
+    const uploadPath = buildImportUploadPath(uploadName, options);
+    const mimeType = options.mime || mime.getType(uploadName) || "application/octet-stream";
+    const source = normalizedInput === "-"
+        ? new NodeStreamSource(process.stdin, uploadName, mimeType, uploadPath)
+        : new NodeStreamSource(createReadStream(resolve(normalizedInput)), uploadName, mimeType, uploadPath);
+    const uploadedUri = await client.files.uploadFile(source);
+
+    return {
+        original: normalizedInput,
+        uploadedUri,
+        tableData: {
+            source: "gcs",
+            uri: uploadedUri,
+            format,
+        },
+    };
+}
+
+function resolveUploadName(input: string, explicitName: unknown): string {
+    if (typeof explicitName === "string" && explicitName.trim() !== "") {
+        return basename(explicitName.trim());
+    }
+
+    if (input === "-") {
+        console.error("Error: --name is required when importing from stdin.");
+        process.exit(1);
+    }
+
+    return basename(input);
+}
+
+function buildImportUploadPath(name: string, options: Record<string, any>): string {
+    const prefix = typeof options.prefix === "string" && options.prefix.trim() !== ""
+        ? options.prefix.trim().replace(/^\/+|\/+$/g, "")
+        : `imports/${getArtifactStorageId(options)}`;
+    return `${prefix}/${Date.now()}-${randomUUID()}-${name}`;
+}
+
+function buildImportMessage(tableName: string, original: string, explicitMessage: unknown): string {
+    if (typeof explicitMessage === "string" && explicitMessage.trim() !== "") {
+        return explicitMessage.trim();
+    }
+    return `Import ${original} into ${tableName} via vertesia CLI`;
+}

--- a/packages/cli/src/data/index.ts
+++ b/packages/cli/src/data/index.ts
@@ -1,0 +1,27 @@
+import { Command } from "commander";
+import { importData, listDataStores } from "./commands.js";
+
+export function registerDataCommand(program: Command) {
+    const data = program.command("data")
+        .description("Manage analytical data stores and imports");
+
+    data.command("list")
+        .description("List data stores in the current project")
+        .option("--json", "Output full JSON instead of tab-separated text")
+        .action(async (options: Record<string, any>) => {
+            await listDataStores(program, options);
+        });
+
+    data.command("import <storeId> <tableName> [input]")
+        .description("Import local files, stdin, or remote URIs directly into a data store table")
+        .option("--mode [mode]", "Import mode: append or replace", "append")
+        .option("--format [format]", "Input format: csv, json, or parquet. Inferred from filename when omitted.")
+        .option("--message [message]", "Version history message for the import")
+        .option("--name [name]", "Uploaded filename to use when reading from stdin or overriding a local filename")
+        .option("--mime [mimeType]", "MIME type for uploads from local files or stdin")
+        .option("--prefix [pathPrefix]", "Custom staging prefix in project storage for uploaded local files")
+        .option("--json", "Output full JSON instead of a short summary")
+        .action(async (storeId: string, tableName: string, input: string | undefined, options: Record<string, any>) => {
+            await importData(program, storeId, tableName, input, options);
+        });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,6 +3,7 @@ import { Command } from 'commander';
 import { registerAppsCommand } from './apps/index.js';
 import { registerArtifactsCommand } from './artifacts/index.js';
 import runExport from './codegen/index.js';
+import { registerDataCommand } from './data/index.js';
 import { genTestData } from './datagen/index.js';
 import { listEnvironments } from './envs/index.js';
 import { listInteractions } from './interactions/index.js';
@@ -130,6 +131,7 @@ setupMemoCommand(memoCmd, getPublishMemoryAction(program));
 registerWorkerCommand(program);
 registerAppsCommand(program);
 registerArtifactsCommand(program);
+registerDataCommand(program);
 
 const profilesRoot = program.command("profiles")
     .description("Manage configuration profiles")


### PR DESCRIPTION
## Summary
- add `vertesia data list` and `vertesia data import` commands for direct datastore operations
- resolve artifact storage context from `VERTESIA_ARTIFACT_STORAGE_ID`, `VERTESIA_AGENTRUN_ID`, and `VERTESIA_RUN_ID`
- align artifact CLI commands with agent/workstream storage namespaces

## Test Plan
- `pnpm exec tsc -p packages/cli/tsconfig.json --pretty false`
- `node packages/cli/bin/app.js data --help`