### PR TITLE
fix: extend agent artifact client options

### DIFF
--- a/packages/client/eslint.config.js
+++ b/packages/client/eslint.config.js
@@ -22,6 +22,7 @@ export default [
       '@typescript-eslint/no-unused-vars': ['warn', {
         argsIgnorePattern: '^_',
         varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
       }],
       '@typescript-eslint/no-unused-expressions': ['error', {
         allowShortCircuit: true,

--- a/packages/client/src/store/AgentsApi.ts
+++ b/packages/client/src/store/AgentsApi.ts
@@ -570,9 +570,11 @@ export class AgentsApi extends ApiTopic {
         id: string,
         path: string,
         disposition?: 'inline' | 'attachment',
+        fileName?: string,
     ): Promise<{ url: string; path: string }> {
         const query: Record<string, string> = { url: '1' };
         if (disposition) query.disposition = disposition;
+        if (fileName) query.filename = fileName;
         return this.get(`/${id}/artifacts/${path}`, { query });
     }
 

--- a/packages/client/src/store/AgentsApi.ts
+++ b/packages/client/src/store/AgentsApi.ts
@@ -2,14 +2,14 @@ import { ApiTopic, ClientBase } from '@vertesia/api-fetch-client';
 import {
     ActiveWorkstreamsQueryResult,
     AgentEvent,
+    AgentArtifactUrlResponse,
     AgentMessage,
     AgentMessageType,
     AgentRun,
-    AgentRunArchiveState,
+    AgentRunDetailsStreamEvent,
     AgentRunInternals,
-    AgentRunStatus,
+    AgentRunUpdatesResponse,
     CompactMessage,
-    ConversationActivityState,
     CreateAgentRunPayload,
     ErrorAnalyticsResponse,
     FirstResponseBehaviorAnalyticsResponse,
@@ -19,21 +19,30 @@ import {
     ListWorkflowRunsResponse,
     parseMessage,
     PromptSizeAnalyticsResponse,
+    PostAgentRunUpdatePayload,
+    PostAgentRunUpdateResponse,
+    RecordAgentRunPayload,
     RunsByAgentAnalyticsResponse,
     SearchAgentRunsQuery,
     SearchAgentRunsResponse,
+    SignalAgentPayload,
+    SignalAgentResponse,
     TimeToFirstResponseAnalyticsResponse,
+    TerminateAgentRunResponse,
     toAgentMessage,
     TokenUsageAnalyticsResponse,
     ToolAnalyticsResponse,
     ToolParameterAnalyticsResponse,
     TopPrincipalsAnalyticsResponse,
+    UpdateAgentRunStatusPayload,
     WorkflowAnalyticsFilterOptionsResponse,
     WorkflowAnalyticsSummaryQuery,
     WorkflowAnalyticsSummaryResponse,
     WorkflowAnalyticsTimeSeriesQuery,
     WorkflowRunWithDetails,
     WorkflowToolParametersQuery,
+    IngestAgentEventsPayload,
+    IngestAgentEventsResponse,
 } from '@vertesia/common';
 import { VertesiaClient } from '../client.js';
 import { EventSourceProvider } from '../execute.js';
@@ -51,7 +60,7 @@ export class AgentsApi extends ApiTopic {
      * Create and start a new agent run.
      * Returns the created AgentRun with its stable id.
      */
-    start<TData = Record<string, any>>(
+    start<TData = Record<string, unknown>>(
         payload: CreateAgentRunPayload<TData>,
     ): Promise<AgentRun<TData>> {
         return this.post('/', { payload });
@@ -61,22 +70,14 @@ export class AgentsApi extends ApiTopic {
      * Record an AgentRun for an already-running workflow (e.g. schedule-triggered).
      * Only creates the MongoDB document — the workflow passes its own Temporal IDs.
      */
-    createRecord(payload: {
-        interaction: string;
-        schedule_id?: string;
-        workflow_id: string;
-        first_workflow_run_id: string;
-        visibility?: string;
-        data?: Record<string, any>;
-        type?: string;
-    }): Promise<AgentRun> {
+    createRecord(payload: RecordAgentRunPayload): Promise<AgentRun> {
         return this.post('/record', { payload });
     }
 
     /**
      * Get agent run by id.
      */
-    retrieve<TData = Record<string, any>>(id: string): Promise<AgentRun<TData>> {
+    retrieve<TData = Record<string, unknown>>(id: string): Promise<AgentRun<TData>> {
         return this.get(`/${id}`);
     }
 
@@ -127,7 +128,7 @@ export class AgentsApi extends ApiTopic {
     /**
      * Cancel/terminate an agent run.
      */
-    terminate(id: string, reason?: string): Promise<{ message: string }> {
+    terminate(id: string, reason?: string): Promise<TerminateAgentRunResponse> {
         const query = reason ? { reason } : undefined;
         return this.del(`/${id}`, { query });
     }
@@ -155,20 +156,7 @@ export class AgentsApi extends ApiTopic {
      */
     updateStatus(
         id: string,
-        update: {
-            status?: AgentRunStatus;
-            activity_state?: ConversationActivityState;
-            title?: string;
-            topic?: string;
-            lessons_learned?: string[];
-            /** ES-only: conversation content text (not stored in MongoDB) */
-            content?: string;
-            // Archive state fields (set by the archive workflow)
-            archive_state?: AgentRunArchiveState;
-            archived_at?: string;
-            archive_version?: number;
-            last_archive_error?: string;
-        },
+        update: UpdateAgentRunStatusPayload,
     ): Promise<AgentRun> {
         return this.post(`/${id}/status`, { payload: update });
     }
@@ -181,7 +169,7 @@ export class AgentsApi extends ApiTopic {
      * Send a signal to a running agent.
      * Signals: "UserInput", "Stop", "FileUploaded"
      */
-    sendSignal(id: string, signalName: string, payload?: any): Promise<{ message: string }> {
+    sendSignal(id: string, signalName: string, payload?: SignalAgentPayload): Promise<SignalAgentResponse> {
         return this.post(`/${id}/signal/${signalName}`, { payload });
     }
 
@@ -210,16 +198,14 @@ export class AgentsApi extends ApiTopic {
      */
     async retrieveMessages(id: string, since?: number): Promise<AgentMessage[]> {
         const query = since ? { since } : undefined;
-        const response = (await this.get(`/${id}/updates`, { query })) as {
-            messages: CompactMessage[];
-        };
+        const response = await this.get(`/${id}/updates`, { query }) as AgentRunUpdatesResponse;
         return response.messages.map((m: CompactMessage) => toAgentMessage(m, id));
     }
 
     /**
      * Post a message/update to an agent run.
      */
-    postMessage(id: string, msg: Partial<AgentMessage>): Promise<void> {
+    postMessage(id: string, msg: PostAgentRunUpdatePayload): Promise<PostAgentRunUpdateResponse> {
         return this.post(`/${id}/updates`, { payload: msg });
     }
 
@@ -382,7 +368,7 @@ export class AgentsApi extends ApiTopic {
                     }
                 };
 
-                sse.onerror = (_err: any) => {
+                sse.onerror = (_err: unknown) => {
                     if (isClosed) return;
                     cleanup();
 
@@ -462,7 +448,7 @@ export class AgentsApi extends ApiTopic {
      */
     async streamRunDetails(
         id: string,
-        onEvent?: (event: { type: string; data: unknown }) => void,
+        onEvent?: (event: AgentRunDetailsStreamEvent) => void,
         signal?: AbortSignal,
     ): Promise<void> {
         const EventSourceImpl = await EventSourceProvider();
@@ -496,16 +482,16 @@ export class AgentsApi extends ApiTopic {
 
             sse.addEventListener('history', (ev: MessageEvent) => {
                 try {
-                    const data = JSON.parse(ev.data);
+                    const data = JSON.parse(ev.data) as Extract<AgentRunDetailsStreamEvent, { type: 'history' }>['data'];
                     if (onEvent) onEvent({ type: 'history', data });
                 } catch (_err) { /* ignore parse errors */ }
             });
 
             sse.addEventListener('control', (ev: MessageEvent) => {
                 try {
-                    const data = JSON.parse(ev.data);
+                    const data = JSON.parse(ev.data) as Extract<AgentRunDetailsStreamEvent, { type: 'control' }>['data'];
                     if (onEvent) onEvent({ type: 'control', data });
-                    if (data.type === 'done') {
+                    if ('type' in data && data.type === 'done') {
                         cleanup();
                         resolve();
                     }
@@ -514,7 +500,7 @@ export class AgentsApi extends ApiTopic {
 
             sse.addEventListener('error', (ev: MessageEvent) => {
                 try {
-                    const data = JSON.parse(ev.data);
+                    const data = JSON.parse(ev.data) as Extract<AgentRunDetailsStreamEvent, { type: 'error' }>['data'];
                     if (onEvent) onEvent({ type: 'error', data });
                 } catch (_err) { /* ignore parse errors */ }
             });
@@ -542,8 +528,8 @@ export class AgentsApi extends ApiTopic {
         childWorkflowId: string,
         options?: { includeHistory?: boolean },
     ): Promise<WorkflowRunWithDetails> {
-        const query: Record<string, any> = {};
-        if (options?.includeHistory) query.include_history = true;
+        const query: Record<string, string> = {};
+        if (options?.includeHistory) query.include_history = 'true';
         return this.get(`/${id}/children/${childWorkflowId}/details`, { query });
     }
 
@@ -571,7 +557,7 @@ export class AgentsApi extends ApiTopic {
         path: string,
         disposition?: 'inline' | 'attachment',
         fileName?: string,
-    ): Promise<{ url: string; path: string }> {
+    ): Promise<AgentArtifactUrlResponse> {
         const query: Record<string, string> = { url: '1' };
         if (disposition) query.disposition = disposition;
         if (fileName) query.filename = fileName;
@@ -592,13 +578,13 @@ export class AgentsApi extends ApiTopic {
         path: string,
         content: Blob | ReadableStream | ArrayBuffer | string,
         contentType?: string,
-    ): Promise<{ url: string; path: string }> {
+    ): Promise<AgentArtifactUrlResponse> {
         const mimeType = contentType || 'application/octet-stream';
 
         // 1. Get signed upload URL from the agents API
         const result = await this.put(`/${id}/artifacts/${path}`, {
             headers: { 'Content-Type': mimeType },
-        }) as { url: string; path: string };
+        }) as AgentArtifactUrlResponse;
 
         // 2. Upload directly to cloud storage
         const res = await fetch(result.url, {
@@ -643,8 +629,9 @@ export class AgentsApi extends ApiTopic {
     ingestEvents(
         agentRunId: string,
         events: AgentEvent[],
-    ): Promise<{ ingested: number; status?: string; error?: string }> {
-        return this.post(`/${agentRunId}/events`, { payload: { events } });
+    ): Promise<IngestAgentEventsResponse> {
+        const payload: IngestAgentEventsPayload = { events };
+        return this.post(`/${agentRunId}/events`, { payload });
     }
 
     // ========================================================================

--- a/packages/client/src/store/AgentsApi.ts
+++ b/packages/client/src/store/AgentsApi.ts
@@ -553,9 +553,14 @@ export class AgentsApi extends ApiTopic {
 
     /**
      * List artifacts for an agent run.
+     * visibility:
+     * - 'user' (default): only user-facing artifacts
+     * - 'internal': only system-managed state files such as conversation snapshots
+     * - 'all': both user-facing and internal files
      */
-    listArtifacts(id: string): Promise<string[]> {
-        return this.get(`/${id}/artifacts`);
+    listArtifacts(id: string, options?: { visibility?: 'user' | 'internal' | 'all' }): Promise<string[]> {
+        const query = options?.visibility ? { visibility: options.visibility } : undefined;
+        return this.get(`/${id}/artifacts`, { query });
     }
 
     /**

--- a/packages/common/src/store/agent-run.ts
+++ b/packages/common/src/store/agent-run.ts
@@ -14,8 +14,10 @@
 
 import { AgentSearchScope, ConversationVisibility, InteractionExecutionConfiguration, InteractionRef, RunSource } from "../interaction.js";
 import { UserChannel } from "../email.js";
+import { AgentEvent } from "../workflow-analytics.js";
+import { UserInputSignal } from "./signals.js";
 import { ContentObjectTypeRef } from "./store.js";
-import { ConversationActivityState } from "./workflow.js";
+import { AgentMessage, CompactMessage, ConversationActivityState, ConversationFileRef, WorkflowRunEvent } from "./workflow.js";
 
 /**
  * Status of an agent run through its lifecycle.
@@ -204,6 +206,138 @@ export interface CreateAgentRunPayload<TData = Record<string, any>, TProperties 
     /** Principal ref of the user who initiated the run (for server-to-server forwarding) */
     started_by?: string;
 }
+
+/**
+ * Payload to record an AgentRun for an already-running workflow.
+ *
+ * Used by server-side callers that have already started a Temporal workflow
+ * and need to create the stable AgentRun MongoDB document against it.
+ *
+ * @typeParam TData - The interaction's expected input data type.
+ */
+export interface RecordAgentRunPayload<TData = CreateAgentRunPayload["data"]> extends Pick<AgentRunBase<TData>, "interaction" | "data" | "schedule_id" | "visibility" | "type"> {
+    /** Temporal workflow ID (stable across continueAsNew) */
+    workflow_id: string;
+
+    /** First Temporal workflow run ID (stable stream/artifact identity) */
+    first_workflow_run_id: string;
+}
+
+/**
+ * Response from terminating an agent run.
+ */
+export interface TerminateAgentRunResponse {
+    message: string;
+    reason?: string;
+}
+
+/**
+ * Payload for updating an AgentRun's lifecycle and derived metadata.
+ */
+export interface UpdateAgentRunStatusPayload {
+    status?: AgentRunStatus;
+    activity_state?: ConversationActivityState;
+    title?: string;
+    topic?: string;
+    lessons_learned?: string[];
+    /** ES-only: conversation content text (not stored in MongoDB) */
+    content?: string;
+    /** Archive state fields (set by the archive workflow) */
+    archive_state?: AgentRunArchiveState;
+    archived_at?: string;
+    archive_version?: number;
+    last_archive_error?: string;
+}
+
+/**
+ * Generic signal payload sent to a running agent workflow.
+ */
+export type SignalAgentPayload =
+    | UserInputSignal
+    | ConversationFileRef
+    | Record<string, unknown>;
+
+/**
+ * Response from signaling an agent workflow.
+ */
+export interface SignalAgentResponse {
+    status: string;
+    message: string;
+}
+
+/**
+ * Response payload for retrieving compact agent updates.
+ */
+export interface AgentRunUpdatesResponse {
+    messages: CompactMessage[];
+}
+
+/**
+ * Payload for posting an update into an agent's workflow stream.
+ */
+export type PostAgentRunUpdatePayload = Partial<AgentMessage>;
+
+/**
+ * Response from posting an agent update.
+ */
+export interface PostAgentRunUpdateResponse {
+    success: boolean;
+}
+
+/**
+ * Signed artifact URL response for agent artifacts.
+ */
+export interface AgentArtifactUrlResponse {
+    url: string;
+    path: string;
+}
+
+/**
+ * Telemetry ingestion payload for an agent run.
+ */
+export interface IngestAgentEventsPayload {
+    events: AgentEvent[];
+}
+
+/**
+ * Telemetry ingestion response for an agent run.
+ */
+export interface IngestAgentEventsResponse {
+    ingested: number;
+    status?: string;
+    error?: string;
+}
+
+/**
+ * History event payload emitted by the agent details SSE stream.
+ */
+export interface AgentRunDetailsHistoryStreamEvent {
+    runId?: string;
+    event: WorkflowRunEvent;
+}
+
+/**
+ * Control payload emitted by the agent details SSE stream.
+ */
+export type AgentRunDetailsControlStreamEvent =
+    | { type: 'continueAsNew'; newRunId: string }
+    | { type: 'done' };
+
+/**
+ * Error payload emitted by the agent details SSE stream.
+ */
+export interface AgentRunDetailsErrorStreamEvent {
+    type: 'error';
+    message: string;
+}
+
+/**
+ * Typed SSE event envelope for the agent details stream.
+ */
+export type AgentRunDetailsStreamEvent =
+    | { type: 'history'; data: AgentRunDetailsHistoryStreamEvent }
+    | { type: 'control'; data: AgentRunDetailsControlStreamEvent }
+    | { type: 'error'; data: AgentRunDetailsErrorStreamEvent };
 
 /**
  * Filters for listing agent runs.


### PR DESCRIPTION
## Summary
- add artifact visibility filtering to `AgentsApi.listArtifacts`
- add optional download filename support to `AgentsApi.getArtifactUrl`

## Test Plan
- not run (client/package changes only)
