### PR TITLE
fix: expose integration secret status types

### DIFF
--- a/packages/client/src/ProjectsApi.ts
+++ b/packages/client/src/ProjectsApi.ts
@@ -1,5 +1,5 @@
 import { ApiTopic, ClientBase, ServerError } from "@vertesia/api-fetch-client";
-import { AwsConfiguration, CompositeAppConfig, CompositeAppConfigPayload, GithubConfiguration, GladiaConfiguration, ICreateProjectPayload, InCodeTypeDefinition, MagicPdfConfiguration, Project, ProjectConfiguration, ProjectIntegrationListEntry, ProjectRef, ProjectToolInfo, RenderingTemplateDefinition, RenderingTemplateDefinitionRef, SupportedIntegrations } from "@vertesia/common";
+import { AwsConfiguration, CompositeAppConfig, CompositeAppConfigPayload, ExaConfiguration, GithubConfiguration, GladiaConfiguration, ICreateProjectPayload, InCodeTypeDefinition, LinkupConfiguration, MagicPdfConfiguration, Project, ProjectConfiguration, ProjectIntegrationListEntry, ProjectRef, ProjectToolInfo, RenderingTemplateDefinition, RenderingTemplateDefinitionRef, ResendConfiguration, SerperConfiguration, SupportedIntegrations } from "@vertesia/common";
 
 export default class ProjectsApi extends ApiTopic {
     constructor(parent: ClientBase) {
@@ -97,7 +97,7 @@ class IntegrationsConfigurationApi extends ApiTopic {
         return this.get(`/${projectId}/integrations`).then(res => res.integrations);
     }
 
-    retrieve(projectId: string, integrationId: SupportedIntegrations): Promise<GladiaConfiguration | GithubConfiguration | AwsConfiguration | MagicPdfConfiguration | undefined> {
+    retrieve(projectId: string, integrationId: SupportedIntegrations): Promise<GladiaConfiguration | GithubConfiguration | AwsConfiguration | MagicPdfConfiguration | SerperConfiguration | ExaConfiguration | LinkupConfiguration | ResendConfiguration | undefined> {
         return this.get(`/${projectId}/integrations/${integrationId}`).catch(err => {
             if (err.status === 404) {
                 return undefined;

--- a/packages/common/src/integrations.ts
+++ b/packages/common/src/integrations.ts
@@ -69,6 +69,7 @@ export interface AskUserWebhookConfiguration extends IntegrationConfigurationBas
     webhook_url: string;
     /** Secret for signing webhook payloads (HMAC-SHA256) */
     webhook_secret?: string;
+    has_webhook_secret?: boolean;
     /** Which events to send: ['requested', 'resolved'] or subset (default: both) */
     events?: ('requested' | 'resolved')[];
     /** Custom headers to include in webhook requests */

--- a/packages/common/src/integrations.ts
+++ b/packages/common/src/integrations.ts
@@ -5,7 +5,8 @@ export interface IntegrationConfigurationBase {
 }
 
 export interface GladiaConfiguration extends IntegrationConfigurationBase {
-    api_key: string;
+    api_key?: string;
+    has_api_key?: boolean;
     url?: string;
 }
 
@@ -25,27 +26,32 @@ export interface MagicPdfConfiguration extends IntegrationConfigurationBase {
 }
 
 export interface SerperConfiguration extends IntegrationConfigurationBase {
-    api_key: string;
+    api_key?: string;
+    has_api_key?: boolean;
     url?: string;
 }
 
 export interface ExaConfiguration extends IntegrationConfigurationBase {
-    api_key: string;
+    api_key?: string;
+    has_api_key?: boolean;
 }
 
 export interface LinkupConfiguration extends IntegrationConfigurationBase {
-    api_key: string;
+    api_key?: string;
+    has_api_key?: boolean;
 }
 
 export interface ResendConfiguration extends IntegrationConfigurationBase {
     /** Resend API key for sending emails */
-    api_key: string;
+    api_key?: string;
+    has_api_key?: boolean;
     /** Domain for email (both sending and receiving). Must be verified in Resend. */
     email_domain: string;
     /** Default display name for outgoing emails (e.g., "Vertesia - Project Name") */
     default_from_name?: string;
     /** Webhook secret for validating inbound email webhooks (required for receiving emails) */
-    webhook_secret: string;
+    webhook_secret?: string;
+    has_webhook_secret?: boolean;
     /** Domains allowed to send emails TO start agents (for inbound validation) */
     allowed_sender_domains?: string[];
     /** Require sender to have project access to start agents via email (default: true) */

--- a/packages/common/src/integrations.ts
+++ b/packages/common/src/integrations.ts
@@ -7,6 +7,7 @@ export interface IntegrationConfigurationBase {
 export interface GladiaConfiguration extends IntegrationConfigurationBase {
     api_key?: string;
     has_api_key?: boolean;
+    api_key_hint?: string;
     url?: string;
 }
 
@@ -28,23 +29,27 @@ export interface MagicPdfConfiguration extends IntegrationConfigurationBase {
 export interface SerperConfiguration extends IntegrationConfigurationBase {
     api_key?: string;
     has_api_key?: boolean;
+    api_key_hint?: string;
     url?: string;
 }
 
 export interface ExaConfiguration extends IntegrationConfigurationBase {
     api_key?: string;
     has_api_key?: boolean;
+    api_key_hint?: string;
 }
 
 export interface LinkupConfiguration extends IntegrationConfigurationBase {
     api_key?: string;
     has_api_key?: boolean;
+    api_key_hint?: string;
 }
 
 export interface ResendConfiguration extends IntegrationConfigurationBase {
     /** Resend API key for sending emails */
     api_key?: string;
     has_api_key?: boolean;
+    api_key_hint?: string;
     /** Domain for email (both sending and receiving). Must be verified in Resend. */
     email_domain: string;
     /** Default display name for outgoing emails (e.g., "Vertesia - Project Name") */
@@ -52,6 +57,7 @@ export interface ResendConfiguration extends IntegrationConfigurationBase {
     /** Webhook secret for validating inbound email webhooks (required for receiving emails) */
     webhook_secret?: string;
     has_webhook_secret?: boolean;
+    webhook_secret_hint?: string;
     /** Domains allowed to send emails TO start agents (for inbound validation) */
     allowed_sender_domains?: string[];
     /** Require sender to have project access to start agents via email (default: true) */
@@ -70,6 +76,7 @@ export interface AskUserWebhookConfiguration extends IntegrationConfigurationBas
     /** Secret for signing webhook payloads (HMAC-SHA256) */
     webhook_secret?: string;
     has_webhook_secret?: boolean;
+    webhook_secret_hint?: string;
     /** Which events to send: ['requested', 'resolved'] or subset (default: both) */
     events?: ('requested' | 'resolved')[];
     /** Custom headers to include in webhook requests */

--- a/packages/workflow/src/activities/media/saveGladiaTranscription.ts
+++ b/packages/workflow/src/activities/media/saveGladiaTranscription.ts
@@ -32,6 +32,14 @@ export async function saveGladiaTranscription(payload: DSLActivityExecutionPaylo
             error: "Gladia integration not enabled",
         };
     }
+    if (!gladiaConfig.api_key) {
+        return {
+            hasText: false,
+            objectId: inputType === 'objectIds' ? context.objectId : undefined,
+            status: TextExtractionStatus.error,
+            error: "Gladia API key not configured",
+        };
+    }
 
     const gladiaClient = new FetchClient(gladiaConfig.url ?? GLADIA_URL);
     gladiaClient.withHeaders({ "x-gladia-key": gladiaConfig.api_key });

--- a/packages/workflow/src/activities/media/transcribeMediaWithGladia.ts
+++ b/packages/workflow/src/activities/media/transcribeMediaWithGladia.ts
@@ -41,6 +41,14 @@ export async function transcribeMedia(payload: DSLActivityExecutionPayload<Trans
             error: "Gladia integration not enabled",
         }
     }
+    if (!gladiaConfig.api_key) {
+        return {
+            hasText: false,
+            objectId: inputType === 'objectIds' ? context.objectId : undefined,
+            status: TextExtractionStatus.error,
+            error: "Gladia API key not configured",
+        }
+    }
 
     const gladiaClient = new FetchClient(gladiaConfig.url ?? GLADIA_URL);
     gladiaClient.withHeaders({ "x-gladia-key": gladiaConfig.api_key });


### PR DESCRIPTION
## Summary
- make integration secret fields optional in shared common types
- add UI-safe secret status flags for API-key and webhook-secret integrations
- add masked secret hint fields so the UI can show placeholders like `http...dev1` without exposing plaintext

## Test Plan
- pnpm --prefix composableai/packages/common build (passed)
- pnpm --prefix composableai/packages/common test (passed: 1 file, 41 tests)
- pnpm --prefix apps/composable-ui build (passed, dependent UI build)
- pnpm --prefix apps/composable-ui test (passed: 3 files, 42 tests)