### PR TITLE
fix: add shard embedding dimension params

### DIFF
--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -391,6 +391,12 @@ export interface CreateReindexTargetResult {
     index_name: string;
     alias_name: string;
     version: number;
+    dimensions?: {
+        text?: number;
+        image?: number;
+        properties?: number;
+    };
+    language?: string;
 }
 
 /**
@@ -455,6 +461,11 @@ export interface IndexShardParams {
     target_index: string;
     shard_min: string;
     shard_max?: string;
+    embedding_dimensions?: {
+        text?: number;
+        image?: number;
+        properties?: number;
+    };
     dry_run?: boolean;
     concurrency?: number;
     batch_size?: number;


### PR DESCRIPTION
## Summary
- add embedding_dimensions to the shard indexing request contract
- include dimensions and language on createReindexTarget responses so callers can pass the target index vector dimensions through explicitly

## Test Plan
- pnpm --prefix composableai/packages/common build