### PR TITLE
Add bulk import workflow type exports

### DIFF
--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -60,6 +60,7 @@
       "activities": "./activities/index.js",
       "dsl-activities": "./activities/index-dsl.js",
       "workflows": "./workflows",
+      "bulk-import": "./bulk-import",
       "workflows-bundle": "./workflows-bundle.js",
       "vars": "./vars"
     }
@@ -89,6 +90,11 @@
       "types": "./lib/types/workflows.d.ts",
       "import": "./lib/esm/workflows.js",
       "require": "./lib/cjs/workflows.js"
+    },
+    "./bulk-import": {
+      "types": "./lib/types/bulk-import.d.ts",
+      "import": "./lib/esm/bulk-import.js",
+      "require": "./lib/cjs/bulk-import.js"
     },
     "./dsl": {
       "types": "./lib/types/dsl.d.ts",
@@ -130,6 +136,9 @@
       ],
       "workflows": [
         "./lib/types/workflows.d.ts"
+      ],
+      "bulk-import": [
+        "./lib/types/bulk-import.d.ts"
       ],
       "dsl": [
         "./lib/types/dsl.d.ts"

--- a/packages/workflow/src/bulk-import.ts
+++ b/packages/workflow/src/bulk-import.ts
@@ -1,0 +1,127 @@
+import type {
+    CreateCollectionPayload,
+    CreateContentObjectPayload,
+} from '@vertesia/common';
+
+export enum ItemTypes {
+    CONTENT_OBJECT = 'ContentObject',
+    COLLECTION = 'Collection',
+    METADATA = 'Metadata',
+    STORAGE_OBJECT = 'StorageObject',
+    FILE = 'File',
+}
+
+export interface BaseItem {
+    kind: ItemTypes;
+}
+
+export interface ContentObjectSourceItem extends BaseItem {
+    kind: ItemTypes.CONTENT_OBJECT | ItemTypes.FILE;
+    object_id?: string;
+    data: CreateContentObjectPayload;
+    options: {
+        collection_id?: string;
+    };
+}
+
+export interface CollectionSourceItem extends BaseItem {
+    kind: ItemTypes.COLLECTION;
+    object_id?: string;
+    data: CreateCollectionPayload;
+}
+
+export interface MetadataSourceItem extends BaseItem {
+    kind: ItemTypes.METADATA;
+    object_id?: string;
+    data: Omit<CreateContentObjectPayload, 'content'>;
+    options: {
+        collection_id?: string;
+    };
+}
+
+export interface StorageObjectSourceItem extends BaseItem {
+    kind: ItemTypes.STORAGE_OBJECT;
+    filename: string;
+    targetPath: string;
+    sourceUrl: string;
+    mimeType: string;
+}
+
+export type SourceItem =
+    | ContentObjectSourceItem
+    | CollectionSourceItem
+    | MetadataSourceItem
+    | StorageObjectSourceItem;
+
+export interface SourceItemBatch {
+    index: number;
+    files: SourceItem[];
+}
+
+export interface SourceItemBatches {
+    batches: SourceItemBatch[];
+}
+
+export interface BatchGenerationParams {
+    batchSize?: number;
+    startPosition: number;
+    endPosition: number;
+}
+
+export interface ImportedSourceItem<T extends BaseItem = SourceItem> {
+    id: string;
+    item: T;
+    isUpdate: boolean;
+}
+
+export interface PartitionGenerationParams {
+    partitionSize: number;
+}
+
+export interface Partition {
+    size: number;
+    startPosition: number;
+    endPosition: number;
+}
+
+export interface Partitions {
+    totalSize: number;
+    partitions: Partition[];
+}
+
+export interface BulkImportParams {
+    maxConcurrentBatches?: number;
+    maxConcurrentPartitions?: number;
+    batchSize?: number;
+    partitionSize?: number;
+    dryRun?: boolean;
+    updateByContentSource?: boolean;
+}
+
+export interface PartitionError {
+    partitionIndex: number;
+    errorCount: number;
+}
+
+export interface BulkImportResult {
+    totalItems: number;
+    processedItems: number;
+    createdItems: number;
+    updatedItems: number;
+    totalBatches: number;
+    completedBatches: number;
+    errors: PartitionError[];
+    resultUri: string;
+}
+
+export interface BatchError {
+    batchIndex: number;
+    index: number;
+    item: SourceItem;
+    msg: string;
+}
+
+export interface AssembledResults {
+    importedItems: ImportedSourceItem[];
+    errors: BatchError[];
+}


### PR DESCRIPTION
## Summary
- Add a public `@vertesia/workflow/bulk-import` subpath for bulk import workflow contracts.
- Export source item, result, batching, partitioning, and assembled result types used by bulk import consumers.

## Changed Packages
- `@vertesia/workflow`

## Verification
- `git status --short` reviewed in `composableai`: clean
- `git ls-remote --heads origin feat-bulk-import-wf`: branch exists at `f42cb531fb088629399e3eed4b473c79095dfcf0`
- `pnpm --prefix composableai/packages/workflow exec tsc --noEmit --project tsconfig.json`: passed
- `pnpm --prefix composableai/packages/workflow build`: passed
- `pnpm --prefix composableai/packages/workflow test`: passed outside sandbox, 19 files / 106 tests

## Notes
- Initial sandboxed `pnpm --prefix composableai/packages/workflow test` failed because the DSL suites could not start the ephemeral Temporal test server (`Operation not permitted`). The same command passed after rerunning with local server permissions.