### PR TITLE
fix(common): export JSON schema properties type

### DIFF
--- a/packages/common/src/json-schema.ts
+++ b/packages/common/src/json-schema.ts
@@ -2,6 +2,7 @@ export type {
     JSONSchema,
     JSONSchemaArray,
     JSONSchemaObject,
+    JSONSchemaProperties,
     JSONSchemaType,
     JSONSchemaTypeName,
 } from "@llumiverse/common";


### PR DESCRIPTION
Exports JSONSchemaProperties from @vertesia/common and updates the llumiverse submodule to vertesia/llumiverse#389. This keeps OpenAPI generation stable in studio by avoiding anonymous Record component names.