### PR TITLE
fix(cli): use Vertesia session token for /cli device approval

### DIFF
--- a/packages/ui/src/session/auth/composable.ts
+++ b/packages/ui/src/session/auth/composable.ts
@@ -249,6 +249,20 @@ export async function fetchComposableTokenFromFirebaseToken(accountId?: string, 
     return fetchComposableToken(getFirebaseAuthToken, accountId, projectId, ttl);
 }
 
+/**
+ * Mint a scoped Vertesia token from an existing Vertesia JWT. STS accepts STS-issued
+ * tokens on /token/issue, so this works for sessions established via Central Auth where
+ * the browser has no Firebase user.
+ */
+export async function fetchComposableTokenFromVertesiaToken(vertesiaToken: string, accountId?: string, projectId?: string, ttl?: number) {
+    return fetchComposableToken(() => Promise.resolve(vertesiaToken), accountId, projectId, ttl);
+}
+
+/** Returns the cached Vertesia raw JWT, if any. Does not refresh. */
+export function getCurrentVertesiaToken(): string | undefined {
+    return AUTH_TOKEN_RAW;
+}
+
 export async function getComposableToken(accountId?: string, projectId?: string, initToken?: string, forceRefresh = false, useInternalAuth = false): Promise<ComposableTokenResponse> {
 
     const selectedAccount = accountId ?? localStorage.getItem(LastSelectedAccountId_KEY) ?? undefined

--- a/packages/ui/src/shell/login/TerminalLogin.tsx
+++ b/packages/ui/src/shell/login/TerminalLogin.tsx
@@ -2,7 +2,7 @@ import { AccountRef, ProjectRef } from '@vertesia/common'
 import { Button, Center, ErrorBox, Input, SelectBox, Spinner, useFetch, useToast } from '@vertesia/ui/core'
 import { Env } from "@vertesia/ui/env"
 import { useLocation } from "@vertesia/ui/router"
-import { fetchComposableTokenFromFirebaseToken, useUserSession } from '@vertesia/ui/session'
+import { fetchComposableTokenFromFirebaseToken, fetchComposableTokenFromVertesiaToken, getCurrentVertesiaToken, useUserSession } from '@vertesia/ui/session'
 import { useState } from 'react'
 import { useUITranslation } from '../../i18n/index.js'
 
@@ -117,7 +117,10 @@ export function TerminalLogin() {
         // expire in 1 day
         let payload: LoginResult | undefined
         try {
-            const token = await fetchComposableTokenFromFirebaseToken(data.account, data.project, 24 * 3600)
+            const vertesiaToken = getCurrentVertesiaToken()
+            const token = vertesiaToken
+                ? await fetchComposableTokenFromVertesiaToken(vertesiaToken, data.account, data.project, 24 * 3600)
+                : await fetchComposableTokenFromFirebaseToken(data.account, data.project, 24 * 3600)
             if (token) {
                 payload = {
                     ...data,


### PR DESCRIPTION
## Summary

Fixes the CLI device-flow approval (`/cli`) when the user is authenticated via **Central Auth** rather than direct Firebase. In that flow the browser has no Firebase user — only the Vertesia JWT minted server-side by central auth — so the existing `fetchComposableTokenFromFirebaseToken` call would throw `"No id token found"`.

## Changes

- `packages/ui/src/session/auth/composable.ts`
  - `fetchComposableTokenFromVertesiaToken(token, account, project, ttl)` — sibling of the Firebase variant; passes any Bearer to STS `/token/issue`. STS already accepts STS-issued tokens on that endpoint, so the same code path is reused.
  - `getCurrentVertesiaToken()` — exposes the cached `AUTH_TOKEN_RAW` without triggering a refresh (which would re-enter the Firebase path).

- `packages/ui/src/shell/login/TerminalLogin.tsx`
  - `onAccept` now prefers the cached Vertesia JWT, falling back to Firebase only when there is none. By the time `AuthAcceptScreen` renders (gated on `useUserSession().user`), the cached token is set in both Central Auth and Firebase paths.

## Server-side dependency

This client change relies on a token-server change in the parent `studio` repo to:
- accept regional STS issuers (`sts.{region}.vertesia.io`)
- allow `vertesia-token` auth to mint scoped user tokens (using the JWT's `user_id` claim, with `principal.type === 'user'` guard)

See the corresponding PR in `vertesia/studio`.

## Test plan

- [ ] Sign in via Central Auth, navigate to `/cli?redirect_uri=…&code=…`, approve — verify token is delivered to the loopback callback
- [ ] Sign in via direct Firebase (Google/GitHub/Microsoft), repeat — verify Firebase fallback still works
- [ ] Verify no regression on `/cli` for users with both a Firebase session and a cached Vertesia token

🤖 Generated with [Claude Code](https://claude.com/claude-code)