### PR TITLE
fix: npm publish integration test, use specified branch

### DIFF
--- a/.github/bin/lib-template-test.sh
+++ b/.github/bin/lib-template-test.sh
@@ -31,7 +31,8 @@ validate_release_type() {
 derive_tag_and_branch() {
   if [ "$RELEASE_TYPE" = "snapshot" ]; then
     NPM_TAG="dev"
-    TEMPLATE_REF="main"
+    # Use caller-supplied TEMPLATE_BRANCH so packages and template come from the same branch.
+    TEMPLATE_REF="${TEMPLATE_BRANCH:-main}"
   else
     NPM_TAG="latest"
     TEMPLATE_REF=""

--- a/.github/bin/test-template-smoke.sh
+++ b/.github/bin/test-template-smoke.sh
@@ -61,6 +61,7 @@ wait_for_npm() {
 
 RELEASE_TYPE=""
 TEMPLATE_NAME="Vertesia Plugin"
+TEMPLATE_BRANCH=""
 WAIT_FOR_NPM=false
 
 while [[ $# -gt 0 ]]; do
@@ -73,13 +74,17 @@ while [[ $# -gt 0 ]]; do
       TEMPLATE_NAME="$2"
       shift 2
       ;;
+    --branch)
+      TEMPLATE_BRANCH="$2"
+      shift 2
+      ;;
     --wait)
       WAIT_FOR_NPM=true
       shift
       ;;
     *)
       echo "Error: Unknown argument '$1'"
-      echo "Usage: $0 --release-type <snapshot|release> [--template <name>] [--wait]"
+      echo "Usage: $0 --release-type <snapshot|release> [--template <name>] [--branch <ref>] [--wait]"
       exit 1
       ;;
   esac

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -89,6 +89,6 @@ jobs:
           node-version: 24
 
       - name: Smoke test - Plugin
-        run: ./.github/bin/test-template-smoke.sh --release-type "${{ inputs.release_type }}" --template "Vertesia Plugin" --wait
+        run: ./.github/bin/test-template-smoke.sh --release-type "${{ inputs.release_type }}" --template "Vertesia Plugin" --branch "${{ github.ref_name }}" --wait
       - name: Smoke test - Tool Server (deprecated)
-        run: ./.github/bin/test-template-smoke.sh --release-type "${{ inputs.release_type }}" --template "Vertesia Tool Server (deprecated)" --wait
+        run: ./.github/bin/test-template-smoke.sh --release-type "${{ inputs.release_type }}" --template "Vertesia Tool Server (deprecated)" --branch "${{ github.ref_name }}" --wait

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -27,8 +27,8 @@ on:
         default: true
 
 permissions:
-  id-token: write  # Required for OIDC between GitHub and NPM
-  contents: write  # Required to push version changes for preview
+  id-token: write # Required for OIDC between GitHub and NPM
+  contents: write # Required to push version changes for preview
 
 jobs:
   publish:
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 
       # Ensure npm 11.5.1 or later is installed
@@ -66,10 +66,12 @@ jobs:
       # Template integration tests using local verdaccio registry (dry-run only)
       - name: Template integration test - Plugin
         if: inputs.dry_run == true
-        run: ./.github/bin/test-template-integration.sh --release-type "${{ inputs.release_type }}" --template "Vertesia Plugin"
+        run: ./.github/bin/test-template-integration.sh --release-type "${{
+          inputs.release_type }}" --template "Vertesia Plugin"
       - name: Template integration test - Tool Server (deprecated)
         if: inputs.dry_run == true
-        run: ./.github/bin/test-template-integration.sh --release-type "${{ inputs.release_type }}" --template "Vertesia Tool Server (deprecated)"
+        run: ./.github/bin/test-template-integration.sh --release-type "${{
+          inputs.release_type }}" --template "Vertesia Tool Server (deprecated)"
 
   # ============================================================
   # Integration test after real publish (non-dry-run only)
@@ -89,6 +91,10 @@ jobs:
           node-version: 24
 
       - name: Smoke test - Plugin
-        run: ./.github/bin/test-template-smoke.sh --release-type "${{ inputs.release_type }}" --template "Vertesia Plugin" --branch "${{ github.ref_name }}" --wait
+        run: ./.github/bin/test-template-smoke.sh --release-type "${{
+          inputs.release_type }}" --template "Vertesia Plugin" --branch "${{
+          github.ref_name }}" --wait
       - name: Smoke test - Tool Server (deprecated)
-        run: ./.github/bin/test-template-smoke.sh --release-type "${{ inputs.release_type }}" --template "Vertesia Tool Server (deprecated)" --branch "${{ github.ref_name }}" --wait
+        run: ./.github/bin/test-template-smoke.sh --release-type "${{
+          inputs.release_type }}" --template "Vertesia Tool Server (deprecated)"
+          --branch "${{ github.ref_name }}" --wait


### PR DESCRIPTION
The integration tests for snapshot releases were hard coded to use main.
Should use the branch being published.

Results in errors like:
* https://github.com/vertesia/composableai/actions/runs/25387587695/job/74454496751#step:5:8
In the error "AgentRunResponse" not found, happens because AgentRunResponse only exists on main at the moment.