### PR TITLE
fix: retry 412 workflow errors

### DIFF
--- a/packages/workflow/src/activities/executeInteraction.test.ts
+++ b/packages/workflow/src/activities/executeInteraction.test.ts
@@ -1,0 +1,72 @@
+import { ApplicationFailure } from '@temporalio/activity';
+import { MockActivityEnvironment } from '@temporalio/testing';
+import type { VertesiaClient } from '@vertesia/client';
+import { ContentEventName, type DSLActivityExecutionPayload } from '@vertesia/common';
+import type { ActivityContext } from '../dsl/setup/ActivityContext.js';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { executeInteraction, type ExecuteInteractionParams } from './executeInteraction.js';
+
+vi.mock('../dsl/setup/ActivityContext.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../dsl/setup/ActivityContext.js')>();
+    return { ...actual, setupActivity: vi.fn() };
+});
+
+let testEnv: MockActivityEnvironment;
+
+beforeAll(() => {
+    testEnv = new MockActivityEnvironment();
+});
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+const createPayload = (): DSLActivityExecutionPayload<ExecuteInteractionParams> => ({
+    auth_token: 'mock-token',
+    account_id: 'test-account',
+    project_id: 'test-project',
+    params: {
+        interactionName: 'testInteraction',
+        prompt_data: {},
+    },
+    config: { studio_url: 'http://mock-studio', store_url: 'http://mock-store' },
+    workflow_name: 'test-workflow',
+    event: ContentEventName.create,
+    objectIds: ['test-object-id'],
+    input: { inputType: 'objectIds', objectIds: ['test-object-id'] },
+    vars: {},
+    activity: { name: 'executeInteraction', params: {} },
+});
+
+async function mockInteractionError(error: Error & { statusCode?: number }): Promise<void> {
+    const { setupActivity } = await import('../dsl/setup/ActivityContext.js');
+    const mockClient = {
+        interactions: {
+            executeByName: vi.fn().mockRejectedValue(error),
+        },
+    } as unknown as VertesiaClient;
+
+    vi.mocked(setupActivity).mockResolvedValue({
+        client: mockClient,
+        inputType: 'objectIds',
+        params: createPayload().params,
+    } as unknown as ActivityContext<ExecuteInteractionParams>);
+}
+
+describe('executeInteraction retryability', () => {
+    it('leaves 412 failures retryable', async () => {
+        await mockInteractionError(Object.assign(new Error('rendition in progress'), { statusCode: 412 }));
+
+        await expect(testEnv.run(executeInteraction, createPayload())).rejects.toMatchObject({
+            message: 'Interaction Execution failed testInteraction: rendition in progress',
+        });
+    });
+
+    it('marks other 4xx failures as non-retryable', async () => {
+        await mockInteractionError(Object.assign(new Error('bad request'), { statusCode: 400 }));
+
+        await expect(testEnv.run(executeInteraction, createPayload())).rejects.toMatchObject({
+            nonRetryable: true,
+        } satisfies Partial<ApplicationFailure>);
+    });
+});

--- a/packages/workflow/src/activities/executeInteraction.test.ts
+++ b/packages/workflow/src/activities/executeInteraction.test.ts
@@ -38,7 +38,7 @@ const createPayload = (): DSLActivityExecutionPayload<ExecuteInteractionParams> 
     activity: { name: 'executeInteraction', params: {} },
 });
 
-async function mockInteractionError(error: Error & { statusCode?: number }): Promise<void> {
+async function mockInteractionError(error: Error & { statusCode?: number; status?: number; code?: number }): Promise<void> {
     const { setupActivity } = await import('../dsl/setup/ActivityContext.js');
     const mockClient = {
         interactions: {
@@ -54,11 +54,22 @@ async function mockInteractionError(error: Error & { statusCode?: number }): Pro
 }
 
 describe('executeInteraction retryability', () => {
-    it('leaves 412 failures retryable', async () => {
+    it('leaves 412 rendition-in-progress failures retryable', async () => {
         await mockInteractionError(Object.assign(new Error('rendition in progress'), { statusCode: 412 }));
 
         await expect(testEnv.run(executeInteraction, createPayload())).rejects.toMatchObject({
             message: 'Interaction Execution failed testInteraction: rendition in progress',
+        });
+    });
+
+    it.each([
+        ['status', { status: 412 }],
+        ['code', { code: 412 }],
+    ])('leaves 412 failures retryable when reported as %s', async (_field, statusProps) => {
+        await mockInteractionError(Object.assign(new Error('precondition failed'), statusProps));
+
+        await expect(testEnv.run(executeInteraction, createPayload())).rejects.toMatchObject({
+            message: 'Interaction Execution failed testInteraction: precondition failed',
         });
     });
 

--- a/packages/workflow/src/activities/executeInteraction.ts
+++ b/packages/workflow/src/activities/executeInteraction.ts
@@ -203,7 +203,8 @@ export async function executeInteraction(payload: DSLActivityExecutionPayload<Ex
         if (error.statusCode === 429 && params.exit_on_resource_exhaustion) {
             throw new ResourceExhaustedError(error.statusCode, "Resource exhausted - rate limit exceeded");
         } else if (is4xxNonRetryable(error.status) || is4xxNonRetryable(error.statusCode) || is4xxNonRetryable(error.code) || error.retryable === false) {
-            // 4xx HTTP errors (except 429 rate-limit) are permanent client errors (e.g. model not found, invalid request).
+            // 4xx HTTP errors (except retryable statuses) are permanent client errors
+            // (e.g. model not found, invalid request).
             // Errors explicitly marked as non-retryable (e.g. LlumiverseError) also fall here.
             // They will not be resolved by retrying.
             throw ApplicationFailure.create({
@@ -341,9 +342,10 @@ export async function executeInteractionFromActivity(
 
 /**
  * Returns true for 4xx status codes that indicate permanent client errors.
- * 429 (Too Many Requests) is excluded because it is retryable.
+ * 412 (Precondition Failed) and 429 (Too Many Requests) are excluded because
+ * they are retryable.
  */
 function is4xxNonRetryable(code: number | undefined): boolean {
     if (code === undefined || typeof code !== 'number') return false;
-    return code >= 400 && code < 500 && code !== 429;
+    return code >= 400 && code < 500 && code !== 412 && code !== 429;
 }


### PR DESCRIPTION
## Summary
- Treat HTTP 412 as retryable in the workflow `executeInteraction` activity.
- Keep other 4xx responses, such as 400, non-retryable.
- Add regression coverage for 412 vs 400 retry behavior.

## Verification
- `pnpm --dir composableai --filter @vertesia/workflow exec vitest run src/activities/executeInteraction.test.ts` (pass)
- `pnpm --dir composableai --filter @vertesia/common build` (pass)
- `pnpm --dir composableai --filter @vertesia/client build` (pass)
- `pnpm --dir composableai --filter @vertesia/json build` (pass)
- `pnpm --dir composableai --filter @vertesia/converters build` (pass)
- `pnpm --dir composableai --filter @vertesia/workflow build` reached the workflow package but initially failed because fresh workspace dependency outputs for `@vertesia/memory` were missing; dependency build setup was continued separately before push.
