### PR TITLE
feat: add sort field to SearchAgentRunsQuery

### DIFF
--- a/packages/client/src/store/AgentsApi.ts
+++ b/packages/client/src/store/AgentsApi.ts
@@ -169,6 +169,7 @@ export class AgentsApi extends ApiTopic {
         if (query?.until) params.until = query.until.toISOString();
         if (query?.limit) params.limit = String(query.limit);
         if (query?.offset) params.offset = String(query.offset);
+        if (query?.sort?.length) params.sort = query.sort.join(',');
         return this.get('/search', { query: params });
     }
 

--- a/packages/common/src/store/agent-run.ts
+++ b/packages/common/src/store/agent-run.ts
@@ -616,6 +616,16 @@ export interface SearchAgentRunsQuery {
 
     /** Offset for pagination */
     offset?: number;
+
+    /**
+     * Multi-field sort. Each item has the form `field` or `field:order`, where
+     *   field is one of: `started_at`, `updated_at`
+     *   order is one of: `asc`, `desc` (default: `desc`)
+     * The first item is the primary sort; subsequent items are tie-breakers.
+     * Example: `['updated_at:desc', 'started_at:asc']`.
+     * Defaults to `['started_at:desc']` when omitted.
+     */
+    sort?: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add optional `sort?: string[]` to `SearchAgentRunsQuery` for multi-field sorting on `GET /agents/search`. Each item is `field` or `field:order` (e.g. `['updated_at:desc', 'started_at:asc']`).
- Serialize `sort` as a comma-joined string in `AgentsApi.search()`, mirroring how `categories`/`tags` are already handled.

## Why this typing
Typed as `string[]` (not an array of `{field, order}` objects) so the OpenAPI generator emits `type: array, items: { type: string }` — same shape as the existing `categories`/`tags` query params and renderable in standard tooling.

## Test Plan
- [x] Type-check: `turbo build --filter=@vertesia/common --filter=@vertesia/client` (run from studio root) — green
- [ ] End-to-end behavior is covered by integration tests in the parent `vertesia/studio` PR `feat-agent-search-sort`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>