### PR TITLE
Add process workstream monitor config

### DIFF
--- a/packages/common/src/store/agent-run.ts
+++ b/packages/common/src/store/agent-run.ts
@@ -263,6 +263,17 @@ export interface ProcessRunConfig {
      * so programmatic runs retain the intent that triggered them.
      */
     user_message?: string;
+    /**
+     * Optional monitor workflow used when a process is launched as a
+     * conversation workstream. The process workflow sends checkpoint status
+     * signals to this monitor so long-running human-task processes do not need
+     * tight polling.
+     */
+    process_workstream_monitor?: {
+        monitor_workflow_id: string;
+        launch_id?: string;
+        workstream_id?: string;
+    };
 }
 
 export interface ProcessRun extends RunBase {


### PR DESCRIPTION
## Summary
- Add optional process workstream monitor metadata to `ProcessRunConfig`.
- Allows process runs launched as conversation workstreams to carry the monitor workflow id and launch/workstream identifiers used for status signaling.

## Test Plan
- `pnpm --prefix packages/common build`
- `pnpm --prefix packages/common test`

## Notes
- Merged latest `origin/main` into the branch before creating this PR.