### PR TITLE
Fix: set full height to collection browse

### DIFF
--- a/packages/ui/src/features/store/collections/BrowseCollectionView.tsx
+++ b/packages/ui/src/features/store/collections/BrowseCollectionView.tsx
@@ -36,10 +36,14 @@ export function BrowseCollectionView({ collection }: BrowseCollectionViewProps) 
         }
     }
     const tableLayout = getTableLayout(collection, typeRegistry);
-    return collection.dynamic ? (
-        <DocumentSearchResults layout={tableLayout} />
-    ) : (
-        <DocumentSearchResultsWithDropZone onUploadDone={onUploadDone} layout={tableLayout} />
+    return (
+        <div className="flex flex-col h-full">
+            {collection.dynamic ? (
+                <DocumentSearchResults layout={tableLayout} />
+            ) : (
+                <DocumentSearchResultsWithDropZone onUploadDone={onUploadDone} layout={tableLayout} />
+            )}
+        </div>
     )
 }
 


### PR DESCRIPTION
The collection browse tab is not full height, not consistent with all the other page in the app

### Before

<img width="1906" height="925" alt="Screenshot 2026-05-11 at 14 11 39" src="https://github.com/user-attachments/assets/9894dfef-bece-482e-8d6d-8eac2058b8fe" />


### After
<img width="1915" height="931" alt="Screenshot 2026-05-11 at 14 12 31" src="https://github.com/user-attachments/assets/38d4bd38-4d27-4223-8414-559fe3eb1629" />
