### PR TITLE
fix(client): correct inverted isTokenExpired comparison

### DIFF
--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from "vitest";
-import { VertesiaClient } from "./client";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { isTokenExpired, VertesiaClient } from "./client";
 
 describe('Test Vertesia Client', () => {
     test('Initialization with studio and zeno URLs', () => {
@@ -131,5 +131,60 @@ describe('Test Vertesia Client', () => {
         expect(client).toBeDefined();
         expect(client.baseUrl).toBe('https://studio-server-production.api.becomposable.com');
         expect(client.storeUrl).toBe('https://zeno-server-production.api.becomposable.com');
+    });
+});
+
+describe('isTokenExpired', () => {
+    // EXPIRATION_THRESHOLD inside client.ts is 60000ms (60s). Tokens with `exp`
+    // less than 60s in the future are treated as expired so the caller refreshes
+    // proactively.
+    const REFRESH_WINDOW_MS = 60_000;
+    const NOW_MS = 1_700_000_000_000;
+
+    function base64UrlEncode(s: string): string {
+        return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    }
+
+    function makeToken(exp: number): string {
+        const header = base64UrlEncode(JSON.stringify({ alg: 'none', typ: 'JWT' }));
+        const payload = base64UrlEncode(JSON.stringify({ exp }));
+        return `${header}.${payload}.signature`;
+    }
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date(NOW_MS));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    test('returns true for a null token', () => {
+        expect(isTokenExpired(null)).toBe(true);
+    });
+
+    test('returns false for a fresh token comfortably inside its lifetime', () => {
+        // 1 hour in the future
+        const exp = Math.floor(NOW_MS / 1000) + 3600;
+        expect(isTokenExpired(makeToken(exp))).toBe(false);
+    });
+
+    test('returns true when the token is within the refresh threshold of expiry', () => {
+        // 30s in the future — inside the 60s refresh window
+        const exp = Math.floor((NOW_MS + 30_000) / 1000);
+        expect(isTokenExpired(makeToken(exp))).toBe(true);
+    });
+
+    test('returns true for a token whose exp is already in the past', () => {
+        // expired 100s ago
+        const exp = Math.floor((NOW_MS - 100_000) / 1000);
+        expect(isTokenExpired(makeToken(exp))).toBe(true);
+    });
+
+    test('returns true exactly at the refresh-window boundary', () => {
+        // exp is exactly REFRESH_WINDOW_MS in the future — should already trigger refresh
+        const exp = Math.floor((NOW_MS + REFRESH_WINDOW_MS) / 1000);
+        expect(isTokenExpired(makeToken(exp))).toBe(true);
     });
 });

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -373,7 +373,11 @@ function isApiKey(apiKey: string) {
     return apiKey.startsWith("pk-") || apiKey.startsWith("sk-");
 }
 
-function isTokenExpired(token: string | null) {
+/**
+ * Returns true when the token should be refreshed: either missing, or within
+ * EXPIRATION_THRESHOLD of its `exp` claim, or already expired. Exported for tests.
+ */
+export function isTokenExpired(token: string | null) {
     if (!token) {
         return true;
     }
@@ -381,7 +385,7 @@ function isTokenExpired(token: string | null) {
     const decoded = decodeJWT(token);
     const exp = decoded.exp;
     const currentTime = Date.now();
-    return currentTime <= exp * 1000 - EXPIRATION_THRESHOLD;
+    return currentTime >= exp * 1000 - EXPIRATION_THRESHOLD;
 }
 
 export function decodeJWT(jwt: string): AuthTokenPayload {


### PR DESCRIPTION
## Summary

`isTokenExpired` in [packages/client/src/client.ts](packages/client/src/client.ts) had an inverted operator:

```ts
// before
return currentTime <= exp * 1000 - EXPIRATION_THRESHOLD;
// after
return currentTime >= exp * 1000 - EXPIRATION_THRESHOLD;
```

For a function expected to return `true` when the token is expired (or within the 60s refresh threshold), the original `<=` returned the opposite of the intended value:

| Phase of token's life | Function returned | Intended | Effect on caller |
| --- | --- | --- | --- |
| First ~99% (well inside lifetime) | `true` (claims expired) | `false` | Refreshes JWT on **every API call** — wasteful but safe |
| Last 60s + after `exp` | `false` (claims not expired) | `true` | Reuses **stale / expired** token — produces 401s under bursty load |

The single caller is `VertesiaClient.withApiKey` in the same file; no other consumers.

Also exports the function and adds unit tests covering the four boundary cases (null, fresh, within-window, past-exp, exactly-at-boundary).

## Why this is a real bug

While most calls have been "saved" by the bug accidentally forcing a refresh on every request, two failure modes existed:
- Wasted load on the token-server `/auth/token` endpoint — every SDK call did an extra round-trip
- Genuine 401s once a token aged into the last 60s and the cached value got reused (the cause of intermittent failures observed in long-running scripts and parallel test runs)

After this fix the SDK refreshes proactively only inside the 60s pre-expiry window and uses the cached token otherwise — the originally-intended behavior.

## Verification

- ✅ `pnpm test` in `packages/client` — **49/49 passing** (17 in `client.test.ts`, 5 new for `isTokenExpired`)
- ✅ `pnpm build` — clean rollup build, no TS warnings
- ✅ `pnpm lint` — 0 errors (58 pre-existing warnings unrelated to this change)

## Test Plan

- [ ] Run an SDK script that makes many sequential calls and confirm `/auth/token` is no longer hit per-call (server-side metric: `service:token-server path:/auth/token` request rate should drop sharply for SDK consumers)
- [ ] Long-running script that crosses the 60s pre-expiry boundary: verify the refresh happens transparently and no 401 is surfaced to the caller
- [ ] Existing integration tests continue to pass

## Follow-up

Once merged, the parent `vertesia/studio` repo's submodule pointer needs a chore commit to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)