### PR TITLE
chore: reduce workflow logging noise

### DIFF
--- a/packages/tools-sdk/src/ToolRegistry.ts
+++ b/packages/tools-sdk/src/ToolRegistry.ts
@@ -59,13 +59,6 @@ export class ToolRegistry {
 
     runTool<ParamsT extends Record<string, any>>(payload: ToolExecutionPayload<ParamsT>, context: ToolExecutionContext): Promise<ToolExecutionResult> {
         const toolName = payload.tool_use.tool_name;
-        const toolUseId = payload.tool_use.id;
-        const runId = payload.metadata?.run_id;
-        console.log(`[ToolRegistry] Executing tool: ${toolName}`, {
-            toolUseId,
-            runId,
-            input: sanitizeInput(payload.tool_use.tool_input),
-        });
         return this.getTool(toolName).run(payload, context);
     }
 
@@ -77,28 +70,4 @@ export class ToolNotFoundError extends HTTPException {
         super(404, { message: "Tool function not found: " + name });
         this.name = "ToolNotFoundError";
     }
-}
-
-const SENSITIVE_KEYS = new Set([
-    'apikey', 'api_key', 'token', 'secret', 'password', 'credential', 'credentials',
-    'authorization', 'auth', 'key', 'private_key', 'access_token', 'refresh_token'
-]);
-
-function sanitizeInput(input: Record<string, any> | null | undefined): Record<string, any> | null {
-    if (!input) return null;
-
-    const sanitized: Record<string, any> = {};
-    for (const [key, value] of Object.entries(input)) {
-        const lowerKey = key.toLowerCase();
-        if (SENSITIVE_KEYS.has(lowerKey) || lowerKey.includes('key') || lowerKey.includes('token') || lowerKey.includes('secret')) {
-            sanitized[key] = '[REDACTED]';
-        } else if (typeof value === 'string' && value.length > 50) {
-            sanitized[key] = value.slice(0, 50) + '...';
-        } else if (typeof value === 'object' && value !== null) {
-            sanitized[key] = Array.isArray(value) ? `[Array(${value.length})]` : '[Object]';
-        } else {
-            sanitized[key] = value;
-        }
-    }
-    return sanitized;
 }

--- a/packages/workflow/src/activities/advanced/createOrUpdateDocumentFromInteractionRun.ts
+++ b/packages/workflow/src/activities/advanced/createOrUpdateDocumentFromInteractionRun.ts
@@ -54,7 +54,7 @@ export async function createOrUpdateDocumentFromInteractionRun(payload: DSLActiv
         throw new ActivityParamNotFoundError("object_type", payload.activity);
     }
 
-    log.info("Creating document from interaction result", { runId, objectTypeName });
+    log.debug("Creating document from interaction result", { runId, objectTypeName });
 
     const run = await client.runs.retrieve(runId).catch((e) => {
         throw new DocumentNotFoundError(`Error fetching run ${runId}: ${e.message}`);
@@ -75,7 +75,7 @@ export async function createOrUpdateDocumentFromInteractionRun(payload: DSLActiv
     try {
         jsonResult = result.object();
     } catch (e) {
-        log.info("Result is not valid JSON, will use text content instead", { error: e instanceof Error ? e.message : String(e) });
+        log.debug("Result is not valid JSON, will use text content instead", { error: e instanceof Error ? e.message : String(e) });
     }
 
     const name = jsonResult?.['name'] || jsonResult?.["title"] || inputData['name'] || params.fallback_name || undefined;
@@ -106,14 +106,14 @@ export async function createOrUpdateDocumentFromInteractionRun(payload: DSLActiv
     let newDoc: boolean = false;
     let doc = undefined;
     if (params.update_existing_id) {
-        log.info(`Updating existing document ${params.update_existing_id}`);
+        log.debug(`Updating existing document ${params.update_existing_id}`);
         doc = await client.objects.update(params.update_existing_id, docPayload, { suppressWorkflows: true });
     } else {
-        log.info(`Creating new document of type ${objectTypeName}`);
+        log.debug(`Creating new document of type ${objectTypeName}`);
         doc = await client.objects.create(docPayload);
         newDoc = true;
     }
 
-    log.info(`Document ${objectTypeName + ' '}${doc.id}(${doc.name}) ${newDoc ? 'created' : 'updated'}`);
+    log.debug(`Document ${objectTypeName + ' '}${doc.id}(${doc.name}) ${newDoc ? 'created' : 'updated'}`);
     return { id: doc.id, isNew: newDoc, type: name }
 }

--- a/packages/workflow/src/activities/generateOrAssignContentType.ts
+++ b/packages/workflow/src/activities/generateOrAssignContentType.ts
@@ -160,7 +160,7 @@ export async function generateOrAssignContentType(
 
   const jsonResult = res.result.object();
 
-  log.info("Selected Content Type Result: " + JSON.stringify(jsonResult));
+  log.debug("Selected Content Type Result: " + JSON.stringify(jsonResult));
 
 
   //if type is not identified or not present in the database, generate a new type

--- a/packages/workflow/src/dsl/dsl-workflow.ts
+++ b/packages/workflow/src/dsl/dsl-workflow.ts
@@ -136,7 +136,7 @@ export async function dslWorkflow(payload: DSLWorkflowExecutionPayload) {
         file: files[0],
     });
 
-    log.info("Executing workflow", { payload });
+    log.debug("Executing workflow", { payload });
 
     // Resolve remote activities from installed apps only if the workflow uses prefixed activity names
     let remoteActivities: RemoteActivityMap = {};
@@ -147,7 +147,7 @@ export async function dslWorkflow(payload: DSLWorkflowExecutionPayload) {
             );
             remoteActivities = await defaultProxy.resolveRemoteActivities(resolvePayload) as RemoteActivityMap;
             if (Object.keys(remoteActivities).length > 0) {
-                log.info("Resolved remote activities", {
+                log.debug("Resolved remote activities", {
                     count: Object.keys(remoteActivities).length,
                     names: Object.keys(remoteActivities),
                 });
@@ -238,7 +238,7 @@ async function handleError(originalError: any, basePayload: BaseActivityPayload,
 
 async function startChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWorkflowExecutionPayload, vars: Vars, debug_mode?: boolean, proxy?: ActivityInterfaceFor<UntypedActivities>, basePayload?: BaseActivityPayload) {
     if (step.condition && !vars.match(step.condition)) {
-        log.info("Child workflow skipped: condition not satisfied", { workflow: step.name, condition: step.condition });
+        log.debug("Child workflow skipped: condition not satisfied", { workflow: step.name, condition: step.condition });
         return;
     }
     if (step.name.startsWith('dsl:') && !step.spec && proxy && basePayload) {
@@ -285,7 +285,7 @@ async function startChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWorkfl
 
 async function executeChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWorkflowExecutionPayload, vars: Vars, debug_mode?: boolean, proxy?: ActivityInterfaceFor<UntypedActivities>, basePayload?: BaseActivityPayload) {
     if (step.condition && !vars.match(step.condition)) {
-        log.info("Child workflow skipped: condition not satisfied", { workflow: step.name, condition: step.condition });
+        log.debug("Child workflow skipped: condition not satisfied", { workflow: step.name, condition: step.condition });
         return;
     }
     if (step.name.startsWith('dsl:') && !step.spec && proxy && basePayload) {
@@ -389,7 +389,7 @@ async function runActivity(activity: DSLActivitySpec, basePayload: BaseActivityP
         log.debug(`Workflow vars before executing activity ${activity.name}`, { vars: vars.resolve() });
     }
     if (activity.condition && !vars.match(activity.condition)) {
-        log.info("Activity skipped: condition not satisfied", activity.condition);
+        log.debug("Activity skipped: condition not satisfied", activity.condition);
         return;
     }
 
@@ -426,7 +426,7 @@ async function runActivity(activity: DSLActivitySpec, basePayload: BaseActivityP
             );
         }
         const remote = remoteActivities[activity.name];
-        log.info("Executing remote activity", {
+        log.debug("Executing remote activity", {
             activityName: activity.name,
             remoteName: remote.activity_name,
             app: remote.app_name,
@@ -482,7 +482,7 @@ async function runActivity(activity: DSLActivitySpec, basePayload: BaseActivityP
     const fn = proxy[activity.name];
     if (activity.parallel) {
         //TODO execute in parallel
-        log.info("Parallel execution not yet implemented");
+        log.debug("Parallel execution not yet implemented");
     } else {
         log.debug("Executing activity: " + activity.name, { importParams });
         const result = await fn(executionPayload);


### PR DESCRIPTION
## Summary
- Drop the unused console-log of every tool invocation (including the input-sanitization helper) in \`ToolRegistry.runTool\` — tool execution is already covered by structured telemetry and the per-call \`console.log\` was operator noise.
- Demote DSL workflow chatter to \`debug\`: \`Executing workflow\` payload, \`Resolved remote activities\` listing, child-workflow skip-on-condition messages, activity skip-on-condition message, "Executing remote activity" details, and "Parallel execution not yet implemented" notice in \`packages/workflow/src/dsl/dsl-workflow.ts\`.
- Demote document-from-interaction-run progress in \`createOrUpdateDocumentFromInteractionRun\` to \`debug\` (creation/update progress, JSON parse fallback, final result line).
- Demote "Selected Content Type Result" payload in \`generateOrAssignContentType\` to \`debug\`.

These are pure log-level / log-removal changes; no behavior changes.

## Submodule Changes
- llumiverse: https://github.com/vertesia/llumiverse/pull/395

## Verification
- Build: covered transitively by parent studio \`turbo build\` for \`@dglabs/workflows\`, \`@dglabs/studio-server\`, \`@dglabs/zeno-server\`, etc. (which depend on \`@vertesia/workflow\`) — passed with this commit pinned.
- Tests: not run separately in the submodule; \`@dglabs/workflows\` unit tests in the parent repo pass (962 tests).

## Test Plan
- [ ] Confirm Datadog volume for the demoted log messages drops once deployed.
- [ ] Confirm no production code path relies on the dropped \`[ToolRegistry] Executing tool\` console output for audit (telemetry is the source of truth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>