### PR TITLE
chore: clarify and enrich handleDslError recovery-failure log

### DIFF
--- a/packages/workflow/src/activities/handleError.ts
+++ b/packages/workflow/src/activities/handleError.ts
@@ -27,7 +27,21 @@ export async function handleDslError(payload: DSLActivityExecutionPayload<Handle
     try {
         await client.objects.update(objectId, { status: ContentObjectStatus.failed });
     } catch (e) {
-        log.error("Failed to handle error", { error: e });
+        // Recovery path: the upstream workflow has already failed (and that
+        // original error is logged by the completion interceptor). What's
+        // happening here is that we *also* couldn't mark the content object
+        // as failed. Stay at error so it remains in dashboards — recurring
+        // recovery failures are a real signal — but enrich the message so
+        // it's clearly distinct from the upstream error rather than reading
+        // like a duplicate.
+        log.error(
+            `Recovery failed: could not update object ${objectId} status to failed`,
+            {
+                error: e,
+                upstreamError: params.errorMessage,
+                workflow_name: payload.workflow_name,
+            },
+        );
     }
     return;
 }


### PR DESCRIPTION
## Summary

`handleDslError`'s inner catch fires when the recovery path itself fails (the object-status update couldn't complete). At 11/hr in dev it's been dominating Datadog dashboards while reading like a duplicate of the upstream error already logged by the workflow completion interceptor.

This PR makes the line **clearly distinct** from the upstream error:
- New message: \`Recovery failed: could not update object \${objectId} status to failed\` (was the indistinct \`Failed to handle error\`).
- Payload now includes the recovery error, the upstream `errorMessage`, and the workflow name.
- **Level stays at `error`** — recurring recovery failures are operationally interesting signal, not noise. Only the readability changes.

## Companion PR
[vertesia/studio#5117](https://github.com/vertesia/studio/pull/5117) — the larger log-level re-classification pass that handles the truly benign / best-effort logs (cancellations, post-hook notifications, etc.). This PR is the composableai side of that work per the plan agreed with the author.

## Verification
- `cd packages/workflow && npx tsc --noEmit` — clean.
- `cd packages/workflow && pnpm test` — 110 tests pass.

## Test plan
- [ ] Trigger an intake workflow failure where the subsequent object-status update will also fail (e.g. with a bad project context). Confirm the log entry has the new message format and the `upstreamError`/`workflow_name` fields are populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>