### PR TITLE
feat(ui): OAuth consent enhancements in shared shell

### DIFF
--- a/packages/common/src/oauth-server.ts
+++ b/packages/common/src/oauth-server.ts
@@ -22,6 +22,7 @@ export interface OAuthClientData {
     response_types: OAuthResponseType[];
     token_endpoint_auth_method: OAuthTokenEndpointAuthMethod;
     allowed_scopes: string[];
+    default_scopes?: string[];
     registration_source: OAuthRegistrationSource;
     status: OAuthClientStatus;
     project_binding_mode: OAuthProjectBindingMode;
@@ -98,6 +99,7 @@ export interface CreateOAuthClientPayload {
     response_types?: OAuthResponseType[];
     token_endpoint_auth_method?: OAuthTokenEndpointAuthMethod;
     allowed_scopes?: string[];
+    default_scopes?: string[];
     project_binding_mode?: OAuthProjectBindingMode;
     fixed_project_id?: string;
     client_secret?: string;
@@ -111,6 +113,7 @@ export interface UpdateOAuthClientPayload {
     response_types?: OAuthResponseType[];
     token_endpoint_auth_method?: OAuthTokenEndpointAuthMethod;
     allowed_scopes?: string[];
+    default_scopes?: string[];
     status?: OAuthClientStatus;
     project_binding_mode?: OAuthProjectBindingMode;
     fixed_project_id?: string;

--- a/packages/ui/src/session/UserSession.ts
+++ b/packages/ui/src/session/UserSession.ts
@@ -14,6 +14,9 @@ export { LastSelectedAccountId_KEY, LastSelectedProjectId_KEY };
 
 const CENTRAL_AUTH_REDIRECT = "https://internal-auth.vertesia.app/";
 
+export interface UserSessionLoginOptions {
+    loadOnboardingStatus?: boolean;
+}
 
 class UserSession {
 
@@ -88,7 +91,7 @@ class UserSession {
         return this.authToken?.account;
     }
 
-    async login(token: string) {
+    async login(token: string, options: UserSessionLoginOptions = {}) {
         this.authError = undefined;
         this.isLoading = false;
         this.client.withAuthCallback(() => this.authCallback)
@@ -101,7 +104,9 @@ class UserSession {
         // notify the host app of the login
         Env.onLogin?.(this.authToken);
 
-        await this.fetchOnboardingStatus();
+        if (options.loadOnboardingStatus ?? true) {
+            await this.fetchOnboardingStatus();
+        }
 
         return Promise.resolve();
 

--- a/packages/ui/src/session/UserSessionProvider.tsx
+++ b/packages/ui/src/session/UserSessionProvider.tsx
@@ -11,8 +11,9 @@ const CENTRAL_AUTH_REDIRECT = "https://internal-auth.vertesia.app/";
 
 interface UserSessionProviderProps {
     children: ReactNode | ReactNode[];
+    loadOnboardingStatus?: boolean;
 }
-export function UserSessionProvider({ children }: UserSessionProviderProps) {
+export function UserSessionProvider({ children, loadOnboardingStatus = true }: UserSessionProviderProps) {
     const hashParams = new URLSearchParams(location.hash.substring(1));
     const token = hashParams.get("token");
     const state = hashParams.get("state");
@@ -73,7 +74,7 @@ export function UserSessionProvider({ children }: UserSessionProviderProps) {
             }
             getComposableToken(selectedAccount, selectedProject, token, false, shouldRedirectToCentralAuth())
                 .then((res) => {
-                    session.login(res.rawToken).then(() => {
+                    session.login(res.rawToken, { loadOnboardingStatus }).then(() => {
                         setSession(session.clone());
                         //cleanup the hash
                         window.location.hash = "";
@@ -163,7 +164,7 @@ export function UserSessionProvider({ children }: UserSessionProviderProps) {
                 session.setSession = setSession;
                 await getComposableToken(selectedAccount, selectedProject, undefined, false, shouldRedirectToCentralAuth())
                     .then((res) => {
-                        session.login(res.rawToken).then(() => setSession(session.clone()));
+                        session.login(res.rawToken, { loadOnboardingStatus }).then(() => setSession(session.clone()));
                     })
                     .catch((err) => {
                         console.error("Failed to fetch user token from studio", err);

--- a/packages/ui/src/shell/VertesiaShell.tsx
+++ b/packages/ui/src/shell/VertesiaShell.tsx
@@ -11,15 +11,22 @@ interface VertesiaShellProps {
     lightLogo?: string;
     darkLogo?: string;
     loadingIcon?: ReactNode;
+    loadOnboardingStatus?: boolean;
+    preserveSignInPath?: boolean;
 }
-export function VertesiaShell({ children, lightLogo, darkLogo, loadingIcon }: VertesiaShellProps) {
+export function VertesiaShell({ children, lightLogo, darkLogo, loadingIcon, loadOnboardingStatus, preserveSignInPath }: VertesiaShellProps) {
     return (
         <ToastProvider>
-            <UserSessionProvider>
+            <UserSessionProvider loadOnboardingStatus={loadOnboardingStatus}>
                 <TypeRegistryProvider>
                     <ThemeProvider defaultTheme="system" storageKey="vite-ui-theme">
                         <SplashScreen icon={loadingIcon} />
-                        <SigninScreen allowedPrefix="/shared/" lightLogo={lightLogo} darkLogo={darkLogo} />
+                        <SigninScreen
+                            allowedPrefix="/shared/"
+                            darkLogo={darkLogo}
+                            lightLogo={lightLogo}
+                            preservePath={preserveSignInPath}
+                        />
                         <UserPermissionProvider>
                             {children}
                         </UserPermissionProvider>

--- a/packages/ui/src/shell/login/SigninScreen.tsx
+++ b/packages/ui/src/shell/login/SigninScreen.tsx
@@ -17,16 +17,17 @@ interface SigninScreenProps {
     allowedPrefix?: string;
     lightLogo?: string;
     darkLogo?: string;
+    preservePath?: boolean;
 }
-export function SigninScreen({ allowedPrefix, isNested = false, lightLogo, darkLogo }: SigninScreenProps) {
+export function SigninScreen({ allowedPrefix, isNested = false, lightLogo, darkLogo, preservePath }: SigninScreenProps) {
     const [allow, setAllow] = useState(false);
     useSafeLayoutEffect(() => {
-        allowedPrefix && setAllow(window.location.href.startsWith(allowedPrefix));
-    }, []);
-    return allow ? null : <SigninScreenImpl isNested={isNested} lightLogo={lightLogo} darkLogo={darkLogo} />;
+        allowedPrefix && setAllow(window.location.pathname.startsWith(allowedPrefix));
+    }, [allowedPrefix]);
+    return allow ? null : <SigninScreenImpl isNested={isNested} lightLogo={lightLogo} darkLogo={darkLogo} preservePath={preservePath} />;
 }
 
-function SigninScreenImpl({ isNested = false, lightLogo, darkLogo }: SigninScreenProps) {
+function SigninScreenImpl({ isNested = false, lightLogo, darkLogo, preservePath }: SigninScreenProps) {
     const { t } = useUITranslation();
     const { isLoading, user, authError } = useUserSession();
 
@@ -41,7 +42,7 @@ function SigninScreenImpl({ isNested = false, lightLogo, darkLogo }: SigninScree
                 )}
             >
 
-                <StandardSigninPanel authError={authError} lightLogo={lightLogo} darkLogo={darkLogo} />
+                <StandardSigninPanel authError={authError} lightLogo={lightLogo} darkLogo={darkLogo} preservePath={preservePath} />
                 <div className="flex gap-x-6 mt-10 justify-center items-center text-muted">
                     <a href="https://vertesiahq.com/privacy" className="text-sm">
                         {t('auth.privacyPolicy')}
@@ -56,10 +57,11 @@ function SigninScreenImpl({ isNested = false, lightLogo, darkLogo }: SigninScree
     ) : null;
 }
 
-function StandardSigninPanel({ authError, darkLogo, lightLogo }: {
+function StandardSigninPanel({ authError, darkLogo, lightLogo, preservePath }: {
     authError?: Error,
     darkLogo?: string,
     lightLogo?: string
+    preservePath?: boolean,
 }) {
     const { t } = useUITranslation();
     const [signupData, setSignupData] = useState<SignupData | undefined>(undefined);
@@ -67,7 +69,11 @@ function StandardSigninPanel({ authError, darkLogo, lightLogo }: {
     const { signOut } = useUserSession();
     const { trackEvent } = useUXTracking();
 
-    history.replaceState({}, '', '/');
+    useEffect(() => {
+        if (!preservePath) {
+            history.replaceState({}, '', '/');
+        }
+    }, [preservePath]);
 
     const goBack = () => {
         console.log("Going back, signing out");


### PR DESCRIPTION
## Summary

Shared `@vertesia/ui` changes needed by the studio PR that lands per-env OAuth consent routing in composable-ui.

- **`oauth-server.ts`**: Add `default_scopes` to `OAuthClientData`, `CreateOAuthClientPayload`, and `UpdateOAuthClientPayload`. Lets clients declare which scopes are granted when an authorization request omits `scope` (separate from the broader allow-list).
- **`UserSession.login()` / `UserSessionProvider`**: New `loadOnboardingStatus` option (defaults to `true`). Lets host apps opt out of the post-login onboarding fetch — needed for standalone OAuth pages that should not run shell-level onboarding logic.
- **`VertesiaShell`**: New `loadOnboardingStatus` and `preserveSignInPath` props; forwarded to `UserSessionProvider` and `SigninScreen`.
- **`SigninScreen` / `StandardSigninPanel`**:
  - Match `allowedPrefix` against `window.location.pathname` (not `.href`) so prefixes like `/shared/` actually match in dev/preview URLs that include query strings or origins.
  - Add `preservePath` prop. When set, do not rewrite history to `/` on sign-in — needed so an OAuth deep-link survives the auth round-trip.
  - Move the `history.replaceState({}, '', '/')` call into a `useEffect` so it doesn't fire on every render.

## Parent PR

Used by [vertesia/studio](https://github.com/vertesia/studio) PR landing the OAuth consent flow and mcp-server metadata routing.

## Verification

- `turbo build --filter=@vertesia/ui` is exercised transitively via the parent repo build (all 30 tasks green).
- No new tests in this package; behavior is exercised in the parent repo's e2e and integration tests.

## Test Plan

- [ ] Verify host apps that don't set `loadOnboardingStatus` still fetch onboarding (default unchanged).
- [ ] Sign in via `/shared/*` URL — `SigninScreen` skips overlay (prefix match now uses pathname).
- [ ] Sign in via `/oauth/*` URL with `preserveSignInPath` — URL is not rewritten to `/` during the sign-in dance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>