### PR TITLE
feat: add plain PDF export and custom branded PDF

### DIFF
--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -211,6 +211,13 @@ export interface ProjectConfiguration {
      */
     main_language?: string;
 
+    /**
+     * Object ID of a content object containing a custom LaTeX template (.latex file)
+     * to use as the branded PDF template. When set, "Export as Branded PDF" uses this
+     * template instead of the built-in Vertesia default template.
+     */
+    pdf_template_object_id?: string;
+
 }
 
 // export interface ProjectConfigurationEmbeddings {

--- a/packages/ui/src/features/store/objects/components/ContentOverview.tsx
+++ b/packages/ui/src/features/store/objects/components/ContentOverview.tsx
@@ -588,7 +588,7 @@ function TextActions({
     const content = object.content;
     const { renderDocument, isDownloading } = useDownloadFile({ client, toast });
     const { data: fullProject } = useFetch(
-        () => project ? client.projects.retrieve(project.id, 'id,configuration') : Promise.resolve(undefined),
+        () => project ? client.projects.retrieve(project.id) : Promise.resolve(undefined),
         [project?.id]
     );
     const pdfTemplateObjectId = fullProject?.configuration?.pdf_template_object_id;

--- a/packages/ui/src/features/store/objects/components/ContentOverview.tsx
+++ b/packages/ui/src/features/store/objects/components/ContentOverview.tsx
@@ -596,7 +596,7 @@ function TextActions({
     // Get content processor type for file extension detection
     const contentProcessorType = getContentProcessorType(object);
 
-    const handleExportDocument = async (format: MarkdownRenditionFormat) => {
+    const handleExportDocument = async (format: MarkdownRenditionFormat, useDefaultTemplate?: boolean) => {
         // Prevent multiple concurrent exports
         if (isDownloading) return;
 
@@ -611,11 +611,13 @@ function TextActions({
         await renderDocument(object.id, {
             format,
             title: object.name || "document",
+            useDefaultTemplate,
         });
     };
 
     const handleExportDocx = () => handleExportDocument(MarkdownRenditionFormat.docx);
-    const handleExportPdf = () => handleExportDocument(MarkdownRenditionFormat.pdf);
+    const handleExportPdf = () => handleExportDocument(MarkdownRenditionFormat.pdf, false);
+    const handleExportBrandedPdf = () => handleExportDocument(MarkdownRenditionFormat.pdf);
 
     const handleDownloadText = (e: React.MouseEvent) => {
         e.preventDefault();
@@ -694,6 +696,12 @@ function TextActions({
                                     <div className="flex items-center gap-2">
                                         {isDownloading ? <Spinner size="sm" /> : <Download className="size-4" />}
                                         Export as PDF
+                                    </div>
+                                </MenuItem>
+                                <MenuItem onClick={handleExportBrandedPdf} isDisabled={isDownloading}>
+                                    <div className="flex items-center gap-2">
+                                        {isDownloading ? <Spinner size="sm" /> : <Download className="size-4" />}
+                                        Export as Branded PDF
                                     </div>
                                 </MenuItem>
                             </>

--- a/packages/ui/src/features/store/objects/components/ContentOverview.tsx
+++ b/packages/ui/src/features/store/objects/components/ContentOverview.tsx
@@ -672,41 +672,47 @@ function TextActions({
                             )}
                         </>
                     )}
-                    <Dropdown trigger={
-                        <Button variant="ghost" size="sm" disabled={!text} className="flex items-center gap-2" alt="download">
-                            <Download className="size-4" />
-                        </Button>}>
-                        {fullText && (
-                            <MenuItem onClick={handleDownloadText} isDisabled={isDownloading}>
-                                <div className="flex items-center gap-2">
-                                    {isDownloading ? <Spinner size="sm" /> : <Download className="size-4" />}
-                                    Download Text
-                                </div>
-                            </MenuItem>
-                        )}
-                        {isMarkdown && text && (
-                            <>
-                                <MenuItem onClick={handleExportDocx} isDisabled={isDownloading}>
+                    {isDownloading ? (
+                        <Button variant="ghost" size="sm" disabled className="flex items-center gap-2" alt="download">
+                            <Spinner size="sm" />
+                        </Button>
+                    ) : (
+                        <Dropdown trigger={
+                            <Button variant="ghost" size="sm" disabled={!text} className="flex items-center gap-2" alt="download">
+                                <Download className="size-4" />
+                            </Button>}>
+                            {fullText && (
+                                <MenuItem onClick={handleDownloadText}>
                                     <div className="flex items-center gap-2">
-                                        {isDownloading ? <Spinner size="sm" /> : <Download className="size-4" />}
-                                        Export as DOCX
+                                        <Download className="size-4" />
+                                        Download Text
                                     </div>
                                 </MenuItem>
-                                <MenuItem onClick={handleExportPdf} isDisabled={isDownloading}>
-                                    <div className="flex items-center gap-2">
-                                        {isDownloading ? <Spinner size="sm" /> : <Download className="size-4" />}
-                                        Export as PDF
-                                    </div>
-                                </MenuItem>
-                                <MenuItem onClick={handleExportBrandedPdf} isDisabled={isDownloading}>
-                                    <div className="flex items-center gap-2">
-                                        {isDownloading ? <Spinner size="sm" /> : <Download className="size-4" />}
-                                        Export as Branded PDF
-                                    </div>
-                                </MenuItem>
-                            </>
-                        )}
-                    </Dropdown>
+                            )}
+                            {isMarkdown && text && (
+                                <>
+                                    <MenuItem onClick={handleExportDocx}>
+                                        <div className="flex items-center gap-2">
+                                            <Download className="size-4" />
+                                            Export as DOCX
+                                        </div>
+                                    </MenuItem>
+                                    <MenuItem onClick={handleExportPdf}>
+                                        <div className="flex items-center gap-2">
+                                            <Download className="size-4" />
+                                            Export as PDF
+                                        </div>
+                                    </MenuItem>
+                                    <MenuItem onClick={handleExportBrandedPdf}>
+                                        <div className="flex items-center gap-2">
+                                            <Download className="size-4" />
+                                            Export as Branded PDF
+                                        </div>
+                                    </MenuItem>
+                                </>
+                            )}
+                        </Dropdown>
+                    )}
 
                 </div>
             </div>

--- a/packages/ui/src/features/store/objects/components/ContentOverview.tsx
+++ b/packages/ui/src/features/store/objects/components/ContentOverview.tsx
@@ -1,7 +1,7 @@
 import { memo, useEffect, useRef, useState, type RefObject } from "react";
 
 import { AUDIO_RENDITION_NAME, AudioMetadata, ContentNature, ContentObject, ContentObjectStatus, DocAnalyzerProgress, DocProcessorOutputFormat, DocumentMetadata, ImageRenditionFormat, MarkdownRenditionFormat, PDF_RENDITION_NAME, Permission, POSTER_RENDITION_NAME, VideoMetadata, WorkflowExecutionStatus } from "@vertesia/common";
-import { Button, Dropdown, MenuItem, Portal, ResizableHandle, ResizablePanel, ResizablePanelGroup, Spinner, useToast } from "@vertesia/ui/core";
+import { Button, Dropdown, MenuItem, Portal, ResizableHandle, ResizablePanel, ResizablePanelGroup, Spinner, useFetch, useToast } from "@vertesia/ui/core";
 import { NavLink } from "@vertesia/ui/router";
 import { useUserSession } from "@vertesia/ui/session";
 import { JSONDisplay, MarkdownRenderer, Progress, XMLViewer } from "@vertesia/ui/widgets";
@@ -587,7 +587,11 @@ function TextActions({
     const { t } = useUITranslation();
     const content = object.content;
     const { renderDocument, isDownloading } = useDownloadFile({ client, toast });
-    const pdfTemplateObjectId = project?.configuration?.pdf_template_object_id;
+    const { data: fullProject } = useFetch(
+        () => project ? client.projects.retrieve(project.id, 'id,configuration') : Promise.resolve(undefined),
+        [project?.id]
+    );
+    const pdfTemplateObjectId = fullProject?.configuration?.pdf_template_object_id;
 
     const isMarkdown =
         content &&

--- a/packages/ui/src/features/store/objects/components/ContentOverview.tsx
+++ b/packages/ui/src/features/store/objects/components/ContentOverview.tsx
@@ -582,11 +582,12 @@ function TextActions({
     onToggleEdit,
     canEdit,
 }: TextActionsProps) {
-    const { client } = useUserSession();
+    const { client, project } = useUserSession();
     const toast = useToast();
     const { t } = useUITranslation();
     const content = object.content;
     const { renderDocument, isDownloading } = useDownloadFile({ client, toast });
+    const pdfTemplateObjectId = project?.configuration?.pdf_template_object_id;
 
     const isMarkdown =
         content &&
@@ -608,10 +609,14 @@ function TextActions({
             duration: 2000,
         });
 
+        // For branded exports, use the project-configured template if available
+        const templateObjectId = useDefaultTemplate !== false ? pdfTemplateObjectId : undefined;
+
         await renderDocument(object.id, {
             format,
             title: object.name || "document",
             useDefaultTemplate,
+            templateObjectId,
         });
     };
 

--- a/packages/ui/src/features/store/objects/components/useDownloadFile.ts
+++ b/packages/ui/src/features/store/objects/components/useDownloadFile.ts
@@ -20,6 +20,8 @@ export interface RenderAndDownloadOptions {
     pandocOptions?: string[];
     /** Use Vertesia default branded template (default: true for PDF) */
     useDefaultTemplate?: boolean;
+    /** Object ID of a content object containing a custom LaTeX template to use instead of the default */
+    templateObjectId?: string;
 }
 
 export interface UseDownloadFileResult {
@@ -121,6 +123,7 @@ export function useDownloadFile({ client, toast }: UseDownloadFileOptions): UseD
                 title: options.title,
                 pandoc_options: options.pandocOptions,
                 use_default_template: options.useDefaultTemplate,
+                template_path: options.templateObjectId ? `store:${options.templateObjectId}` : undefined,
             }, filename);
 
             toast({

--- a/packages/ui/src/features/store/objects/components/useDownloadFile.ts
+++ b/packages/ui/src/features/store/objects/components/useDownloadFile.ts
@@ -18,6 +18,8 @@ export interface RenderAndDownloadOptions {
     artifactRunId?: string;
     /** Additional Pandoc options */
     pandocOptions?: string[];
+    /** Use Vertesia default branded template (default: true for PDF) */
+    useDefaultTemplate?: boolean;
 }
 
 export interface UseDownloadFileResult {
@@ -118,6 +120,7 @@ export function useDownloadFile({ client, toast }: UseDownloadFileOptions): UseD
                 format: options.format,
                 title: options.title,
                 pandoc_options: options.pandocOptions,
+                use_default_template: options.useDefaultTemplate,
             }, filename);
 
             toast({


### PR DESCRIPTION
- Add 'Export as PDF' (no template) by passing use_default_template: false to the rendering API for the plain export.
- Renames the existing option to 'Export as Branded PDF'. 
- Replace the entire dropdown with a standalone disabled spinner button when downloading so it's visible to users.
- Add pdf_template_object_id to ProjectConfiguration type.                                                                                                                                       - Add templateObjectId option to RenderAndDownloadOptions.                        
- Read project-configured template object ID for branded PDF exports.                                