### PR TITLE
fix: normalize wildcard URL allowlist hosts

### DIFF
--- a/packages/common/src/host-utils.test.ts
+++ b/packages/common/src/host-utils.test.ts
@@ -13,6 +13,7 @@ describe('host-utils', () => {
     it('normalizes hosts, URLs, wildcards, ports, and IPv6 brackets', () => {
         expect(normalizeHost(' HTTPS://App.Example.COM:443/login ')).toBe('app.example.com');
         expect(normalizeHost('*.example.com')).toBe('example.com');
+        expect(normalizeHost('https://*.example.com/login')).toBe('example.com');
         expect(normalizeHost('localhost:3000')).toBe('localhost');
         expect(normalizeHost('::1')).toBe('::1');
         expect(normalizeHost('[::1]:3000')).toBe('::1');

--- a/packages/common/src/host-utils.ts
+++ b/packages/common/src/host-utils.ts
@@ -28,7 +28,7 @@ export function normalizeHost(value: unknown): string | undefined {
 
     try {
         const url = new URL(input);
-        let host = stripIPv6Brackets(url.hostname.toLowerCase());
+        let host = stripLeadingWildcard(stripIPv6Brackets(url.hostname.toLowerCase()));
         host = host.endsWith('.') ? host.slice(0, -1) : host;
         return host && !hasWhitespace(host) ? host : undefined;
     } catch {


### PR DESCRIPTION
## Summary
- Normalize wildcard hostnames after URL parsing so allowlist entries like https://*.example.com/login match example.com.
- Add a regression assertion for wildcard URL host normalization.

## Test Plan
- pnpm --dir composableai/packages/common test src/host-utils.test.ts
- pnpm --dir composableai/packages/common test
- pnpm --dir composableai/packages/common build