### PR TITLE
fix: smoke-test using published package instead of current code

### DIFF
--- a/packages/create-plugin/src/package-manager.ts
+++ b/packages/create-plugin/src/package-manager.ts
@@ -1,9 +1,19 @@
 /**
  * Package manager detection and selection
  */
+import chalk from 'chalk';
 import { execSync } from 'child_process';
 import prompts from 'prompts';
-import chalk from 'chalk';
+
+export function buildPackageManagerEnv(packageManager: string): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+
+  if (packageManager === 'pnpm' && !env.pnpm_config_registry && env.npm_config_registry) {
+    env.pnpm_config_registry = env.npm_config_registry;
+  }
+
+  return env;
+}
 
 /**
  * Check if a command exists on the system (cross-platform)
@@ -89,6 +99,7 @@ export async function installDependencies(projectName: string, packageManager: s
     execSync(`${packageManager} install`, {
       cwd: projectName,
       stdio: 'inherit',
+      env: buildPackageManagerEnv(packageManager),
     });
     console.log();
   } catch (error) {

--- a/packages/create-plugin/src/post-install.ts
+++ b/packages/create-plugin/src/post-install.ts
@@ -4,6 +4,7 @@
 import chalk from 'chalk';
 import { spawn, spawnSync } from 'child_process';
 import prompts from 'prompts';
+import { buildPackageManagerEnv } from './package-manager.js';
 import { PostInstallConfig, PreInstallConfig } from './template-config.js';
 
 /**
@@ -29,7 +30,8 @@ async function installGlobalPackage(packageName: string, packageManager: string)
 
     const child = spawn(packageManager, args, {
       stdio: 'inherit',
-      shell: true
+      shell: true,
+      env: buildPackageManagerEnv(packageManager)
     });
 
     child.on('close', (code) => {


### PR DESCRIPTION
Smoke test could fail under some conditions because it incorrectly used the latest published package instead of verdaccio.

The smoke test publishes the current branch’s packages to a local Verdaccio registry, then sets npm_config_registry before running @vertesia/create-plugin through npm exec.

That part works for npm exec, but the generated template does not necessarily install dependencies with npm. In non-interactive mode, create-plugin prefers pnpm when it is available. pnpm does not honor npm_config_registry for installs the way this flow expected; it uses pnpm_config_registry.

As a result, the bootstrap step could do this:

Fetch @vertesia/create-plugin from the intended registry.
Hand off dependency installation to pnpm.
pnpm then resolve template dependencies from public npm instead of Verdaccio

Fix: 
Propagate the registry setting in a pnpm-compatible way