### PR TITLE
Fix UI core circular imports

### DIFF
--- a/packages/ui/src/core/components/EmptyCollection.tsx
+++ b/packages/ui/src/core/components/EmptyCollection.tsx
@@ -1,5 +1,5 @@
 import { Plus } from "lucide-react";
-import { Button } from "@vertesia/ui/core";
+import { Button } from "./shadcn/button";
 
 
 interface EmptyInteractionsProps {

--- a/packages/ui/src/core/components/InputList.tsx
+++ b/packages/ui/src/core/components/InputList.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 
 import { Badge } from './shadcn/badge';
 import { Input } from './shadcn/input';
-import { VTooltip } from '@vertesia/ui/core';
+import { VTooltip } from './shadcn/tooltip';
 
 interface InputListProps {
     value?: string[];

--- a/packages/ui/src/core/components/shadcn/button.tsx
+++ b/packages/ui/src/core/components/shadcn/button.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
-import { VTooltip } from "@vertesia/ui/core"
+import { VTooltip } from "./tooltip"
 
 import { cn } from "../libs/utils"
 import { Check, CopyIcon, Loader2 } from "lucide-react"

--- a/packages/ui/src/core/components/shadcn/input.tsx
+++ b/packages/ui/src/core/components/shadcn/input.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "../libs/utils"
 import { X } from "lucide-react";
 import { ChangeEvent } from "react";
-import { Button } from "@vertesia/ui/core";
+import { Button } from "./button";
 
 const variants = cva(
   "",

--- a/packages/ui/src/core/hooks/useScrollableSearch.tsx
+++ b/packages/ui/src/core/hooks/useScrollableSearch.tsx
@@ -1,4 +1,4 @@
-import { useIntersectionObserver } from "@vertesia/ui/core";
+import { useIntersectionObserver } from "./useIntersectionObserver";
 import { useEffect, useRef, useState } from "react";
 
 interface SearchResponse<ResultT, PageT> {


### PR DESCRIPTION
## Summary
- Replace internal @vertesia/ui/core self-imports in core components/hooks with local module imports.
- Break the Rollup/Vite circular dependency warnings surfaced by plugin-template builds.

## Test Plan
- pnpm --prefix composableai/packages/ui run build
- pnpm --prefix composableai/packages/ui run lint (passes; existing warnings remain)
- pnpm --prefix composableai/packages/ui run test
- pnpm --prefix composableai/templates/plugin-template run lint
- pnpm --prefix composableai/templates/plugin-template run build
- pnpm --prefix composableai/templates/plugin-template run test (package placeholder exits with "Error: no test specified")
- pnpm --dir composableai run lint (passes; existing workspace warnings remain)
- pnpm --dir composableai run ci:test
- pnpm run build