### PR TITLE
fix: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Actions are pinned to commit SHAs; Dependabot updates the SHA + version comment.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/code-sync.yaml
+++ b/.github/workflows/code-sync.yaml
@@ -33,7 +33,7 @@ jobs:
       sync_ref: ${{ steps.sync.outputs.SYNC_REF }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # Fetch all because we need to access info from different branches
           fetch-tags: false
@@ -158,7 +158,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # Fetch all because we need to access info from different branches
           fetch-tags: false
@@ -236,7 +236,7 @@ jobs:
     if: ${{ always() && needs.sync.outputs.should_cleanup != 'false' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # Fetch all because we need to access info from different branches
           fetch-tags: false

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,11 +11,11 @@ jobs:
     name: Lint codebase
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,16 +10,16 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: "pnpm"
       - name: Install pandoc
-        uses: pandoc/actions/setup@main
+        uses: pandoc/actions/setup@86321b6dd4675f5014c611e05088e10d4939e09e # v1.1.1
       - name: Install native test dependencies
         run: |
           sudo apt-get update
@@ -34,11 +34,11 @@ jobs:
   template-smoke-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: "pnpm"

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -36,13 +36,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
           ssh-key: ${{ secrets.DEPLOY_KEY }} # Use deploy key to bypass branch protection rules
 
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
@@ -84,9 +84,9 @@ jobs:
     needs: publish
     if: inputs.dry_run == false
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
 

--- a/.github/workflows/update-git-submodule.yaml
+++ b/.github/workflows/update-git-submodule.yaml
@@ -39,14 +39,14 @@ jobs:
           echo "Branch '${{ env.TARGET_COMPOSABLEAI_BRANCH }}' is valid."
 
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
           fetch-depth: 0 # Fetch all history to ensure we can access the specified commit
           ref: ${{ env.TARGET_COMPOSABLEAI_BRANCH }}
 
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm


### PR DESCRIPTION
## Summary

Replace mutable major-version tags (e.g. `actions/checkout@v6`) on every third-party `uses:` reference with full 40-character commit SHAs and a trailing version comment.

**Why now:** Major-version tags are mutable — the action owner can move `@v6` to any commit at any time. This is exactly the vector exploited in the March 2025 `tj-actions/changed-files` supply-chain compromise (~23k repos affected). A poisoned action would have direct access to whatever secrets/tokens the workflow already exposes.

**SHA selection policy:** every pinned SHA references a commit authored **on or before 2026-05-13** (>=7 days old at time of authoring). This is a defense-in-depth window: if a maintainer's account was compromised within the past week but the release hasn't yet been publicly reported, our pins won't have landed on the tainted commit.

## Changes

- 5 workflow files repinned to SHAs + version comment
- New `.github/dependabot.yml` with the `github-actions` ecosystem so Dependabot keeps the SHA *and* the trailing comment in sync on weekly bumps
- Llumiverse submodule pointer bumped to pick up the same change there

## Submodule Changes

- llumiverse: https://github.com/vertesia/llumiverse/pull/407

## Verification

- All 6 modified/added YAML files parse cleanly with `yaml.safe_load` (no syntax breakage).
- No lint/typecheck/test apply to workflow-only changes — workflows are validated by GitHub Actions at runtime.

## Test plan

- [ ] Land llumiverse PR #407 first so the submodule bump points at a merged commit.
- [ ] Confirm `main.yaml` workflow on this PR succeeds with the pinned action SHAs.
- [ ] Confirm Dependabot opens a "github-actions" group PR within a week and the SHA + version comment update together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)