### PR TITLE
chore: lint cleanup, a11y fixes, test typecheck infra

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,6 +28,8 @@ jobs:
       - run: pnpm install
       - name: Build workspace
         run: pnpm build
+      - name: Typecheck tests
+        run: pnpm typecheck:test
       - name: Run package tests
         run: pnpm ci:test
 

--- a/biome.json
+++ b/biome.json
@@ -28,14 +28,14 @@
     "rules": {
       "recommended": false,
       "correctness": {
-        "noUnusedFunctionParameters": "warn",
-        "noUnusedImports": "warn",
-        "noUnusedVariables": "warn"
+        "noUnusedFunctionParameters": "error",
+        "noUnusedImports": "error",
+        "noUnusedVariables": "error"
       },
       "suspicious": {
-        "noExplicitAny": "warn",
-        "noImplicitAnyLet": "warn",
-        "noUnusedExpressions": "off"
+        "noExplicitAny": "error",
+        "noImplicitAnyLet": "error",
+        "noUnusedExpressions": "error"
       },
       "a11y": {
         "useAltText": "error",
@@ -50,11 +50,11 @@
         "useButtonType": "error",
         "useFocusableInteractive": "error",
         "useSemanticElements": "error",
-        "useKeyWithClickEvents": "warn",
-        "useKeyWithMouseEvents": "warn",
-        "noStaticElementInteractions": "warn",
-        "useAriaActivedescendantWithTabindex": "warn",
-        "noLabelWithoutControl": "warn"
+        "useKeyWithClickEvents": "error",
+        "useKeyWithMouseEvents": "error",
+        "noStaticElementInteractions": "error",
+        "useAriaActivedescendantWithTabindex": "error",
+        "noLabelWithoutControl": "error"
       }
     }
   },
@@ -89,7 +89,7 @@
         "rules": {
           "correctness": {
             "useExhaustiveDependencies": "warn",
-            "useHookAtTopLevel": "warn"
+            "useHookAtTopLevel": "error"
           }
         }
       }
@@ -103,7 +103,7 @@
         "rules": {
           "style": {
             "useComponentExportOnlyModules": {
-              "level": "warn",
+              "level": "error",
               "options": {
                 "allowConstantExport": true
               }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "pnpm exec turbo run build",
     "ci:test": "pnpm exec turbo run test --filter=@vertesia/api-fetch-client --filter=@vertesia/client --filter=@vertesia/converters --filter=@vertesia/json --filter=@vertesia/workflow --filter=@vertesia/ui",
     "test": "pnpm -r test",
+    "typecheck:test": "pnpm -r --if-present typecheck:test",
     "clean": "rimraf ./node_modules && pnpm -r clean",
     "prepublishOnly": "pnpm build",
     "lint": "pnpm exec biome lint",

--- a/packages/api-fetch-client/package.json
+++ b/packages/api-fetch-client/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "test": "ESBK_TSCONFIG_PATH=./test/tsconfig.json pnpm exec mocha -r tsx --exit ./test/**/*.ts",
     "lint": "biome lint src",
+    "typecheck:test": "tsc -p test/tsconfig.json --noEmit",
     "build": "pnpm exec tsmod build",
     "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
   },

--- a/packages/api-fetch-client/src/base.ts
+++ b/packages/api-fetch-client/src/base.ts
@@ -5,6 +5,10 @@ import { buildQueryString, join, removeTrailingSlash } from "./utils.js";
 export type FETCH_FN = (input: RequestInfo, init?: RequestInit) => Promise<Response>;
 type IPrimitives = string | number | boolean | null | undefined | string[] | number[] | boolean[];
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object';
+}
+
 export interface IRequestParams {
     query?: Record<string, IPrimitives> | null;
     headers?: Record<string, string> | null;
@@ -17,7 +21,7 @@ export interface IRequestParams {
      * If set to 'sse' the response will be treated as a server-sent event stream
      * and the request will return a Promise<ReadableStream<ServerSentEvent>> object
      */
-    reader?: 'sse' | ((response: Response) => any);
+    reader?: 'sse' | ((response: Response) => unknown);
     /**
      * Set to false to disable automatic JSON payload serialization
      * If you need to post other data than a json payload, set this to false and use the `payload` property to set the desired payload
@@ -42,8 +46,8 @@ export function fetchPromise(fetchImpl?: FETCH_FN | Promise<FETCH_FN>) {
     }
 }
 
-function isInvalidJsonPayload(payload: any) {
-    return payload?.error === "Not a valid JSON payload" && typeof payload.text === "string";
+function isInvalidJsonPayload(payload: unknown) {
+    return isRecord(payload) && payload.error === "Not a valid JSON payload" && typeof payload.text === "string";
 }
 
 export abstract class ClientBase {
@@ -79,24 +83,24 @@ export abstract class ClientBase {
         return removeTrailingSlash(join(this.baseUrl, path));
     }
 
-    get(path: string, params?: IRequestParams) {
-        return this.request('GET', path, params);
+    get<T = unknown>(path: string, params?: IRequestParams): Promise<T> {
+        return this.request<T>('GET', path, params);
     }
 
-    del(path: string, params?: IRequestParams) {
+    del<T = unknown>(path: string, params?: IRequestParams): Promise<T> {
+        return this.request<T>('DELETE', path, params);
+    }
+
+    delete(path: string, params?: IRequestParams): Promise<unknown> {
         return this.request('DELETE', path, params);
     }
 
-    delete(path: string, params?: IRequestParams) {
-        return this.request('DELETE', path, params);
+    post<T = unknown>(path: string, params?: IRequestParamsWithPayload): Promise<T> {
+        return this.request<T>('POST', path, params);
     }
 
-    post(path: string, params?: IRequestParamsWithPayload) {
-        return this.request('POST', path, params);
-    }
-
-    put(path: string, params?: IRequestParamsWithPayload) {
-        return this.request('PUT', path, params);
+    put<T = unknown>(path: string, params?: IRequestParamsWithPayload): Promise<T> {
+        return this.request<T>('PUT', path, params);
     }
 
     /**
@@ -104,7 +108,7 @@ export abstract class ClientBase {
      * @param text
      * @returns
      */
-    jsonParse(text: string) {
+    jsonParse(text: string): unknown {
         return JSON.parse(text);
     }
 
@@ -119,20 +123,20 @@ export abstract class ClientBase {
         return Promise.resolve(new Request(url, init));
     }
 
-    createServerError(req: Request, res: Response, payload: any): RequestError {
+    createServerError(req: Request, res: Response, payload: unknown): RequestError {
         const status = res.status;
         let message = 'Server Error: ' + status;
         if (payload) {
             if (isInvalidJsonPayload(payload)) {
                 message += res.statusText ? ' ' + res.statusText : '';
                 message += ': non-JSON response';
-            } else if (payload.message) {
+            } else if (isRecord(payload) && payload.message) {
                 message = String(payload.message);
-            } else if (payload.error) {
+            } else if (isRecord(payload) && payload.error) {
                 if (typeof payload.error === 'string') {
                     message = String(payload.error);
-                } else if (typeof payload.error.message === 'string') {
-                    message = String(payload.error.message);
+                } else if (isRecord(payload.error) && typeof payload.error.message === 'string') {
+                    message = payload.error.message;
                 }
             }
         }
@@ -147,20 +151,20 @@ export abstract class ClientBase {
             } else {
                 try {
                     return this.jsonParse(text);
-                } catch (err: any) {
+                } catch (err: unknown) {
                     return {
                         status: res.status,
                         error: "Not a valid JSON payload",
-                        message: err.message,
+                        message: err instanceof Error ? err.message : String(err),
                         text: text,
                     };
                 }
             }
-        }).catch((err) => {
+        }).catch((err: unknown) => {
             return {
                 status: res.status,
                 error: "Unable to load response content",
-                message: err.message,
+                message: err instanceof Error ? err.message : String(err),
             };
         });
     }
@@ -169,17 +173,17 @@ export abstract class ClientBase {
      * Subclasses You can override this to do something with the response
      * @param res
      */
-    handleResponse(req: Request, res: Response, params: IRequestParamsWithPayload | undefined) {
+    handleResponse<T = unknown>(req: Request, res: Response, params: IRequestParamsWithPayload | undefined): T | Promise<T> {
         if (params && params.reader) {
             if (params.reader === 'sse') {
-                return sse(res);
+                return sse(res) as T;
             } else {
-                return params.reader.call(this, res);
+                return params.reader.call(this, res) as T | Promise<T>;
             }
         } else {
             return this.readJSONPayload(res).then((payload) => {
                 if (res.ok) {
-                    return payload;
+                    return payload as T;
                 } else {
                     this.throwError(this.createServerError(req, res, payload));
                 }
@@ -187,7 +191,7 @@ export abstract class ClientBase {
         }
     }
 
-    async request(method: string, path: string, params?: IRequestParamsWithPayload) {
+    async request<T = unknown>(method: string, path: string, params?: IRequestParamsWithPayload): Promise<T> {
         let url = this.getUrl(path);
         if (params?.query) {
             url += '?' + buildQueryString(params.query);
@@ -226,7 +230,7 @@ export abstract class ClientBase {
             console.error(`Failed to connect to ${url}`, err);
             this.throwError(new ConnectionError(req, err));
         }).then(res => {
-            return this.handleResponse(req, res, params);
+            return this.handleResponse<T>(req, res, params);
         }));
     }
 

--- a/packages/api-fetch-client/src/client.ts
+++ b/packages/api-fetch-client/src/client.ts
@@ -97,13 +97,13 @@ export class AbstractFetchClient<T extends AbstractFetchClient<T>> extends Clien
         }
         this.response = undefined;
         const request = await super.createRequest(url, init);
-        this.onRequest && this.onRequest(request);
+        this.onRequest?.(request);
         return request;
     }
 
     async handleResponse<T = unknown>(req: Request, res: Response, params: IRequestParamsWithPayload | undefined): Promise<T> {
         this.response = res; // store last response
-        this.onResponse && this.onResponse(res, req);
+        this.onResponse?.(res, req);
         return super.handleResponse<T>(req, res, params);
     }
 

--- a/packages/api-fetch-client/src/client.ts
+++ b/packages/api-fetch-client/src/client.ts
@@ -101,10 +101,10 @@ export class AbstractFetchClient<T extends AbstractFetchClient<T>> extends Clien
         return request;
     }
 
-    async handleResponse(req: Request, res: Response, params: IRequestParamsWithPayload | undefined) {
+    async handleResponse<T = unknown>(req: Request, res: Response, params: IRequestParamsWithPayload | undefined): Promise<T> {
         this.response = res; // store last response
         this.onResponse && this.onResponse(res, req);
-        return super.handleResponse(req, res, params);
+        return super.handleResponse<T>(req, res, params);
     }
 
 }
@@ -132,8 +132,8 @@ export abstract class ApiTopic extends ClientBase {
         return this.client.createRequest(url, init);
     }
 
-    handleResponse(req: Request, res: Response, params: IRequestParamsWithPayload | undefined): Promise<any> {
-        return this.client.handleResponse(req, res, params);
+    handleResponse<T = unknown>(req: Request, res: Response, params: IRequestParamsWithPayload | undefined): T | Promise<T> {
+        return this.client.handleResponse<T>(req, res, params);
     }
 
     get headers() {

--- a/packages/api-fetch-client/src/errors.ts
+++ b/packages/api-fetch-client/src/errors.ts
@@ -1,9 +1,23 @@
 
-function createMessage(message: string, request: Request, status: number, payload: any, displayDetails: boolean) {
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object';
+}
+
+function getDetails(payload: unknown): unknown {
+    if (!isRecord(payload)) {
+        return undefined;
+    }
+    if (payload.details) {
+        return payload.details;
+    }
+    return isRecord(payload.error) ? payload.error.details : undefined;
+}
+
+function createMessage(message: string, request: Request, status: number, payload: unknown, displayDetails: boolean) {
     let msg = message;
     if (displayDetails) {
         msg += '\nRequest: ' + request.method + ' ' + request.url + ' => ' + status;
-        const details = payload?.details || payload?.error?.details;
+        const details = getDetails(payload);
         if (details) {
             const detailsType = typeof details;
             if (detailsType === 'string') {
@@ -19,12 +33,12 @@ function createMessage(message: string, request: Request, status: number, payloa
 
 export class RequestError extends Error {
     status: number;
-    payload: any;
+    payload: unknown;
     request: Request;
     request_info: string;
     displayDetails: boolean;
     original_message: string;
-    constructor(message: string, request: Request, status: number, payload: any, displayDetails = true) {
+    constructor(message: string, request: Request, status: number, payload: unknown, displayDetails = true) {
         super(createMessage(message, request, status, payload, displayDetails));
         this.original_message = message;
         this.request = request;
@@ -35,19 +49,20 @@ export class RequestError extends Error {
     }
 
     get details() {
-        return this.payload?.details || this.payload?.error?.details;
+        return getDetails(this.payload);
     }
 
 }
 
 export class ServerError extends RequestError {
-    constructor(message: string, req: Request, status: number, payload: any, displayDetails = true) {
+    constructor(message: string, req: Request, status: number, payload: unknown, displayDetails = true) {
         super(message, req, status, payload, displayDetails);
     }
 
-    updateDetails(details: any) {
+    updateDetails(details: unknown) {
         if (details !== this.details) {
-            return new ServerError(this.original_message, this.request, this.status, { ...this.payload, details }, this.displayDetails)
+            const payload = isRecord(this.payload) ? { ...this.payload, details } : { details };
+            return new ServerError(this.original_message, this.request, this.status, payload, this.displayDetails)
         } else {
             return this;
         }

--- a/packages/api-fetch-client/src/sse/TextDecoderStream.ts
+++ b/packages/api-fetch-client/src/sse/TextDecoderStream.ts
@@ -55,8 +55,7 @@ if (globalThis.TextDecoderStream && typeof globalThis.TextDecoderStream === 'fun
             }
         }
     }
-    _TextDecoderStream = MyTextDecoderStream as any;
+    _TextDecoderStream = MyTextDecoderStream as typeof TextDecoderStream;
 }
 
 export { _TextDecoderStream as TextDecoderStream };
-

--- a/packages/api-fetch-client/src/sse/index.ts
+++ b/packages/api-fetch-client/src/sse/index.ts
@@ -13,8 +13,8 @@ export type ServerSentEvent = ParsedEvent | ReconnectInterval;
 export async function sse(response: Response): Promise<ReadableStream<ServerSentEvent>> {
     if (!response.ok) {
         const text = await response.text();
-        const error = new Error("SSE error: " + response.status + ". Content:\n" + text);
-        (error as any).status = response.status;
+        const error = new Error("SSE error: " + response.status + ". Content:\n" + text) as Error & { status?: number };
+        error.status = response.status;
         throw error;
     }
     if (!response.body) {

--- a/packages/api-fetch-client/src/utils.ts
+++ b/packages/api-fetch-client/src/utils.ts
@@ -1,5 +1,5 @@
 
-export function buildQueryString(query: any) {
+export function buildQueryString(query: Record<string, unknown>) {
     const parts = [];
     for (const key of Object.keys(query)) {
         const val = query[key];

--- a/packages/api-fetch-client/test/endpoints.ts
+++ b/packages/api-fetch-client/test/endpoints.ts
@@ -12,7 +12,7 @@ export default class Endpoints extends Resource {
         router.get("/no-content", this.getNoContent, this);
     }
 
-    async getRoot(ctx: Context) {
+    async getRoot(_ctx: Context) {
         return { message: "Hello World!" };
     }
 

--- a/packages/api-fetch-client/test/test.ts
+++ b/packages/api-fetch-client/test/test.ts
@@ -25,30 +25,37 @@ after(() => server.stop());
 
 describe('Test requests', () => {
     it('get method works', done => {
-        client.get('/').then((payload: any) => {
-            assert(payload.message === "Hello World!");
+        client.get('/').then((payload) => {
+            assert((payload as { message: string }).message === "Hello World!");
             done();
         }).catch(done);
     });
     it('withHeaders works', done => {
-        client.get('/token').then((payload: any) => {
-            assert(payload.token === "1234");
+        client.get('/token').then((payload) => {
+            assert((payload as { token: string }).token === "1234");
             done();
         }).catch(done);
     });
     it('handles incorrect content type', done => {
-        client.get('/html').then((payload: any) => {
-            assert(payload.text === "<html><body>Hello!</body></html>");
+        client.get('/html').then((payload) => {
+            assert((payload as { text: string }).text === "<html><body>Hello!</body></html>");
             done();
         }).catch(done);
     });
     it('handles errors in incorrect content type', done => {
-        client.get('/html-error').catch((err: any) => {
-            assert(err.payload.text === "<html><body>Error!</body></html>");
-            assert(err.status === 401);
-            assert(err.original_message.startsWith("Server Error: 401"));
-            assert(err.original_message.includes("non-JSON response"));
-            assert(!err.message.includes("Unexpected token"));
+        type FetchErr = {
+            payload: { text: string };
+            status: number;
+            original_message: string;
+            message: string;
+        };
+        client.get('/html-error').catch((err: unknown) => {
+            const e = err as FetchErr;
+            assert(e.payload.text === "<html><body>Error!</body></html>");
+            assert(e.status === 401);
+            assert(e.original_message.startsWith("Server Error: 401"));
+            assert(e.original_message.includes("non-JSON response"));
+            assert(!e.message.includes("Unexpected token"));
             done();
         }).catch(done);
     });

--- a/packages/api-fetch-client/test/tsconfig.json
+++ b/packages/api-fetch-client/test/tsconfig.json
@@ -22,7 +22,8 @@
     "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
     "strict": true, /* Enable all strict type-checking options. */ /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true, /* Skip type checking all .d.ts files. */
+    "types": ["mocha"]
   },
   "references": [
     {

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "lint": "biome lint src",
     "test": "vitest run",
+    "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
     "build": "pnpm exec tsmod build && pnpm exec rollup -c",
     "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
   },

--- a/packages/build-tools/src/parsers/frontmatter.ts
+++ b/packages/build-tools/src/parsers/frontmatter.ts
@@ -6,7 +6,7 @@ import matter from 'gray-matter';
 
 export interface FrontmatterResult {
     /** Parsed frontmatter data */
-    frontmatter: Record<string, any>;
+    frontmatter: Record<string, unknown>;
 
     /** Content without frontmatter */
     content: string;

--- a/packages/build-tools/src/presets/prompt.ts
+++ b/packages/build-tools/src/presets/prompt.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 import type { TransformerPreset } from '../types.js';
 import { parseFrontmatter } from '../parsers/frontmatter.js';
 import path from 'path';
-import { TemplateType } from '@vertesia/common';
+import { JSONSchema, TemplateType } from '@vertesia/common';
 import { PromptRole } from '@llumiverse/common';
 
 /**
@@ -44,7 +44,7 @@ export const PromptDefinitionSchema = z.object({
     role: z.nativeEnum(PromptRole),
     content: z.string(),
     content_type: z.nativeEnum(TemplateType),
-    schema: z.any().optional(),
+    schema: z.custom<JSONSchema>().optional(),
     name: z.string().optional(),
     externalId: z.string().optional(),
 });
@@ -53,6 +53,8 @@ export const PromptDefinitionSchema = z.object({
  * TypeScript type inferred from the Zod schema
  */
 export type PromptDefinition = z.infer<typeof PromptDefinitionSchema>;
+
+type PromptFrontmatter = z.infer<typeof PromptFrontmatterSchema>;
 
 /**
  * Normalize schema path for import
@@ -114,7 +116,7 @@ function inferContentType(filePath: string): TemplateType {
  * @returns Prompt definition object and optional imports
  */
 function buildPromptDefinition(
-    frontmatter: Record<string, any>,
+    frontmatter: PromptFrontmatter,
     content: string,
     filePath: string
 ): { prompt: PromptDefinition; imports?: string[]; schemaImportName?: string } {
@@ -184,9 +186,11 @@ export const promptTransformer: TransformerPreset = {
             );
         }
 
+        const validatedFrontmatter = frontmatterValidation.data;
+
         // Build prompt definition
         const { prompt, imports, schemaImportName } = buildPromptDefinition(
-            frontmatter,
+            validatedFrontmatter,
             promptContent,
             filePath
         );

--- a/packages/build-tools/src/presets/skill-collection.ts
+++ b/packages/build-tools/src/presets/skill-collection.ts
@@ -61,7 +61,7 @@ export const skillCollectionTransformer: TransformerPreset = {
                         names.push(identifier);
                     }
                 }
-            } catch (err) {
+            } catch {
                 // Skip entries that can't be read
                 continue;
             }

--- a/packages/build-tools/src/presets/skill.ts
+++ b/packages/build-tools/src/presets/skill.ts
@@ -79,7 +79,7 @@ const SkillFrontmatterSchema = z.object({
     execution: SkillExecutionFrontmatterSchema.optional(),
     input_schema: z.object({
         type: z.literal('object'),
-        properties: z.record(z.any()).optional(),
+        properties: z.record(z.unknown()).optional(),
         required: z.array(z.string()).optional()
     }).optional(),
 
@@ -105,7 +105,7 @@ export const SkillDefinitionSchema = z.object({
     content_type: z.enum(['md', 'jst']),
     input_schema: z.object({
         type: z.literal('object'),
-        properties: z.record(z.any()).optional(),
+        properties: z.record(z.unknown()).optional(),
         required: z.array(z.string()).optional()
     }).optional(),
     context_triggers: SkillContextTriggersSchema,
@@ -130,6 +130,8 @@ export const SkillPropertiesSchema = SkillDefinitionSchema.partial().passthrough
  * Can also be imported from consumer packages for type safety
  */
 export type SkillDefinition = z.infer<typeof SkillDefinitionSchema>;
+
+type SkillFrontmatter = z.infer<typeof SkillFrontmatterSchema>;
 
 /**
  * Build a SkillDefinition from frontmatter and markdown content.
@@ -160,7 +162,7 @@ export type SkillDefinition = z.infer<typeof SkillDefinitionSchema>;
  * @returns Skill definition object
  */
 function buildSkillDefinition(
-    frontmatter: Record<string, any>,
+    frontmatter: SkillFrontmatter,
     instructions: string,
     contentType: SkillContentType,
     widgets: string[],
@@ -180,7 +182,7 @@ function buildSkillDefinition(
     // Nested: context_triggers: { keywords: [...], tool_names: [...] }
     // Flat: keywords: [...], tools: [...]
     const contextTriggers = frontmatter.context_triggers;
-    const hasNestedTriggers = contextTriggers && typeof contextTriggers === 'object';
+    const hasNestedTriggers = contextTriggers !== undefined;
     const hasFlatTriggers = frontmatter.keywords || frontmatter.tools || frontmatter.data_patterns;
 
     if (hasNestedTriggers || hasFlatTriggers) {
@@ -193,19 +195,25 @@ function buildSkillDefinition(
 
     // Build execution config - support both flat and nested structure
     const execution = frontmatter.execution;
-    const hasNestedExecution = execution && typeof execution === 'object';
-    const hasFlatExecution = frontmatter.language;
 
-    if (hasNestedExecution || hasFlatExecution) {
+    if (execution) {
         skill.execution = {
-            language: hasNestedExecution ? execution.language : frontmatter.language,
-            packages: hasNestedExecution ? execution.packages : frontmatter.packages,
-            system_packages: hasNestedExecution ? execution.system_packages : frontmatter.system_packages,
+            language: execution.language,
+            packages: execution.packages,
+            system_packages: execution.system_packages,
         };
+    } else if (frontmatter.language) {
+        skill.execution = {
+            language: frontmatter.language,
+            packages: frontmatter.packages,
+            system_packages: frontmatter.system_packages,
+        };
+    }
 
+    if (skill.execution) {
         // Extract code template from instructions if present
         const codeBlockMatch = instructions.match(/```(?:python|javascript|typescript|js|ts|py)\n([\s\S]*?)```/);
-        if (codeBlockMatch) {
+        if (codeBlockMatch?.[1]) {
             skill.execution.template = codeBlockMatch[1].trim();
         }
     }
@@ -263,15 +271,17 @@ export const skillTransformer: TransformerPreset = {
             );
         }
 
+        const validatedFrontmatter = frontmatterValidation.data;
+
         // Determine content type from frontmatter or file extension
-        const content_type: SkillContentType = frontmatter.content_type || 'md';
+        const content_type: SkillContentType = validatedFrontmatter.content_type || 'md';
 
         // Discover assets (scripts and widgets) in the skill directory
         const assets = discoverSkillAssets(filePath);
 
         // Build skill definition using the same logic as parseSkillFile in tools-sdk
         const skillData = buildSkillDefinition(
-            frontmatter,
+            validatedFrontmatter,
             markdown,
             content_type,
             assets.widgets,

--- a/packages/build-tools/src/presets/template.ts
+++ b/packages/build-tools/src/presets/template.ts
@@ -20,6 +20,8 @@ const TemplateFrontmatterSchema = z.object({
     type: z.enum(['presentation', 'document']),
 }).strict();
 
+type TemplateFrontmatter = z.infer<typeof TemplateFrontmatterSchema>;
+
 /**
  * MUST be kept in sync with @vertesia/tools-sdk RenderingTemplateDefinition
  * Zod schema for template definition
@@ -88,6 +90,7 @@ export const templateTransformer: TransformerPreset = {
                 `Invalid frontmatter in ${filePath}:\n${errors}`
             );
         }
+        const validatedFrontmatter: TemplateFrontmatter = frontmatterValidation.data;
 
         // Derive template path from directory structure
         const { category, templateName, relative: templatePath } = deriveTemplatePathInfo(filePath);
@@ -100,11 +103,11 @@ export const templateTransformer: TransformerPreset = {
         const templateData: RenderingTemplateDefinition = {
             id: `${category}:${templateName}`,
             name: templateName,
-            title: frontmatter.title,
-            description: frontmatter.description,
+            title: validatedFrontmatter.title,
+            description: validatedFrontmatter.description,
             instructions: markdown,
-            tags: frontmatter.tags,
-            type: frontmatter.type,
+            tags: validatedFrontmatter.tags,
+            type: validatedFrontmatter.type,
             assets: assets.fileNames.map(f => `/templates/${templatePath}/${f}`),
         };
 

--- a/packages/build-tools/src/types.ts
+++ b/packages/build-tools/src/types.ts
@@ -58,7 +58,7 @@ export interface TransformerRule {
     transform: TransformFunction;
 
     /** Optional: Zod schema for validation */
-    schema?: z.ZodType<any>;
+    schema?: z.ZodType<unknown>;
 
     /** Optional: If true, the transformer generates virtual modules (no file to read) */
     virtual?: boolean;

--- a/packages/build-tools/src/utils/widget-compiler.ts
+++ b/packages/build-tools/src/utils/widget-compiler.ts
@@ -2,10 +2,29 @@
  * Widget compilation utility using Rollup
  */
 
-import { rollup, type RollupOptions, type Plugin } from 'rollup';
+import { rollup, type RollupOptions, type OutputOptions, type Plugin } from 'rollup';
 import path from 'node:path';
 import type { WidgetConfig } from '../types.js';
 import type { WidgetMetadata } from './asset-discovery.js';
+import type { RollupTypescriptOptions } from '@rollup/plugin-typescript';
+import type { RollupJsonOptions } from '@rollup/plugin-json';
+import type { RollupNodeResolveOptions } from '@rollup/plugin-node-resolve';
+import type { Options as TerserOptions } from '@rollup/plugin-terser';
+
+type PluginFactory<TOptions = undefined> = (options?: TOptions) => Plugin;
+
+function getPluginFactory<TOptions>(module: unknown, packageName: string): PluginFactory<TOptions> {
+    if (typeof module === 'function') {
+        return module as PluginFactory<TOptions>;
+    }
+    if (module && typeof module === 'object' && 'default' in module) {
+        const defaultExport = module.default;
+        if (typeof defaultExport === 'function') {
+            return defaultExport as PluginFactory<TOptions>;
+        }
+    }
+    throw new Error(`Rollup plugin ${packageName} does not export a plugin factory`);
+}
 
 /**
  * Default external dependencies for widgets
@@ -44,14 +63,22 @@ export async function compileWidgets(
 
     // Build each widget separately to get individual bundles
     const buildPromises = widgets.map(async (widget) => {
-        // Dynamically import plugins - use any to bypass TypeScript module resolution issues
-        const typescript = (await import('@rollup/plugin-typescript' as any)).default as any;
-        const nodeResolve = (await import('@rollup/plugin-node-resolve' as any)).default as any;
-        const commonjs = (await import('@rollup/plugin-commonjs' as any)).default as any;
+        const typescript = getPluginFactory<RollupTypescriptOptions>(
+            await import('@rollup/plugin-typescript'),
+            '@rollup/plugin-typescript'
+        );
+        const nodeResolve = getPluginFactory<RollupNodeResolveOptions>(
+            await import('@rollup/plugin-node-resolve'),
+            '@rollup/plugin-node-resolve'
+        );
+        const commonjs = getPluginFactory(await import('@rollup/plugin-commonjs'), '@rollup/plugin-commonjs');
         // @rollup/plugin-json — required when widgets transitively import JSON files,
         // e.g. @vertesia/ui pulls in i18n locale JSON via lib/esm/i18n/locales/*.json.
         // Without this, Rollup tries to parse JSON as JS and bails.
-        const json = (await import('@rollup/plugin-json' as any)).default as any;
+        const json = getPluginFactory<RollupJsonOptions>(
+            await import('@rollup/plugin-json'),
+            '@rollup/plugin-json'
+        );
 
         const plugins: Plugin[] = [
             typescript({
@@ -73,7 +100,10 @@ export async function compileWidgets(
 
         // Add minification if requested
         if (minify) {
-            const { terser } = await import('rollup-plugin-terser' as any);
+            const terser = getPluginFactory<TerserOptions>(
+                await import('@rollup/plugin-terser'),
+                '@rollup/plugin-terser'
+            );
             plugins.push(
                 terser({
                     compress: {
@@ -83,14 +113,16 @@ export async function compileWidgets(
             );
         }
 
+        const output: OutputOptions = {
+            file: path.join(outputDir, `${widget.name}.js`),
+            format: 'es',
+            sourcemap: true,
+            inlineDynamicImports: true
+        };
+
         const rollupConfig: RollupOptions = {
             input: widget.path,
-            output: {
-                file: path.join(outputDir, `${widget.name}.js`),
-                format: 'es',
-                sourcemap: true,
-                inlineDynamicImports: true
-            },
+            output,
             external,
             plugins,
             // Suppress noisy but benign upstream-library warnings:
@@ -109,7 +141,7 @@ export async function compileWidgets(
         };
 
         const bundle = await rollup(rollupConfig);
-        await bundle.write(rollupConfig.output as any);
+        await bundle.write(output);
         await bundle.close();
     });
 

--- a/packages/build-tools/tests/asset-discovery.test.ts
+++ b/packages/build-tools/tests/asset-discovery.test.ts
@@ -31,7 +31,7 @@ describe('Asset Discovery', () => {
     expect(scriptAssets).toHaveLength(2);
 
     // Widgets should NOT have asset files (compiled separately)
-    const widgetAssets = assets.assetFiles.filter(a => a.type === 'widget');
+    const widgetAssets = assets.assetFiles.filter(a => (a.type as string) === 'widget');
     expect(widgetAssets).toHaveLength(0);
   });
 

--- a/packages/build-tools/tests/skill-assets.test.ts
+++ b/packages/build-tools/tests/skill-assets.test.ts
@@ -21,7 +21,7 @@ describe('Skill Transformer with Assets', () => {
     expect(result.data).toHaveProperty('scripts');
     expect(result.data).toHaveProperty('widgets');
 
-    const data = result.data as any;
+    const data = result.data as { scripts?: string[]; widgets?: string[] };
     expect(data.scripts).toContain('helper.js');
     expect(data.scripts).toContain('script.py');
     expect(data.widgets).toContain('widget');
@@ -61,7 +61,7 @@ describe('Skill Transformer with Assets', () => {
 
     const result = await skillTransformer.transform(content, filePath);
 
-    const data = result.data as any;
+    const data = result.data as { scripts?: string[]; widgets?: string[] };
     expect(data.scripts).toBeUndefined();
     expect(data.widgets).toBeUndefined();
   });

--- a/packages/build-tools/tests/skill.test.ts
+++ b/packages/build-tools/tests/skill.test.ts
@@ -38,7 +38,7 @@ Content here`;
 
     const result = await skillTransformer.transform(content, 'test.md');
     expect(result.data).toHaveProperty('context_triggers');
-    expect((result.data as any).context_triggers).toEqual({
+    expect((result.data as { context_triggers: { keywords: string[] } }).context_triggers).toEqual({
       keywords: ['foo', 'bar', 'baz']
     });
   });
@@ -54,7 +54,7 @@ Content`;
 
     const result = await skillTransformer.transform(content, 'test.md');
     expect(result.data).toHaveProperty('tools');
-    expect((result.data as any).tools).toEqual(['tool1', 'tool2']);
+    expect((result.data as { tools: string[] }).tools).toEqual(['tool1', 'tool2']);
   });
 
   it('should validate against schema successfully', () => {

--- a/packages/build-tools/tsconfig.test.json
+++ b/packages/build-tools/tsconfig.test.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": true,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "src",
+    "tests"
+  ],
+  "exclude": [
+    "node_modules",
+    "lib",
+    "tests/fixtures"
+  ]
+}

--- a/packages/cli/src/agent-context.ts
+++ b/packages/cli/src/agent-context.ts
@@ -1,4 +1,11 @@
-export function getAgentRunId(options: Record<string, unknown> = {}): string {
+import { getStringOption, type CliOptions } from "./utils/options.js";
+
+type RunContextOptions = CliOptions<{
+    runId?: string;
+    storageId?: string;
+}>;
+
+export function getAgentRunId(options: RunContextOptions = {}): string {
     const runId =
         getStringOption(options.runId)
         || process.env.VERTESIA_AGENTRUN_ID
@@ -14,7 +21,7 @@ export function getAgentRunId(options: Record<string, unknown> = {}): string {
     return runId;
 }
 
-export function getArtifactStorageId(options: Record<string, unknown> = {}): string {
+export function getArtifactStorageId(options: RunContextOptions = {}): string {
     const storageId =
         getStringOption(options.runId)
         || getStringOption(options.storageId)
@@ -30,8 +37,4 @@ export function getArtifactStorageId(options: Record<string, unknown> = {}): str
     }
 
     return storageId;
-}
-
-function getStringOption(value: unknown): string | undefined {
-    return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
 }

--- a/packages/cli/src/apps/commands.ts
+++ b/packages/cli/src/apps/commands.ts
@@ -3,8 +3,24 @@ import colors from "ansi-colors";
 import { Command } from "commander";
 import { readFile } from "fs/promises";
 import { getClient } from "../client.js";
+import { hasErrorCode, isRecord, type CliOptions } from "../utils/options.js";
 
-export async function listApps(program: Command, _options: Record<string, any>) {
+type ManifestOptions = CliOptions<{
+    manifest?: string;
+    manifestFile?: string;
+    install?: boolean;
+}>;
+
+type SettingsOptions = CliOptions<{
+    settings?: string;
+    settingsFile?: string;
+}>;
+
+type InstalledAppsOptions = CliOptions<{
+    kind?: AppInstallationKind;
+}>;
+
+export async function listApps(program: Command, _options: Record<string, unknown>) {
     const client = await getClient(program);
     const apps = await client.apps.list();
 
@@ -23,7 +39,7 @@ export async function listApps(program: Command, _options: Record<string, any>) 
     });
 }
 
-export async function getApp(program: Command, appId: string, _options: Record<string, any>) {
+export async function getApp(program: Command, appId: string, _options: Record<string, unknown>) {
     const client = await getClient(program);
     const apps = await client.apps.list();
 
@@ -37,7 +53,7 @@ export async function getApp(program: Command, appId: string, _options: Record<s
     console.log(JSON.stringify(app, null, 2));
 }
 
-export async function createApp(program: Command, options: Record<string, any>) {
+export async function createApp(program: Command, options: ManifestOptions) {
     const client = await getClient(program);
 
     let manifest: AppManifestData;
@@ -45,9 +61,9 @@ export async function createApp(program: Command, options: Record<string, any>) 
     if (options.manifestFile) {
         try {
             const content = await readFile(options.manifestFile, 'utf-8');
-            manifest = JSON.parse(content);
-        } catch (err: any) {
-            if (err.code === 'ENOENT') {
+            manifest = JSON.parse(content) as AppManifestData;
+        } catch (err: unknown) {
+            if (hasErrorCode(err, 'ENOENT')) {
                 console.error(`${colors.red('✗')} File not found: ${options.manifestFile}`);
                 process.exit(1);
             }
@@ -55,8 +71,8 @@ export async function createApp(program: Command, options: Record<string, any>) 
         }
     } else if (options.manifest) {
         try {
-            manifest = JSON.parse(options.manifest);
-        } catch (err) {
+            manifest = JSON.parse(options.manifest) as AppManifestData;
+        } catch {
             console.error(`${colors.red('✗')} Invalid JSON in manifest option`);
             process.exit(1);
         }
@@ -97,7 +113,7 @@ export async function createApp(program: Command, options: Record<string, any>) 
     }
 }
 
-export async function updateApp(program: Command, appId: string, options: Record<string, any>) {
+export async function updateApp(program: Command, appId: string, options: ManifestOptions) {
     const client = await getClient(program);
 
     let manifest: AppManifestData;
@@ -105,9 +121,9 @@ export async function updateApp(program: Command, appId: string, options: Record
     if (options.manifestFile) {
         try {
             const content = await readFile(options.manifestFile, 'utf-8');
-            manifest = JSON.parse(content);
-        } catch (err: any) {
-            if (err.code === 'ENOENT') {
+            manifest = JSON.parse(content) as AppManifestData;
+        } catch (err: unknown) {
+            if (hasErrorCode(err, 'ENOENT')) {
                 console.error(`${colors.red('✗')} File not found: ${options.manifestFile}`);
                 process.exit(1);
             }
@@ -115,8 +131,8 @@ export async function updateApp(program: Command, appId: string, options: Record
         }
     } else if (options.manifest) {
         try {
-            manifest = JSON.parse(options.manifest);
-        } catch (err) {
+            manifest = JSON.parse(options.manifest) as AppManifestData;
+        } catch {
             console.error(`${colors.red('✗')} Invalid JSON in manifest option`);
             process.exit(1);
         }
@@ -131,17 +147,17 @@ export async function updateApp(program: Command, appId: string, options: Record
     console.log(`  Name: ${result.name}`);
 }
 
-export async function installApp(program: Command, appId: string, options: Record<string, any>) {
+export async function installApp(program: Command, appId: string, options: SettingsOptions) {
     const client = await getClient(program);
 
-    let settings: Record<string, any> | undefined;
+    let settings: Record<string, unknown> | undefined;
 
     if (options.settingsFile) {
         try {
             const content = await readFile(options.settingsFile, 'utf-8');
-            settings = JSON.parse(content);
-        } catch (err: any) {
-            if (err.code === 'ENOENT') {
+            settings = readSettings(JSON.parse(content));
+        } catch (err: unknown) {
+            if (hasErrorCode(err, 'ENOENT')) {
                 console.error(`${colors.red('✗')} File not found: ${options.settingsFile}`);
                 process.exit(1);
             }
@@ -149,8 +165,8 @@ export async function installApp(program: Command, appId: string, options: Recor
         }
     } else if (options.settings) {
         try {
-            settings = JSON.parse(options.settings);
-        } catch (err) {
+            settings = readSettings(JSON.parse(options.settings));
+        } catch {
             console.error(`${colors.red('✗')} Invalid JSON in settings option`);
             process.exit(1);
         }
@@ -162,16 +178,16 @@ export async function installApp(program: Command, appId: string, options: Recor
     console.log(`  App Manifest ID: ${result.manifest}`);
 }
 
-export async function deleteAppInstallation(program: Command, installationId: string, _options: Record<string, any>) {
+export async function deleteAppInstallation(program: Command, installationId: string, _options: Record<string, unknown>) {
     const client = await getClient(program);
 
     await client.apps.uninstall(installationId);
     console.log(`${colors.green('✓')} App uninstalled successfully`);
 }
 
-export async function listInstalledApps(program: Command, options: Record<string, any>) {
+export async function listInstalledApps(program: Command, options: InstalledAppsOptions) {
     const client = await getClient(program);
-    const kind = options.kind as AppInstallationKind | undefined;
+    const kind = options.kind;
 
     const apps = await client.apps.getInstalledApps(kind);
 
@@ -191,7 +207,7 @@ export async function listInstalledApps(program: Command, options: Record<string
     });
 }
 
-export async function getAppInstallation(program: Command, appName: string, _options: Record<string, any>) {
+export async function getAppInstallation(program: Command, appName: string, _options: Record<string, unknown>) {
     const client = await getClient(program);
 
     const installation = await client.apps.getAppInstallationByName(appName);
@@ -209,14 +225,14 @@ export async function getAppInstallation(program: Command, appName: string, _opt
     // Fetch user or group details for each permission
     const enrichedPermissions = await Promise.all(
         permissions.map(async (perm) => {
-            let principalDetails;
+            let principalDetails: unknown;
             try {
                 if (perm.principal_type === 'user') {
                     principalDetails = await client.users.get(perm.principal);
                 } else if (perm.principal_type === 'group') {
                     principalDetails = await client.iam.groups.get(perm.principal);
                 }
-            } catch (err) {
+            } catch {
                 // If we can't fetch details, just use the ID
                 principalDetails = null;
             }
@@ -234,17 +250,17 @@ export async function getAppInstallation(program: Command, appName: string, _opt
     }, null, 2));
 }
 
-export async function updateAppInstallationSettings(program: Command, appId: string, options: Record<string, any>) {
+export async function updateAppInstallationSettings(program: Command, appId: string, options: SettingsOptions) {
     const client = await getClient(program);
 
-    let settings: Record<string, any>;
+    let settings: Record<string, unknown>;
 
     if (options.settingsFile) {
         try {
             const content = await readFile(options.settingsFile, 'utf-8');
-            settings = JSON.parse(content);
-        } catch (err: any) {
-            if (err.code === 'ENOENT') {
+            settings = readSettings(JSON.parse(content));
+        } catch (err: unknown) {
+            if (hasErrorCode(err, 'ENOENT')) {
                 console.error(`${colors.red('✗')} File not found: ${options.settingsFile}`);
                 process.exit(1);
             }
@@ -252,8 +268,8 @@ export async function updateAppInstallationSettings(program: Command, appId: str
         }
     } else if (options.settings) {
         try {
-            settings = JSON.parse(options.settings);
-        } catch (err) {
+            settings = readSettings(JSON.parse(options.settings));
+        } catch {
             console.error(`${colors.red('✗')} Invalid JSON in settings option`);
             process.exit(1);
         }
@@ -270,4 +286,12 @@ export async function updateAppInstallationSettings(program: Command, appId: str
     console.log(`${colors.green('✓')} App settings updated successfully`);
     console.log(`  Installation ID: ${result.id}`);
     console.log(`  App Name: ${result.manifest.name}`);
+}
+
+function readSettings(value: unknown): Record<string, unknown> {
+    if (!isRecord(value)) {
+        console.error(`${colors.red('✗')} Settings must be a JSON object`);
+        process.exit(1);
+    }
+    return value;
 }

--- a/packages/cli/src/apps/index.ts
+++ b/packages/cli/src/apps/index.ts
@@ -52,13 +52,13 @@ export function registerAppsCommand(program: Command) {
 
     apps.command("list")
         .description("List all available app manifests")
-        .action(async (options: Record<string, any>) => {
+        .action(async (options: Record<string, unknown>) => {
             await listApps(program, options);
         });
 
     apps.command("get <appId>")
         .description("Get an app manifest by ID or name")
-        .action(async (appId: string, options: Record<string, any>) => {
+        .action(async (appId: string, options: Record<string, unknown>) => {
             await getApp(program, appId, options);
         });
 
@@ -72,7 +72,7 @@ Example manifest.json:
 
 ${JSON.stringify(exampleManifest, null, 2)}
 `)
-        .action(async (options: Record<string, any>) => {
+        .action(async (options: Record<string, unknown>) => {
             await createApp(program, options);
         });
 
@@ -85,7 +85,7 @@ Example manifest.json:
 
 ${JSON.stringify(exampleManifest, null, 2)}
 `)
-        .action(async (appId: string, options: Record<string, any>) => {
+        .action(async (appId: string, options: Record<string, unknown>) => {
             await updateApp(program, appId, options);
         });
 
@@ -93,27 +93,27 @@ ${JSON.stringify(exampleManifest, null, 2)}
         .description("Install an app in the current project")
         .option('-s, --settings <json>', 'Settings as JSON string')
         .option('-f, --settings-file <file>', 'Settings from a JSON file')
-        .action(async (appId: string, options: Record<string, any>) => {
+        .action(async (appId: string, options: Record<string, unknown>) => {
             await installApp(program, appId, options);
         });
 
     apps.command("uninstall <installationId>")
         .alias("remove")
         .description("Uninstall an app from the current project")
-        .action(async (installationId: string, options: Record<string, any>) => {
+        .action(async (installationId: string, options: Record<string, unknown>) => {
             await deleteAppInstallation(program, installationId, options);
         });
 
     apps.command("list-installed")
         .description("List installed apps you have access to in the current project")
         .option('-k, --kind <kind>', 'Filter by installation kind (e.g., agent, tool)')
-        .action(async (options: Record<string, any>) => {
+        .action(async (options: Record<string, unknown>) => {
             await listInstalledApps(program, options);
         });
 
     apps.command("get-installation <appName>")
         .description("Get an app installation by name")
-        .action(async (appName: string, options: Record<string, any>) => {
+        .action(async (appName: string, options: Record<string, unknown>) => {
             await getAppInstallation(program, appName, options);
         });
 
@@ -121,7 +121,7 @@ ${JSON.stringify(exampleManifest, null, 2)}
         .description("Update app installation settings")
         .option('-s, --settings <json>', 'Settings as JSON string')
         .option('-f, --settings-file <file>', 'Settings from a JSON file')
-        .action(async (appId: string, options: Record<string, any>) => {
+        .action(async (appId: string, options: Record<string, unknown>) => {
             await updateAppInstallationSettings(program, appId, options);
         });
 }

--- a/packages/cli/src/artifacts/commands.ts
+++ b/packages/cli/src/artifacts/commands.ts
@@ -3,21 +3,30 @@ import { createReadStream, createWriteStream } from "fs";
 import { basename } from "path";
 import { pipeline } from "stream/promises";
 import { Readable } from "stream";
+import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import { NodeStreamSource } from "@vertesia/client/node";
 import { getArtifactStorageId } from "../agent-context.js";
 import { getClient } from "../client.js";
+import { type CliOptions } from "../utils/options.js";
 
 // Artifact storage prefix - matches the client's ARTIFACTS_PREFIX
 const ARTIFACTS_PREFIX = "agents";
 
+type ArtifactOptions = CliOptions<{
+    runId?: string;
+    name?: string;
+    mime?: string;
+    output?: string;
+}>;
+
 /**
  * Get run ID from options or environment variable
  */
-function getRunId(options: Record<string, any>): string {
+function getRunId(options: ArtifactOptions): string {
     return getArtifactStorageId(options);
 }
 
-export async function uploadArtifact(program: Command, file: string | undefined, options: Record<string, any>) {
+export async function uploadArtifact(program: Command, file: string | undefined, options: ArtifactOptions) {
     const client = await getClient(program);
     const runId = getRunId(options);
 
@@ -42,25 +51,25 @@ export async function uploadArtifact(program: Command, file: string | undefined,
     console.log(`Uploaded artifact: ${result}`);
 }
 
-export async function downloadArtifact(program: Command, name: string, options: Record<string, any>) {
+export async function downloadArtifact(program: Command, name: string, options: ArtifactOptions) {
     const client = await getClient(program);
     const runId = getRunId(options);
 
     const stream = await client.files.downloadArtifact(runId, name);
 
     if (options.output) {
-        const nodeStream = Readable.fromWeb(stream as any);
+        const nodeStream = Readable.fromWeb(stream as NodeReadableStream<Uint8Array>);
         const writeStream = createWriteStream(options.output);
         await pipeline(nodeStream, writeStream);
         console.log(`Downloaded to: ${options.output}`);
     } else {
         // Stream to stdout
-        const nodeStream = Readable.fromWeb(stream as any);
+        const nodeStream = Readable.fromWeb(stream as NodeReadableStream<Uint8Array>);
         await pipeline(nodeStream, process.stdout);
     }
 }
 
-export async function listArtifacts(program: Command, options: Record<string, any>) {
+export async function listArtifacts(program: Command, options: ArtifactOptions) {
     const client = await getClient(program);
     const runId = getRunId(options);
 
@@ -73,7 +82,7 @@ export async function listArtifacts(program: Command, options: Record<string, an
     });
 }
 
-export async function getArtifactUrl(program: Command, name: string, options: Record<string, any>) {
+export async function getArtifactUrl(program: Command, name: string, options: ArtifactOptions) {
     const client = await getClient(program);
     const runId = getRunId(options);
 

--- a/packages/cli/src/artifacts/index.ts
+++ b/packages/cli/src/artifacts/index.ts
@@ -10,7 +10,7 @@ export function registerArtifactsCommand(program: Command) {
         .option("--run-id [runId]", "Artifact storage ID (defaults to VERTESIA_ARTIFACT_STORAGE_ID, then VERTESIA_AGENTRUN_ID)")
         .option("--name [name]", "Artifact name (required for stdin, defaults to filename otherwise)")
         .option("--mime [mimeType]", "MIME type of the file")
-        .action(async (file: string | undefined, options: Record<string, any>) => {
+        .action(async (file: string | undefined, options: Record<string, unknown>) => {
             await uploadArtifact(program, file, options);
         });
 
@@ -18,21 +18,21 @@ export function registerArtifactsCommand(program: Command) {
         .description("Download an artifact from an agent run")
         .option("--run-id [runId]", "Artifact storage ID (defaults to VERTESIA_ARTIFACT_STORAGE_ID, then VERTESIA_AGENTRUN_ID)")
         .option("-o, --output [path]", "Output file path (defaults to stdout)")
-        .action(async (name: string, options: Record<string, any>) => {
+        .action(async (name: string, options: Record<string, unknown>) => {
             await downloadArtifact(program, name, options);
         });
 
     artifacts.command("list")
         .description("List artifacts for an agent run")
         .option("--run-id [runId]", "Artifact storage ID (defaults to VERTESIA_ARTIFACT_STORAGE_ID, then VERTESIA_AGENTRUN_ID)")
-        .action(async (options: Record<string, any>) => {
+        .action(async (options: Record<string, unknown>) => {
             await listArtifacts(program, options);
         });
 
     artifacts.command("url <name>")
         .description("Get download URL for an artifact")
         .option("--run-id [runId]", "Artifact storage ID (defaults to VERTESIA_ARTIFACT_STORAGE_ID, then VERTESIA_AGENTRUN_ID)")
-        .action(async (name: string, options: Record<string, any>) => {
+        .action(async (name: string, options: Record<string, unknown>) => {
             await getArtifactUrl(program, name, options);
         });
 }

--- a/packages/cli/src/data/commands.ts
+++ b/packages/cli/src/data/commands.ts
@@ -7,11 +7,22 @@ import { basename, resolve } from "node:path";
 import { createReadStream } from "node:fs";
 import { getArtifactStorageId } from "../agent-context.js";
 import { getClient } from "../client.js";
+import { getStringOption, type CliOptions } from "../utils/options.js";
 
 const IMPORT_MODES = new Set(["append", "replace"]);
 const IMPORT_FORMATS = new Set<ImportDataFormat>(["csv", "json", "parquet"]);
 
-export async function listDataStores(program: Command, options: Record<string, any>) {
+type ImportDataOptions = CliOptions<{
+    json?: boolean;
+    mode?: string;
+    format?: string;
+    name?: string;
+    prefix?: string;
+    mime?: string;
+    message?: string;
+}>;
+
+export async function listDataStores(program: Command, options: CliOptions<{ json?: boolean }>) {
     const client = await getClient(program);
     const stores = await client.data.list();
 
@@ -35,7 +46,7 @@ export async function listDataStores(program: Command, options: Record<string, a
     });
 }
 
-export async function importData(program: Command, storeId: string, tableName: string, input: string | undefined, options: Record<string, any>) {
+export async function importData(program: Command, storeId: string, tableName: string, input: string | undefined, options: ImportDataOptions) {
     const client = await getClient(program);
     const mode = normalizeMode(options.mode);
     const source = await resolveImportSource(client, input, options);
@@ -108,7 +119,7 @@ function inferFormatFromName(name?: string): ImportDataFormat | undefined {
 async function resolveImportSource(
     client: Awaited<ReturnType<typeof getClient>>,
     input: string | undefined,
-    options: Record<string, any>,
+    options: ImportDataOptions,
 ): Promise<{ tableData: ImportTableData; original: string; uploadedUri?: string }> {
     const normalizedInput = typeof input === "string" && input.trim() !== "" ? input.trim() : "-";
 
@@ -137,7 +148,7 @@ async function resolveImportSource(
     const uploadName = resolveUploadName(normalizedInput, options.name);
     const format = normalizeFormat(options.format, uploadName);
     const uploadPath = buildImportUploadPath(uploadName, options);
-    const mimeType = options.mime || mime.getType(uploadName) || "application/octet-stream";
+    const mimeType = getStringOption(options.mime) || mime.getType(uploadName) || "application/octet-stream";
     const source = normalizedInput === "-"
         ? new NodeStreamSource(process.stdin, uploadName, mimeType, uploadPath)
         : new NodeStreamSource(createReadStream(resolve(normalizedInput)), uploadName, mimeType, uploadPath);
@@ -167,9 +178,10 @@ function resolveUploadName(input: string, explicitName: unknown): string {
     return basename(input);
 }
 
-function buildImportUploadPath(name: string, options: Record<string, any>): string {
-    const prefix = typeof options.prefix === "string" && options.prefix.trim() !== ""
-        ? options.prefix.trim().replace(/^\/+|\/+$/g, "")
+function buildImportUploadPath(name: string, options: ImportDataOptions): string {
+    const optionPrefix = getStringOption(options.prefix);
+    const prefix = optionPrefix
+        ? optionPrefix.replace(/^\/+|\/+$/g, "")
         : `imports/${getArtifactStorageId(options)}`;
     return `${prefix}/${Date.now()}-${randomUUID()}-${name}`;
 }

--- a/packages/cli/src/data/index.ts
+++ b/packages/cli/src/data/index.ts
@@ -8,7 +8,7 @@ export function registerDataCommand(program: Command) {
     data.command("list")
         .description("List data stores in the current project")
         .option("--json", "Output full JSON instead of tab-separated text")
-        .action(async (options: Record<string, any>) => {
+        .action(async (options: Record<string, unknown>) => {
             await listDataStores(program, options);
         });
 
@@ -21,7 +21,7 @@ export function registerDataCommand(program: Command) {
         .option("--mime [mimeType]", "MIME type for uploads from local files or stdin")
         .option("--prefix [pathPrefix]", "Custom staging prefix in project storage for uploaded local files")
         .option("--json", "Output full JSON instead of a short summary")
-        .action(async (storeId: string, tableName: string, input: string | undefined, options: Record<string, any>) => {
+        .action(async (storeId: string, tableName: string, input: string | undefined, options: Record<string, unknown>) => {
             await importData(program, storeId, tableName, input, options);
         });
 }

--- a/packages/cli/src/envs/index.ts
+++ b/packages/cli/src/envs/index.ts
@@ -4,7 +4,7 @@ import { ExecutionEnvironment } from "@vertesia/common";
 import colors from "ansi-colors";
 
 
-export async function listEnvironments(program: Command, envId: string | undefined, options: Record<string, any>) {
+export async function listEnvironments(program: Command, envId: string | undefined, options: Record<string, unknown>) {
     const client = await getClient(program);
     if (envId) {
         const env = await client.environments.retrieve(envId);
@@ -18,7 +18,7 @@ export async function listEnvironments(program: Command, envId: string | undefin
 }
 
 
-function printEnv(env: ExecutionEnvironment, _options: Record<string, any>) {
+function printEnv(env: ExecutionEnvironment, _options: Record<string, unknown>) {
     console.log(colors.bold(env.name) + " [" + env.id + "]")
     console.log(colors.bold("Provider:"), env.provider);
     console.log(colors.bold("Description:"), env.description || 'n/a');

--- a/packages/cli/src/iam/commands.ts
+++ b/packages/cli/src/iam/commands.ts
@@ -1,9 +1,20 @@
-import { AccessControlPrincipalType, AccessControlResourceType } from '@vertesia/common';
+import { AccessControlPrincipalType, AccessControlResourceType, ProjectRoles } from '@vertesia/common';
 import { Command } from 'commander';
 import colors from 'ansi-colors';
 import { getClient } from '../client.js';
+import { getStringOption, type CliOptions } from '../utils/options.js';
 
-export async function listAces(program: Command, _options: Record<string, any>) {
+type CreateAceOptions = CliOptions<{
+    principal?: string;
+    principalType?: AccessControlPrincipalType;
+    resource?: string;
+    resourceType?: AccessControlResourceType;
+    role?: ProjectRoles;
+    principalProps?: string;
+    resourceProps?: string;
+}>;
+
+export async function listAces(program: Command, _options: Record<string, unknown>) {
     const client = await getClient(program);
     const aces = await client.iam.aces.listProjectAces();
 
@@ -19,29 +30,48 @@ export async function listAces(program: Command, _options: Record<string, any>) 
     console.log(`\n${colors.gray(`${aces.length} entries`)}`);
 }
 
-export async function createAce(program: Command, options: Record<string, any>) {
+export async function createAce(program: Command, options: CreateAceOptions) {
     const client = await getClient(program);
 
-    const conditions: Record<string, any> = {};
-    if (options.principalProps) {
-        conditions.principal_props = JSON.parse(options.principalProps);
+    const conditions: Record<string, unknown> = {};
+    const principalProps = getStringOption(options.principalProps);
+    const resourceProps = getStringOption(options.resourceProps);
+    if (principalProps) {
+        conditions.principal_props = JSON.parse(principalProps);
     }
-    if (options.resourceProps) {
-        conditions.resource_props = JSON.parse(options.resourceProps);
+    if (resourceProps) {
+        conditions.resource_props = JSON.parse(resourceProps);
     }
 
     const hasConditions = Object.keys(conditions).length > 0;
 
     const ace = await client.iam.aces.create({
-        principal: options.principal,
-        principal_type: options.principalType as AccessControlPrincipalType,
-        resource: options.resource,
-        resource_type: options.resourceType as AccessControlResourceType,
-        role: options.role,
+        principal: requireStringOption(options.principal, '--principal'),
+        principal_type: requireEnumOption(options.principalType, '--principal-type'),
+        resource: requireStringOption(options.resource, '--resource'),
+        resource_type: requireEnumOption(options.resourceType, '--resource-type'),
+        role: requireEnumOption(options.role, '--role'),
         conditions: hasConditions ? conditions : undefined,
     });
 
     console.log(`${colors.green('✓')} ACE created: ${ace.id}`);
+}
+
+function requireStringOption(value: unknown, name: string): string {
+    const option = getStringOption(value);
+    if (!option) {
+        console.error(`${colors.red('✗')} ${name} is required`);
+        process.exit(1);
+    }
+    return option;
+}
+
+function requireEnumOption<T extends string>(value: T | undefined, name: string): T {
+    if (!value) {
+        console.error(`${colors.red('✗')} ${name} is required`);
+        process.exit(1);
+    }
+    return value;
 }
 
 export async function deleteAce(program: Command, aceId: string) {

--- a/packages/cli/src/iam/index.ts
+++ b/packages/cli/src/iam/index.ts
@@ -9,7 +9,7 @@ export function registerIamCommand(program: Command) {
 
     iam.command('list')
         .description('List all access control entries for the current project')
-        .action(async (options: Record<string, any>) => {
+        .action(async (options: Record<string, unknown>) => {
             await listAces(program, options);
         });
 
@@ -22,7 +22,7 @@ export function registerIamCommand(program: Command) {
         .requiredOption('--role <role>', 'Role: owner, admin, developer, reader, member, etc.')
         .option('--principal-props <json>', 'Principal conditions JSON (for principal_set)')
         .option('--resource-props <json>', 'Resource conditions JSON (for content_set)')
-        .action(async (options: Record<string, any>) => {
+        .action(async (options: Record<string, unknown>) => {
             await createAce(program, options);
         });
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -29,6 +29,7 @@ import { listProjects, useProject } from './projects/index.js';
 import runInteraction from './run/index.js';
 import { runHistory } from './runs/index.js';
 import { registerWorkflowsCommand } from './workflows/index.js';
+import { getBooleanOption, hasStatus } from './utils/options.js';
 //warnIfNotLatest();
 
 const program = new Command();
@@ -38,7 +39,7 @@ program.version(getVersion());
 program.command("upgrade")
     .description("Upgrade to the latest version of the CLI")
     .option("-y, --yes", "Skip the confirmation prompt")
-    .action((options: Record<string, any> = {}) => upgrade(options.yes))
+    .action((options: Record<string, unknown> = {}) => upgrade(getBooleanOption(options.yes)))
 
 const projectsRoot = program.command("projects")
     .description("List the projects you have access to")
@@ -91,12 +92,12 @@ authRoot.command("refresh")
 
 program.command("envs [envId]")
     .description("List the environments you have access to")
-    .action((envId: string | undefined, options: Record<string, any>) => {
+    .action((envId: string | undefined, options: Record<string, unknown>) => {
         listEnvironments(program, envId, options);
     })
 program.command("interactions [interaction]")
     .description("List the interactions available in the current project")
-    .action((interactionId: string | undefined, options: Record<string, any>) => {
+    .action((interactionId: string | undefined, options: Record<string, unknown>) => {
         listInteractions(program, interactionId, options);
     })
 program.command("run <interaction>")
@@ -122,7 +123,7 @@ program.command("run <interaction>")
     .option('--data-only', 'Write down only the data returned by the LLM and not the entire execution run. This mode is forced when streaming', false)
     .option('-r, --run-data [level]', 'Override the level of storage for the run data. Possible values are: "standard", "restricted", or "debug". Optional. If not specified, it uses the level defined in Studio.')
     .option('--by-id', 'When used, the interaction is selected by ID instead of by name')
-    .action((interaction: string, options: Record<string, any>) => runInteraction(program, interaction, options));
+    .action((interaction: string, options: Record<string, unknown>) => runInteraction(program, interaction, options));
 program.command("runs [interactionId]")
     .description('Search the run history for specific execution runs')
     .option('-t, --tags [tags]', 'A comma separated list of tags to filter the run history')
@@ -136,7 +137,7 @@ program.command("runs [interactionId]")
     .option("-o, --output [file]", "The output file if any. If not specified it will print to stdout")
     .option("--before [date]", "Filter runs before the given date. The date must be in ISO format")
     .option("--after [date]", "Filter runs after the given date. The date must be in ISO format")
-    .action((interactionId: string | undefined, options: Record<string, any>) => {
+    .action((interactionId: string | undefined, options: Record<string, unknown>) => {
         runHistory(program, interactionId, options);
     });
 
@@ -209,8 +210,8 @@ program.parseAsync(process.argv).catch(err => {
     process.exit(1);
 });
 
-process.on("unhandledRejection", (err: any) => {
-    if (err.status === 401) { // token expired?
+process.on("unhandledRejection", (err: unknown) => {
+    if (hasStatus(err, 401)) { // token expired?
         console.error("ERROR", err);
         tryRefreshToken();
     }

--- a/packages/cli/src/interactions/index.ts
+++ b/packages/cli/src/interactions/index.ts
@@ -7,7 +7,7 @@ function textToPascalCase(text: string) {
     return text.trim().split(/\W/).map(w => w ? w[0].toUpperCase() + w.substring(1) : '').join('')
 }
 
-export async function listInteractions(program: Command, interactionId: string | undefined, options: Record<string, any>) {
+export async function listInteractions(program: Command, interactionId: string | undefined, options: Record<string, unknown>) {
     const client = await getClient(program);
     if (!interactionId) {
         const interactions = await client.interactions.list();
@@ -26,7 +26,7 @@ export async function listInteractions(program: Command, interactionId: string |
 }
 
 
-function printInteraction(interaction: Interaction, versions: InteractionRef[], _options: Record<string, any>) {
+function printInteraction(interaction: Interaction, versions: InteractionRef[], _options: Record<string, unknown>) {
     console.log(colors.bold(interaction.name) + " [" + interaction.id + "]");
     console.log(colors.bold("Description:"), interaction.description || 'n/a');
     console.log(colors.bold("Class name:"), textToPascalCase(interaction.name));

--- a/packages/cli/src/objects/commands.ts
+++ b/packages/cli/src/objects/commands.ts
@@ -18,7 +18,9 @@ import mime from "mime";
 import { basename, join, resolve } from "path";
 import { pipeline } from "stream/promises";
 import { Readable } from "stream";
+import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import { getClient } from "../client.js";
+import { getStringOption, hasErrorCode, type CliOptions } from "../utils/options.js";
 const { prompt } = enquirer;
 
 const AUTOMATIC_TYPE_SELECTION = "auto";
@@ -43,6 +45,27 @@ interface SearchObjectsOptions extends JsonOutputOptions {
 
 interface QueryObjectsOptions extends JsonOutputOptions {
     dsl?: string;
+}
+
+type CreateObjectOptions = CliOptions<{
+    name?: string;
+    type?: string;
+    path?: string;
+    recursive?: boolean;
+}>;
+
+type DownloadObjectOptions = CliOptions<{
+    output?: string;
+}>;
+
+interface TypeChoice {
+    name: string;
+    value: string;
+    id?: string;
+}
+
+interface TypePromptState {
+    focused: TypeChoice;
 }
 
 function splitInChunksWithSize<T>(arr: Array<T>, size: number): T[][] {
@@ -85,12 +108,12 @@ async function listFilesInDirectory(dir: string, recursive = false): Promise<str
     }));
 }
 
-export async function createObject(program: Command, files: string[], options: Record<string, any>) {
+export async function createObject(program: Command, files: string[], options: CreateObjectOptions) {
     if (files.length === 0) {
         return "No files specified"
     } else if (files.length > 1) {
-        const types: any[] = await listTypes(program);
-        const questions: any[] = [];
+        const types = await listTypes(program);
+        const questions = [];
         if (!options.type) {
             questions.push({
                 type: 'select',
@@ -98,11 +121,11 @@ export async function createObject(program: Command, files: string[], options: R
                 message: "Select a Type",
                 choices: types,
                 limit: 10,
-                result() {
+                result(this: TypePromptState) {
                     return this.focused.value;
                 }
             });
-            const response: any = await prompt(questions);
+            const response = await prompt<{ type: string }>(questions);
             options.type = response.type;
         } else {
             const searchedType = findTypeValue(types, options.type);
@@ -129,8 +152,8 @@ export async function createObject(program: Command, files: string[], options: R
             let stats: Stats;
             try {
                 stats = await stat(file);
-            } catch (err: any) {
-                if (err.code === 'ENOENT') {
+            } catch (err: unknown) {
+                if (hasErrorCode(err, 'ENOENT')) {
                     console.error('No such file or directory: ', file);
                     process.exit(2);
                 }
@@ -138,8 +161,8 @@ export async function createObject(program: Command, files: string[], options: R
                 process.exit(2);
             }
 
-            const types: any[] = await listTypes(program);
-            const questions: any[] = [];
+            const types = await listTypes(program);
+            const questions = [];
             if (stats.isFile()) {
                 if (!options.type) {
                     questions.push({
@@ -148,11 +171,11 @@ export async function createObject(program: Command, files: string[], options: R
                         message: "Select a Type",
                         choices: types,
                         limit: 10,
-                        result() {
+                        result(this: TypePromptState) {
                             return this.focused.value;
                         }
                     });
-                    const response: any = await prompt(questions);
+                    const response = await prompt<{ type: string }>(questions);
                     options.type = response.type;
                 } else {
                     const searchedType = findTypeValue(types, options.type);
@@ -175,25 +198,25 @@ export async function createObject(program: Command, files: string[], options: R
                     message: "Select a Type (the type will be used for all the files in the directory)",
                     choices: types,
                     limit: 10,
-                    result() {
+                    result(this: TypePromptState) {
                         return this.focused.value;
                     }
                 });
-                const response: any = await prompt(questions);
+                const response = await prompt<{ type: string }>(questions);
                 options.type = response.type;
 
                 if (options.type === AUTOMATIC_TYPE_SELECTION) {
                     delete options.type;
                 }
 
-                const files = await listFilesInDirectory(file, options.recursive || false);
+                const files = await listFilesInDirectory(file, options.recursive ?? false);
                 return createObjectFromFiles(program, files, options);
             }
         }
     }
 }
 
-export async function createObjectFromFiles(program: Command, files: string[], options: Record<string, any>) {
+export async function createObjectFromFiles(program: Command, files: string[], options: CreateObjectOptions) {
     if (!options) options = {};
     // split in 10 chunks
     const chunks = splitInChunks(files, 10);
@@ -204,7 +227,7 @@ export async function createObjectFromFiles(program: Command, files: string[], o
     }));
 }
 
-export async function createObjectFromFile(program: Command, file: string, options: Record<string, any>) {
+export async function createObjectFromFile(program: Command, file: string, options: CreateObjectOptions) {
     const client = await getClient(program);
     let res: ContentObject;
     if (file.startsWith("s3://") || file.startsWith("gs://")) {
@@ -216,7 +239,7 @@ export async function createObjectFromFile(program: Command, file: string, optio
     return res;
 }
 
-export async function createObjectFromLocalFile(client: VertesiaClient, file: string, options: Record<string, any>) {
+export async function createObjectFromLocalFile(client: VertesiaClient, file: string, options: CreateObjectOptions) {
     const fileName = basename(file);
     const stream = createReadStream(file);
 
@@ -236,7 +259,7 @@ export async function createObjectFromLocalFile(client: VertesiaClient, file: st
     return res;
 }
 
-async function createObjectFromExternalSource(client: VertesiaClient, uri: string, options: Record<string, any>) {
+async function createObjectFromExternalSource(client: VertesiaClient, uri: string, options: CreateObjectOptions) {
     return client.objects.createFromExternalSource(uri, {
         name: options.name,
         type: options.type,
@@ -244,9 +267,9 @@ async function createObjectFromExternalSource(client: VertesiaClient, uri: strin
     });
 }
 
-export async function updateObject(program: Command, objectId: string, type: string, _options: Record<string, any>) {
-    const types: any[] = await listTypes(program);
-    let searchedType = findTypeValue(types, type);
+export async function updateObject(program: Command, objectId: string, type: string, _options: Record<string, unknown>) {
+    const types = await listTypes(program);
+    let searchedType: string | undefined = findTypeValue(types, type);
     if (searchedType === TYPE_SELECTION_ERROR) {
         console.error(`${type} is not an existing type`);
         process.exit(2);
@@ -259,12 +282,12 @@ export async function updateObject(program: Command, objectId: string, type: str
     console.log(await client.objects.update(objectId, payload));
 }
 
-export async function deleteObject(program: Command, objectId: string, _options: Record<string, any>) {
+export async function deleteObject(program: Command, objectId: string, _options: Record<string, unknown>) {
     const client = await getClient(program);
     await client.objects.delete(objectId);
 }
 
-export async function getObject(program: Command, objectId: string, _options: Record<string, any>) {
+export async function getObject(program: Command, objectId: string, _options: Record<string, unknown>) {
     const client = await getClient(program);
     const object = await client.objects.retrieve(objectId);
     console.log(object);
@@ -330,8 +353,8 @@ export async function queryObjects(program: Command, options: QueryObjectsOption
     printQueryResult(result);
 }
 
-export async function listTypes(program: Command) {
-    const types: any[] = []
+export async function listTypes(program: Command): Promise<TypeChoice[]> {
+    const types: TypeChoice[] = []
     types.push({ name: AUTOMATIC_TYPE_SELECTION_DESC, value: AUTOMATIC_TYPE_SELECTION })
 
     const client = await getClient(program);
@@ -342,12 +365,12 @@ export async function listTypes(program: Command) {
     return types;
 }
 
-export function findTypeValue(types: any[], name: string) {
+export function findTypeValue(types: TypeChoice[], name: string) {
     const type = types.find(type => type.name === name || type.id === name);
     return type ? type.value : TYPE_SELECTION_ERROR;
 }
 
-export async function downloadObjectContent(program: Command, objectId: string, options: Record<string, any>) {
+export async function downloadObjectContent(program: Command, objectId: string, options: DownloadObjectOptions) {
     const client = await getClient(program);
 
     // Get object to find content source and name
@@ -368,8 +391,8 @@ export async function downloadObjectContent(program: Command, objectId: string, 
         process.exit(1);
     }
 
-    const outputPath = options.output || object.name;
-    const nodeStream = Readable.fromWeb(response.body as any);
+    const outputPath = getStringOption(options.output) || object.name;
+    const nodeStream = Readable.fromWeb(response.body as NodeReadableStream<Uint8Array>);
     const writeStream = createWriteStream(outputPath);
     await pipeline(nodeStream, writeStream);
 
@@ -411,7 +434,7 @@ function printJson(value: unknown) {
     console.log(JSON.stringify(value, null, 2));
 }
 
-function printObjectItems(objects: Array<ContentObjectItem | ContentObjectItemApiResponse>) {
+function printObjectItems(objects: Array<ContentObjectItem<unknown> | ContentObjectItemApiResponse>) {
     if (objects.length === 0) {
         console.log("No objects found");
         return;
@@ -428,7 +451,7 @@ function printObjectItems(objects: Array<ContentObjectItem | ContentObjectItemAp
     );
 }
 
-function readObjectTypeName(object: ContentObjectItem | ContentObjectItemApiResponse): string {
+function readObjectTypeName(object: ContentObjectItem<unknown> | ContentObjectItemApiResponse): string {
     if (!object.type) {
         return "";
     }

--- a/packages/cli/src/objects/index.ts
+++ b/packages/cli/src/objects/index.ts
@@ -22,34 +22,34 @@ export function registerObjectsCommand(program: Command) {
         .option('--mime [mime]', 'The mime-type of the file content. If not specified the mime type will be inferred from the file name extension.')
         .option('--path [parentPath]', 'The path of the parent folder where the object is created. If not specified the object will be created in the root of the store.')
         .option('-r, --recursive', 'Recurse directory if the file argument is a directory. The default is to not recurse.')
-        .action(async (files: string[], options: Record<string, any>) => {
+        .action(async (files: string[], options: Record<string, unknown>) => {
             await createObject(program, files, options);
         });
     store.command("update <objectId> <type>")
         .description("Update an existing object type given its ID")
-        .action(async (objectId: string, type: string, options: Record<string, any>) => {
+        .action(async (objectId: string, type: string, options: Record<string, unknown>) => {
             await updateObject(program, objectId, type, options);
         });
     store.command('delete <objectId>')
         .description("Delete an existing object given its ID")
-        .action(async (objectId: string, options: Record<string, any>) => {
+        .action(async (objectId: string, options: Record<string, unknown>) => {
             await deleteObject(program, objectId, options);
         });
     store.command('get <objectId>')
         .description("Get an existing object given its ID")
-        .action(async (objectId: string, options: Record<string, any>) => {
+        .action(async (objectId: string, options: Record<string, unknown>) => {
             await getObject(program, objectId, options);
         });
     store.command('text <objectId>')
         .description("Get the extracted text for an existing object")
         .option('--json', 'Print raw JSON instead of plain text')
-        .action(async (objectId: string, options: Record<string, any>) => {
+        .action(async (objectId: string, options: Record<string, unknown>) => {
             await getObjectText(program, objectId, options);
         });
     store.command('download <objectId>')
         .description("Download an object's content to a file")
         .option('-o, --output [path]', 'Output file path (defaults to object name)')
-        .action(async (objectId: string, options: Record<string, any>) => {
+        .action(async (objectId: string, options: Record<string, unknown>) => {
             await downloadObjectContent(program, objectId, options);
         });
     store.command('list [folderPath]')
@@ -57,7 +57,7 @@ export function registerObjectsCommand(program: Command) {
         .option('-l,--limit [limit]', 'Limit the number of objects returned. The default limit is 100. Useful for pagination.')
         .option('-s,--skip [skip]', 'Skip the number of objects to skip. Default is 0. Useful for pagination.')
         .option('--json', 'Print raw JSON')
-        .action(async (folderPath: string | undefined, options: Record<string, any>) => {
+        .action(async (folderPath: string | undefined, options: Record<string, unknown>) => {
             await listObjects(program, folderPath, options);
         });
     store.command('search <query>')
@@ -67,14 +67,14 @@ export function registerObjectsCommand(program: Command) {
         .option('--path [path]', 'Filter by object location/path')
         .option('--select [fields]', 'Selection string for returned fields')
         .option('--json', 'Print raw JSON')
-        .action(async (query: string, options: Record<string, any>) => {
+        .action(async (query: string, options: Record<string, unknown>) => {
             await searchObjects(program, query, options);
         });
     store.command('query')
         .description("Query indexed documents using raw Elasticsearch DSL")
         .option('--dsl [json]', 'Raw Elasticsearch DSL as a JSON string')
         .option('--json', 'Print raw JSON')
-        .action(async (options: Record<string, any>) => {
+        .action(async (options: Record<string, unknown>) => {
             await queryObjects(program, options);
         });
 }

--- a/packages/cli/src/package.ts
+++ b/packages/cli/src/package.ts
@@ -3,15 +3,21 @@ import enquirer from "enquirer";
 import { readFileSync } from 'fs';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { getBooleanOption, getStringOption, isRecord } from './utils/options.js';
 
 const { prompt } = enquirer;
 
 const packageDir = dirname(dirname(fileURLToPath(import.meta.url)));
 
-let _package: any;
-function getPackage() {
+interface PackageMetadata {
+    name: string;
+    version: string;
+}
+
+let _package: PackageMetadata | undefined;
+function getPackage(): PackageMetadata {
     if (_package === undefined) {
-        _package = JSON.parse(readFileSync(`${packageDir}/package.json`, 'utf8'));
+        _package = readPackageMetadata(JSON.parse(readFileSync(`${packageDir}/package.json`, 'utf8')));
     }
     return _package;
 }
@@ -21,11 +27,11 @@ function getVersion() {
 
 async function getLatestVersion() {
     const { name } = getPackage();
-    const { version } = await fetch(`https://registry.npmjs.org/${name}/latest`,
+    const response = await fetch(`https://registry.npmjs.org/${name}/latest`,
         { signal: AbortSignal.timeout(900) })
         .then(res => res.json())
         .catch(() => undefined);
-    return version;
+    return isRecord(response) ? getStringOption(response.version) : undefined;
 }
 
 export async function upgrade(yes: boolean) {
@@ -35,13 +41,13 @@ export async function upgrade(yes: boolean) {
         let doUpgrade = false;
         if (!yes) {
             console.log('There is a new version available (v' + latestVersion + ').');
-            const answer: any = await prompt({
+            const answer = await prompt<{ upgrade?: boolean }>({
                 name: 'upgrade',
                 type: 'confirm',
                 message: "Would you like to upgrade?",
                 initial: true,
             });
-            if (answer.upgrade) {
+            if (getBooleanOption(answer.upgrade)) {
                 doUpgrade = true;
             }
         } else {
@@ -55,6 +61,18 @@ export async function upgrade(yes: boolean) {
     } else {
         console.log('No updates are available.');
     }
+}
+
+function readPackageMetadata(value: unknown): PackageMetadata {
+    if (!isRecord(value)) {
+        throw new Error("Invalid package metadata");
+    }
+    const name = getStringOption(value.name);
+    const version = getStringOption(value.version);
+    if (!name || !version) {
+        throw new Error("Invalid package metadata");
+    }
+    return { name, version };
 }
 
 async function warnIfNotLatest() {

--- a/packages/cli/src/profiles/index.ts
+++ b/packages/cli/src/profiles/index.ts
@@ -89,13 +89,21 @@ function isDevDeploymentTarget(value: string): boolean {
 }
 
 export function getCloudTypeFromConfigUrl(url: string) {
-    if (url.startsWith("https://localhost")) {
+    let parsedUrl: URL;
+    try {
+        parsedUrl = new URL(url);
+    } catch {
+        throw new Error("Unknown cloud env type");
+    }
+
+    const { hostname, protocol } = parsedUrl;
+    if (protocol === "https:" && hostname === "localhost") {
         return "staging";
-    } else if (url.includes(".ui.dev1.vertesia.io")) {
+    } else if (hostname.endsWith(".ui.dev1.vertesia.io")) {
         return "staging";
-    } else if (url.startsWith("https://preview.")) {
+    } else if (protocol === "https:" && hostname.startsWith("preview.")) {
         return "preview";
-    } else if (url.startsWith("https://cloud.")) {
+    } else if (protocol === "https:" && hostname.startsWith("cloud.")) {
         return "production";
     } else {
         throw new Error("Unknown cloud env type");

--- a/packages/cli/src/profiles/index.ts
+++ b/packages/cli/src/profiles/index.ts
@@ -3,6 +3,7 @@ import jwt from 'jsonwebtoken';
 import os from "node:os";
 import { join } from "path";
 import { readJsonFile, writeJsonFile } from "../utils/stdio.js";
+import { hasErrorCode } from "../utils/options.js";
 import { ConfigPayload, ConfigResult, startConfigSession } from "./server/index.js";
 import type { OnResultCallback } from "./commands.js";
 import { canUseOAuthProfile, OAuthUnavailableError, startOAuthSession } from "./oauth.js";
@@ -356,8 +357,8 @@ export class Config {
             if (stats.isFile()) {
                 this.isDevMode = true;
             }
-        } catch (err: any) {
-            if (err.code !== 'ENOENT') {
+        } catch (err: unknown) {
+            if (!hasErrorCode(err, 'ENOENT')) {
                 throw err;
             }
         }
@@ -394,8 +395,8 @@ export class Config {
             if (needsSave) {
                 this.save();
             }
-        } catch (err: any) {
-            if (err.code !== 'ENOENT') {
+        } catch (err: unknown) {
+            if (!hasErrorCode(err, 'ENOENT')) {
                 throw err;
             }
         }

--- a/packages/cli/src/profiles/server/server.ts
+++ b/packages/cli/src/profiles/server/server.ts
@@ -14,7 +14,7 @@ export async function startServer(cb: (req: IncomingMessage, res: ServerResponse
 export function readRequestBody(request: IncomingMessage) {
     return new Promise((resolve, reject) => {
         const chunks: Buffer[] = [];
-        let body;
+        let body: string;
         request.on('data', (chunk) => {
             chunks.push(chunk);
         }).on('end', () => {

--- a/packages/cli/src/run/executor.ts
+++ b/packages/cli/src/run/executor.ts
@@ -1,6 +1,7 @@
 import { VertesiaClient } from "@vertesia/client";
-import { ConfigModes, InteractionExecutionResult, RunDataStorageLevel } from "@vertesia/common";
+import { ConfigModes, InteractionExecutionPayload, InteractionExecutionResult, RunDataStorageLevel } from "@vertesia/common";
 import { TextFallbackOptions } from "@llumiverse/common";
+import { getStringOption, type CliOptions } from "../utils/options.js";
 
 export type CliExecutionResult = InteractionExecutionResult & {
     runNumber?: number;
@@ -22,7 +23,7 @@ export class ExecutionQueue {
         this.abortController.abort();
     }
 
-    async run(onBatch: (completed: CliExecutionResult[]) => void, onChunk?: ((chunk: any) => void), signal?: AbortSignal) {
+    async run(onBatch: (completed: CliExecutionResult[]) => void, onChunk?: ((chunk: string) => void), signal?: AbortSignal) {
         // If an external signal is provided, link it to our local abort controller
         if (signal) {
             if (signal.aborted) {
@@ -77,12 +78,12 @@ export class ExecutionQueue {
     }
 }
 
-function convertRunData(raw_run_data: any): RunDataStorageLevel | undefined {
+function convertRunData(raw_run_data: unknown): RunDataStorageLevel | undefined {
     const levelStr: string = typeof raw_run_data === 'string' ? raw_run_data.toUpperCase() : "";
     return Object.values(RunDataStorageLevel).includes(levelStr as RunDataStorageLevel) ? levelStr as RunDataStorageLevel : undefined;
 }
 
-function convertConfigMode(raw_config_mode: any): ConfigModes | undefined {
+function convertConfigMode(raw_config_mode: unknown): ConfigModes | undefined {
     const configStr: string = typeof raw_config_mode === 'string' ? raw_config_mode.toUpperCase() : "";
     return Object.values(ConfigModes).includes(configStr as ConfigModes) ? configStr as ConfigModes : undefined;
 }
@@ -94,11 +95,11 @@ export class ExecutionRequest {
     constructor(
         public readonly client: VertesiaClient,
         public interactionSpec: string, // namespace:name@version
-        public data: any,
-        public options: Record<string, any>) {
+        public data: unknown,
+        public options: CliOptions) {
     }
 
-    async run(onChunk?: ((chunk: any) => void), signal?: AbortSignal): Promise<CliExecutionResult> {
+    async run(onChunk?: ((chunk: string) => void), signal?: AbortSignal): Promise<CliExecutionResult> {
         // Check if already aborted
         if (signal?.aborted) {
             throw new Error("Operation aborted");
@@ -115,7 +116,7 @@ export class ExecutionRequest {
             top_k: typeof options.topK === 'string' ? parseInt(options.topK) : undefined,
             presence_penalty: typeof options.presencePenalty === 'string' ? parseFloat(options.presencePenalty) : undefined,
             frequency_penalty: typeof options.frequencyPenalty === 'string' ? parseFloat(options.frequencyPenalty) : undefined,
-            stop_sequence: options.stopSequence ? options.stopSequence.trim().split(/\s*,\s*/) : undefined,
+            stop_sequence: getStringOption(options.stopSequence)?.split(/\s*,\s*/),
         };
 
         const config = {
@@ -125,10 +126,10 @@ export class ExecutionRequest {
             configMode: convertConfigMode(options.configMode),
             run_data: convertRunData(options.runData),
         };
-        const tags = options.tags ? options.tags.trim().split(/\s,*\s*/) : undefined;
+        const tags = getStringOption(options.tags)?.split(/\s,*\s*/);
 
         // Create a wrapper for the onChunk callback that checks for abort
-        const abortAwareChunkHandler = onChunk ? (chunk: any) => {
+        const abortAwareChunkHandler = onChunk ? (chunk: string) => {
             if (signal?.aborted) return;
             onChunk(chunk);
         } : undefined;
@@ -137,13 +138,13 @@ export class ExecutionRequest {
         try {
             if (this.options.byId) {
                 run = await this.client.interactions.execute(this.interactionSpec, {
-                    data: this.data,
+                    data: readInteractionData(this.data),
                     config,
                     tags
                 }, abortAwareChunkHandler);
             } else {
                 run = await this.client.interactions.executeByName(this.interactionSpec, {
-                    data: this.data,
+                    data: readInteractionData(this.data),
                     config,
                     tags
                 }, abortAwareChunkHandler);
@@ -168,4 +169,8 @@ export class ExecutionRequest {
             throw error;
         }
     }
+}
+
+function readInteractionData(data: unknown): InteractionExecutionPayload["data"] {
+    return data as InteractionExecutionPayload["data"];
 }

--- a/packages/cli/src/run/index.ts
+++ b/packages/cli/src/run/index.ts
@@ -3,9 +3,20 @@ import { getClient } from "../client.js";
 import { Spinner } from "../utils/console.js";
 import { readFile, readStdin, writeFile } from "../utils/stdio.js";
 import { CliExecutionResult, ExecutionQueue, ExecutionRequest } from "./executor.js";
+import { errorMessage, type CliOptions } from "../utils/options.js";
 
+type RunInteractionOptions = CliOptions<{
+    input?: string | boolean;
+    output?: string;
+    data?: string;
+    count?: string;
+    stream?: boolean;
+    verbose?: boolean;
+    jsonl?: boolean;
+    dataOnly?: boolean;
+}>;
 
-export default async function runInteraction(program: Command, interactionSpec: string, options: Record<string, any>) {
+export default async function runInteraction(program: Command, interactionSpec: string, options: RunInteractionOptions) {
     // Create abort controller for handling interruption
     const abortController = new AbortController();
     const { signal } = abortController;
@@ -34,7 +45,7 @@ export default async function runInteraction(program: Command, interactionSpec: 
         const data = await getInputData(options);
         const client = await getClient(program);
 
-        let count = options.count ? parseInt(options.count) : 1;
+        let count = options.count ? parseInt(options.count, 10) : 1;
         if (isNaN(count) || count < 0) {
             count = 1;
         }
@@ -42,10 +53,10 @@ export default async function runInteraction(program: Command, interactionSpec: 
         const hasMultiOutputs = (Array.isArray(data) && data.length > 1) || count > 1;
         const totalSize = Array.isArray(data) ? data.length * count : count;
 
-        let onChunk: ((chunk: any) => void) | undefined = undefined;
+        let onChunk: ((chunk: string) => void) | undefined = undefined;
         // TODO we can add an option --async to be able to force sync mode and use streaming for array data inputs?
         if (!hasMultiOutputs && options.stream) { // stream to stdout
-            onChunk = (chunk: string) => {
+            onChunk = (chunk) => {
                 if (chunk && !signal.aborted) {
                     process.stdout.write(chunk);
                 }
@@ -130,7 +141,7 @@ export default async function runInteraction(program: Command, interactionSpec: 
         process.off('SIGTERM', handleSignal);
         
         writeResult(result, hasMultiOutputs, options);
-    } catch (err: any) {
+    } catch (err: unknown) {
         // Clean up signal handlers
         process.off('SIGINT', handleSignal);
         process.off('SIGTERM', handleSignal);
@@ -141,14 +152,14 @@ export default async function runInteraction(program: Command, interactionSpec: 
         }
         
         if (spinner) spinner.done(false);
-        console.error("Failed to execute the interaction", err?.message);
+        console.error("Failed to execute the interaction", errorMessage(err));
         throw err;
     }
 }
 
-async function getInputData(options: Record<string, any>) {
+async function getInputData(options: RunInteractionOptions) {
     try {
-        let input: any;
+        let input: string | undefined;
         if (options.data) {
             input = options.data;
         } else if (options.input) {
@@ -159,13 +170,13 @@ async function getInputData(options: Record<string, any>) {
             }
         }
         return input ? JSON.parse(input) : undefined;
-    } catch (err: any) {
-        console.error('Invalid JSON data: ', err.message);
+    } catch (err: unknown) {
+        console.error('Invalid JSON data: ', errorMessage(err));
         process.exit(1);
     }
 }
 
-function writeResult(runs: CliExecutionResult[], hasMultiOutputs: boolean, options: Record<string, any>) {
+function writeResult(runs: CliExecutionResult[], hasMultiOutputs: boolean, options: RunInteractionOptions) {
     const out = formatResult(runs, hasMultiOutputs, options);
     if (typeof options.output === 'string') {
         writeFile(options.output, out);
@@ -174,7 +185,7 @@ function writeResult(runs: CliExecutionResult[], hasMultiOutputs: boolean, optio
     }
 }
 
-function formatResult(runs: CliExecutionResult[], hasMultiOutputs: boolean, options: Record<string, any>) {
+function formatResult(runs: CliExecutionResult[], hasMultiOutputs: boolean, options: RunInteractionOptions) {
     const outputData = options.dataOnly ? runs.map(run => run.result) : runs;
     let out: string;
     if (!hasMultiOutputs) {
@@ -191,7 +202,7 @@ function formatResult(runs: CliExecutionResult[], hasMultiOutputs: boolean, opti
     return out;
 }
 
-function toJson(data: any, space?: string | number | undefined) {
+function toJson(data: unknown, space?: string | number | undefined) {
     if (typeof data === 'string') {
         return data;
     } else {

--- a/packages/cli/src/runs/index.ts
+++ b/packages/cli/src/runs/index.ts
@@ -1,12 +1,28 @@
 import { Command } from "commander";
+import { ExecutionRunStatus } from "@vertesia/common";
 import { getClient } from "../client.js";
 import { writeFile } from "../utils/stdio.js";
+import { getStringOption, type CliOptions } from "../utils/options.js";
 
-export async function runHistory(program: Command, interactionId: string | undefined, options: Record<string, any>) {
+type RunHistoryOptions = CliOptions<{
+    page?: string;
+    limit?: string;
+    tags?: string;
+    status?: ExecutionRunStatus;
+    env?: string;
+    model?: string;
+    query?: string;
+    start?: string;
+    end?: string;
+    format?: 'json' | 'jsonl' | 'csv';
+    output?: string;
+}>;
+
+export async function runHistory(program: Command, interactionId: string | undefined, options: RunHistoryOptions) {
     const client = await getClient(program);
 
-    const page = options.page ? parseInt(options.page) : 0;
-    let limit = options.limit ? parseInt(options.limit) : 100;
+    const page = options.page ? parseInt(options.page, 10) : 0;
+    let limit = options.limit ? parseInt(options.limit, 10) : 100;
     if (limit <= 0) {
         limit = 100;
     }
@@ -16,19 +32,19 @@ export async function runHistory(program: Command, interactionId: string | undef
         limit, offset,
         query: {
             interaction: interactionId || undefined,
-            tags: options.tags ? options.tags.split(/\s*,\s*/) : undefined,
+            tags: getStringOption(options.tags)?.split(/\s*,\s*/),
             status: options.status || undefined,
             environment: options.env || undefined,
             model: options.model || undefined,
-            query: options.query as string || undefined,
-            start: options.start as string || undefined,
-            end: options.end as string || undefined,
+            query: options.query || undefined,
+            start: options.start || undefined,
+            end: options.end || undefined,
         },
 
     });
 
     const runs = response || [];
-    let out;
+    let out: string;
     if (options.format === 'json') {
         out = JSON.stringify(runs, undefined, 4);
     } else if (options.format === 'jsonl') {

--- a/packages/cli/src/utils/console.ts
+++ b/packages/cli/src/utils/console.ts
@@ -123,7 +123,7 @@ export class Spinner {
             try {
                 const frames = this.data.frames;
                 this.log.print(this.prefix + frames[++i % frames.length] + this.suffix);
-            } catch (error) {
+            } catch {
                 // If we can't update, stop the spinner to prevent console issues
                 this.done(false);
             }
@@ -168,11 +168,11 @@ export class Spinner {
                 showCursor(this.log.stream);
                 this._restoreCursor = false;
             }
-        } catch (error) {
+        } catch {
             // If an error occurs during cleanup, make a best effort to restore the cursor
             try {
                 showCursor(this.log.stream);
-            } catch (_) {
+            } catch {
                 // Last resort - ignore errors in error handler
             }
         }

--- a/packages/cli/src/utils/console.ts
+++ b/packages/cli/src/utils/console.ts
@@ -215,7 +215,11 @@ const streamsToRestore: WriteStream[] = [];
 let restoreCursorIsRegistered = false;
 
 export function toggleCursor(show: boolean, stream: WriteStream = process.stdout) {
-    show ? showCursor(stream) : hideCursor(stream);
+    if (show) {
+        showCursor(stream);
+    } else {
+        hideCursor(stream);
+    }
 }
 
 export function showCursor(stream: WriteStream = process.stdout) {

--- a/packages/cli/src/utils/options.ts
+++ b/packages/cli/src/utils/options.ts
@@ -1,0 +1,25 @@
+export type CliOptions<T extends object = object> = Record<string, unknown> & T;
+
+export function getStringOption(value: unknown): string | undefined {
+    return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+export function getBooleanOption(value: unknown): boolean {
+    return value === true;
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+export function hasErrorCode(error: unknown, code: string): boolean {
+    return isRecord(error) && error.code === code;
+}
+
+export function hasStatus(error: unknown, status: number): boolean {
+    return isRecord(error) && error.status === status;
+}

--- a/packages/cli/src/utils/stdio.ts
+++ b/packages/cli/src/utils/stdio.ts
@@ -1,5 +1,6 @@
 
 import { readFileSync, writeFileSync, mkdirSync } from "fs";
+import { hasErrorCode } from "./options.js";
 
 export async function readStdin() {
     const chunks = [];
@@ -32,8 +33,8 @@ export function writeJsonFile(file: string, data: object) {
 export function makeDir(dir: string) {
     try {
         return mkdirSync(dir, { recursive: true });
-    } catch (err: any) {
-        if (err.code !== 'EEXIST') {
+    } catch (err: unknown) {
+        if (!hasErrorCode(err, 'EEXIST')) {
             throw err;
         }
     }

--- a/packages/cli/src/workflows/commands.ts
+++ b/packages/cli/src/workflows/commands.ts
@@ -1,14 +1,48 @@
-import { ExecuteWorkflowPayload, WorkflowRuleInputType } from "@vertesia/common";
+import { CreateWorkflowRulePayload, DSLWorkflowSpec, ExecuteWorkflowPayload, UploadWorkflowRulePayload, WorkflowRuleInputType } from "@vertesia/common";
 import { Command } from "commander";
 import fs from "fs";
 import { resolve, join, basename } from "path";
 import { getClient } from "../client.js";
+import { getStringOption, isRecord, type CliOptions } from "../utils/options.js";
 import { loadJSONWorkflowDefinition } from "./json-loader.js";
 import { loadTsWorkflowDefinition } from "./ts-loader.js";
 import { ValidationError } from "./validation.js";
 import { streamRun } from "./streams.js";
 
-export async function createWorkflowRule(program: Command, options: Record<string, any>) {
+type CreateWorkflowRuleOptions = CliOptions<{
+    name?: string;
+    on?: string;
+    run?: string;
+    inputType?: WorkflowRuleInputType;
+}>;
+
+type WorkflowFileOptions = CliOptions<{
+    file?: string;
+    tags?: string[];
+    skipValidation?: boolean;
+}>;
+
+type WorkflowExecuteOptions = CliOptions<{
+    objectId?: string[];
+    vars?: string;
+    config?: Record<string, unknown>;
+    file?: string;
+    stream?: boolean;
+    interactive?: boolean;
+    output?: string;
+    outputFile?: string;
+    queue?: string;
+}>;
+
+type WorkflowOutputOptions = CliOptions<{
+    file?: string;
+}>;
+
+type TranspileWorkflowOptions = CliOptions<{
+    out?: string;
+}>;
+
+export async function createWorkflowRule(program: Command, options: CreateWorkflowRuleOptions) {
     const { name, on, run, inputType } = options;
     if (!name) {
         console.log("A name for the workflow rule is required. Use --name argument");
@@ -36,7 +70,7 @@ export async function createWorkflowRule(program: Command, options: Record<strin
     console.log("Created workflow rule", workflow.id);
 }
 
-export async function createOrUpdateWorkflowRule(program: Command, options: Record<string, any>) {
+export async function createOrUpdateWorkflowRule(program: Command, options: WorkflowFileOptions) {
     const { file, tags } = options;
 
     if (!file) {
@@ -45,7 +79,7 @@ export async function createOrUpdateWorkflowRule(program: Command, options: Reco
     }
 
     const payload = fs.readFileSync(file, "utf-8");
-    const json = JSON.parse(payload);
+    const json = readWorkflowRulePayload(JSON.parse(payload));
     if (tags) {
         json.tags = tags;
     }
@@ -56,13 +90,13 @@ export async function createOrUpdateWorkflowRule(program: Command, options: Reco
     console.log("Applied workflow rule", rule.id);
 }
 
-export async function deleteWorkflowRule(program: Command, ruleId: string, _options: Record<string, any>) {
+export async function deleteWorkflowRule(program: Command, ruleId: string, _options: Record<string, unknown>) {
     const client = await getClient(program);
     const res = await client.workflows.rules.delete(ruleId);
     console.log("Workflow rule deleted", res);
 }
 
-export async function getWorkflowRule(program: Command, ruleId: string, options: Record<string, any>) {
+export async function getWorkflowRule(program: Command, ruleId: string, options: WorkflowOutputOptions) {
     const client = await getClient(program);
     const res = await client.workflows.rules.retrieve(ruleId);
     const pretty = JSON.stringify(res, null, 2);
@@ -75,17 +109,17 @@ export async function getWorkflowRule(program: Command, ruleId: string, options:
     }
 }
 
-export async function executeWorkflowByName(program: Command, workflowName: string, options: Record<string, any>) {
+export async function executeWorkflowByName(program: Command, workflowName: string, options: WorkflowExecuteOptions) {
     const { objectId, vars, file, stream, interactive, output: outputFile } = options;
     console.debug("Executing interaction in workflow", workflowName, "with options", options);
 
     const mergedConfig = {
-        objectIds: objectId ? objectId : [],
-        vars: JSON.parse(vars || "{}") || {},
+        objectIds: normalizeStringArray(objectId),
+        vars: parseJsonObject(vars || "{}"),
     } as ExecuteWorkflowPayload;
 
     if (file) {
-        const payload = JSON.parse(fs.readFileSync(file, "utf-8"));
+        const payload = parseJsonObject(fs.readFileSync(file, "utf-8"));
         Object.assign(mergedConfig, payload);
     }
 
@@ -115,7 +149,7 @@ export async function executeWorkflowByName(program: Command, workflowName: stri
     // Save the result to a file if outputFile is specified
     if (outputFile && runId) {
         const runDetails = await client.workflows.getRunDetails(runId, workflowId);
-        const output = runDetails.result?.output;
+        const output = isRecord(runDetails.result) ? runDetails.result.output : undefined;
         let outputContent: string;
         if (!output) {
             console.error("No output found for workflow run", runId);
@@ -133,37 +167,33 @@ export async function executeWorkflowByName(program: Command, workflowName: stri
     }
 }
 
-export async function executeWorkflowRule(program: Command, workflowId: string, options: Record<string, any>) {
+export async function executeWorkflowRule(program: Command, workflowId: string, options: WorkflowExecuteOptions) {
     console.log("Executing workflow rule", workflowId, options);
     const { objectId, config, file } = options;
 
-    let mergedConfig = config
-        ? {
-              ...config,
-          }
-        : {};
+    let mergedConfig = config ? { ...config } : {};
 
     if (file) {
-        const payload = JSON.parse(fs.readFileSync(file, "utf-8"));
+        const payload = parseJsonObject(fs.readFileSync(file, "utf-8"));
         mergedConfig = {
             ...payload,
-            ...config,
+            ...mergedConfig,
         };
     }
 
     const client = await getClient(program);
-    const res = await client.workflows.rules.execute(workflowId, objectId, mergedConfig);
+    const res = await client.workflows.rules.execute(workflowId, normalizeStringArray(objectId), mergedConfig);
     console.log(res);
 }
 
-export async function listWorkflowsRule(program: Command, _options: Record<string, any>) {
+export async function listWorkflowsRule(program: Command, _options: Record<string, unknown>) {
     const client = await getClient(program);
     const res = await client.workflows.rules.list();
     const pretty = JSON.stringify(res, null, 2);
     console.log(pretty);
 }
 
-export async function transpileWorkflow(_program: Command, files: string[], options: Record<string, any>) {
+export async function transpileWorkflow(_program: Command, files: string[], options: TranspileWorkflowOptions) {
     if (!files || !files.length) {
         console.log("A .ts file argument is required.");
         process.exit(1);
@@ -174,7 +204,7 @@ export async function transpileWorkflow(_program: Command, files: string[], opti
         if (out && fs.lstatSync(out).isDirectory()) {
             saveToDir = true;
         }
-    } catch (err) {
+    } catch {
         //ignore
     }
     if (files.length > 1 && !saveToDir) {
@@ -186,7 +216,7 @@ export async function transpileWorkflow(_program: Command, files: string[], opti
         if (!out) {
             console.log(JSON.stringify(json, null, 2));
         } else {
-            let outFile;
+            let outFile: string;
             if (saveToDir) {
                 let fileName = basename(file);
                 fileName = fileName.replace(".ts", ".json");
@@ -204,7 +234,7 @@ export async function transpileWorkflow(_program: Command, files: string[], opti
 export async function createOrUpdateWorkflowDefinition(
     program: Command,
     workflowId: string | undefined,
-    options: Record<string, any>,
+    options: WorkflowFileOptions,
 ) {
     const { file, tags, skipValidation } = options;
 
@@ -215,13 +245,13 @@ export async function createOrUpdateWorkflowDefinition(
 
     const isTs = file.endsWith(".ts");
     const loadWorkflow = isTs ? loadTsWorkflowDefinition : loadJSONWorkflowDefinition;
-    let json: any;
+    let json: DSLWorkflowSpec;
     try {
         if (isTs) {
             console.log(`Transpiling file ${file} ...`);
         }
         json = await loadWorkflow(file, skipValidation);
-    } catch (err: any) {
+    } catch (err: unknown) {
         if (err instanceof ValidationError) {
             console.log(err.message);
             process.exit(1);
@@ -244,13 +274,13 @@ export async function createOrUpdateWorkflowDefinition(
     }
 }
 
-export async function listWorkflowsDefinition(program: Command, _options: Record<string, any>) {
+export async function listWorkflowsDefinition(program: Command, _options: Record<string, unknown>) {
     const client = await getClient(program);
     const res = await client.workflows.definitions.list();
     console.log(res);
 }
 
-export async function getWorkflowDefinition(program: Command, objectId: string, options: Record<string, any>) {
+export async function getWorkflowDefinition(program: Command, objectId: string, options: WorkflowOutputOptions) {
     const client = await getClient(program);
     const res = await client.workflows.definitions.retrieve(objectId);
     const pretty = JSON.stringify(res, null, 2);
@@ -263,8 +293,33 @@ export async function getWorkflowDefinition(program: Command, objectId: string, 
     }
 }
 
-export async function deleteWorkflowDefinition(program: Command, objectId: string, _options: Record<string, any>) {
+export async function deleteWorkflowDefinition(program: Command, objectId: string, _options: Record<string, unknown>) {
     const client = await getClient(program);
     const res = await client.workflows.definitions.delete(objectId);
     console.log(res);
+}
+
+function parseJsonObject(content: string): Record<string, unknown> {
+    const value = JSON.parse(content);
+    if (!isRecord(value)) {
+        console.error("Expected a JSON object.");
+        process.exit(1);
+    }
+    return value;
+}
+
+function readWorkflowRulePayload(value: unknown): CreateWorkflowRulePayload {
+    if (!isRecord(value)) {
+        console.error("Expected workflow rule JSON to be an object.");
+        process.exit(1);
+    }
+    return value as UploadWorkflowRulePayload as CreateWorkflowRulePayload;
+}
+
+function normalizeStringArray(value: string[] | string | undefined): string[] | undefined {
+    if (Array.isArray(value)) {
+        return value;
+    }
+    const option = getStringOption(value);
+    return option ? [option] : undefined;
 }

--- a/packages/cli/src/workflows/index.ts
+++ b/packages/cli/src/workflows/index.ts
@@ -28,7 +28,7 @@ export function registerWorkflowsCommand(program: Command) {
             'The event which trigger this rule. Format: "eventName[:objectType]" where objectType is optional.',
         )
         .option("--run [endpoint]", "The workflow to run.")
-        .action(async (options: Record<string, any>) => {
+        .action(async (options: Record<string, unknown>) => {
             await createWorkflowRule(program, options);
         });
 
@@ -36,7 +36,7 @@ export function registerWorkflowsCommand(program: Command) {
         .command("get <ruleId>")
         .description("Get a workflow rule by ID")
         .option("-f, --file [file]", "The file to save the workflow rule to.")
-        .action(async (ruleId: string, options: Record<string, any>) => {
+        .action(async (ruleId: string, options: Record<string, unknown>) => {
             await getWorkflowRule(program, ruleId, options);
         });
 
@@ -44,14 +44,14 @@ export function registerWorkflowsCommand(program: Command) {
         .command("apply")
         .description("Create or update a workflow rule using a file")
         .option("-f, --file <file>", "The file containing the workflow rule to apply.")
-        .action(async (options: Record<string, any>) => {
+        .action(async (options: Record<string, unknown>) => {
             await createOrUpdateWorkflowRule(program, options);
         });
 
     rules
         .command("list")
         .description("List all workflow rules")
-        .action(async (options: Record<string, any>) => {
+        .action(async (options: Record<string, unknown>) => {
             await listWorkflowsRule(program, options);
         });
 
@@ -61,14 +61,14 @@ export function registerWorkflowsCommand(program: Command) {
         .option("-o, --objectId [objectIds...]", "The object to execute the rule on.")
         .option("--vars [vars]", "workflow vars as an inlined JSON string.")
         .option("-f, --file [file]", "The file containing workflow execution payload.")
-        .action(async (workflowId: string, options: Record<string, any>) => {
+        .action(async (workflowId: string, options: Record<string, unknown>) => {
             await executeWorkflowRule(program, workflowId, options);
         });
 
     rules
         .command("delete <ruleId>")
         .description("Delete a workflow rule given its ID")
-        .action(async (ruleId: string, options: Record<string, any>) => {
+        .action(async (ruleId: string, options: Record<string, unknown>) => {
             await deleteWorkflowRule(program, ruleId, options);
         });
 
@@ -82,7 +82,7 @@ export function registerWorkflowsCommand(program: Command) {
         .option("-s, --stream", "Stream the execution")
         .option("-i, --interactive", "Enable interactive mode to send messages during workflow execution", false)
         .option("--output [output]", "Output file for the workflow execution")
-        .action(async (workflowName: string, options: Record<string, any>) => {
+        .action(async (workflowName: string, options: Record<string, unknown>) => {
             // If interactive is true, make sure stream is also enabled
             if (options.interactive) {
                 options.stream = true;
@@ -106,7 +106,7 @@ export function registerWorkflowsCommand(program: Command) {
             "-o, --out [file]",
             "An output file or directory. When multiple files are specified it must be a directory. If not specified the transpiled files are printed to stdout.",
         )
-        .action(async (files: string[], options: Record<string, any>) => {
+        .action(async (files: string[], options: Record<string, unknown>) => {
             await transpileWorkflow(program, files, options);
         });
 
@@ -114,7 +114,7 @@ export function registerWorkflowsCommand(program: Command) {
         .command("create")
         .description("Create a new workflow definition.")
         .option("-f, --file <file>", "The file containing the workflow definition.")
-        .action(async (options: Record<string, any>) => {
+        .action(async (options: Record<string, unknown>) => {
             await createOrUpdateWorkflowDefinition(program, undefined, options);
         });
 
@@ -123,14 +123,14 @@ export function registerWorkflowsCommand(program: Command) {
         .description("Create or update a workflow definition using a file.")
         .option("-f, --file <file>", "The file containing the workflow definition.")
         .option("--skip-validation", "Skip the validation of the workflow definition.")
-        .action(async (workflowId, options: Record<string, any>) => {
+        .action(async (workflowId, options: Record<string, unknown>) => {
             await createOrUpdateWorkflowDefinition(program, workflowId, options);
         });
 
     definitions
         .command("list")
         .description("List all workflow definitions.")
-        .action(async (options: Record<string, any>) => {
+        .action(async (options: Record<string, unknown>) => {
             await listWorkflowsDefinition(program, options);
         });
 
@@ -138,14 +138,14 @@ export function registerWorkflowsCommand(program: Command) {
         .command("get <objectId>")
         .description("Get a workflow definition given its ID.")
         .option("-f, --file [file]", "The file to save the workflow definition to.")
-        .action(async (objectId: string, options: Record<string, any>) => {
+        .action(async (objectId: string, options: Record<string, unknown>) => {
             await getWorkflowDefinition(program, objectId, options);
         });
 
     definitions
         .command("delete <objectId>")
         .description("Delete a workflow definition given its ID.")
-        .action(async (objectId: string, options: Record<string, any>) => {
+        .action(async (objectId: string, options: Record<string, unknown>) => {
             await deleteWorkflowDefinition(program, objectId, options);
         });
 }

--- a/packages/cli/src/workflows/json-loader.ts
+++ b/packages/cli/src/workflows/json-loader.ts
@@ -1,12 +1,13 @@
 import { DSLWorkflowSpec } from "@vertesia/common";
 import { readFile } from "fs/promises";
+import { errorMessage } from "../utils/options.js";
 import { ValidationError, validateWorkflow } from "./validation.js";
 
 function parseJSON(content: string): DSLWorkflowSpec {
     try {
         return JSON.parse(content);
-    } catch (err: any) {
-        throw new ValidationError("Invalid JSON: " + err.message);
+    } catch (err: unknown) {
+        throw new ValidationError("Invalid JSON: " + errorMessage(err));
     }
 }
 

--- a/packages/cli/src/workflows/streams.ts
+++ b/packages/cli/src/workflows/streams.ts
@@ -8,6 +8,8 @@ import figures from "figures";
 import logUpdate from "log-update";
 import logSymbols from "log-symbols";
 import * as readline from "readline";
+import type { Command } from "commander";
+import { getStringOption, isRecord, type CliOptions } from "../utils/options.js";
 
 // Define emoji icons for different message types (using integer enum keys)
 const typeIcons: Partial<Record<AgentMessageType, string>> = {
@@ -21,7 +23,9 @@ const typeIcons: Partial<Record<AgentMessageType, string>> = {
 };
 
 // Enhanced color palette with gradients (using integer enum keys)
-const typeColors: Partial<Record<AgentMessageType, any>> = {
+type GradientAlias = typeof gradient.atlas;
+
+const typeColors: Partial<Record<AgentMessageType, GradientAlias>> = {
     [AgentMessageType.SYSTEM]: gradient.atlas,
     [AgentMessageType.THOUGHT]: gradient.mind,
     [AgentMessageType.PLAN]: gradient.passion,
@@ -61,9 +65,15 @@ const boxStyles: Partial<Record<AgentMessageType, { padding: number; margin: num
     },
 };
 
-export async function streamRun(workflowId: string, runId: string, program: any, options: Record<string, any> = {}) {
+type StreamRunOptions = CliOptions<{
+    since?: string;
+    interactive?: boolean;
+}>;
+
+export async function streamRun(workflowId: string, runId: string, program: Command, options: StreamRunOptions = {}) {
     const client = await getClient(program);
-    const since = options.since ? parseInt(options.since, 10) : undefined;
+    const sinceOption = getStringOption(options.since);
+    const since = sinceOption ? parseInt(sinceOption, 10) : undefined;
     const interactive = options.interactive === true;
 
     // Setup cleanup resources
@@ -168,10 +178,10 @@ export async function streamRun(workflowId: string, runId: string, program: any,
             heartbeatCount = 0;
 
             // Safely format the timestamp
-            let timeString;
+            let timeString: string;
             try {
                 timeString = message.timestamp ? new Date(message.timestamp).toISOString() : new Date().toISOString();
-            } catch (err) {
+            } catch {
                 console.warn(`Invalid timestamp in message: ${message.timestamp}`);
                 timeString = new Date().toISOString();
             }
@@ -213,23 +223,23 @@ export async function streamRun(workflowId: string, runId: string, program: any,
             // Check if message details are long plan or complex data
             if (message.details) {
                 // Special handling for plans - they can be very long
-                if (messageType === AgentMessageType.PLAN && typeof message.details === "object" && message.details.plan) {
+                if (messageType === AgentMessageType.PLAN && hasPlanDetails(message.details)) {
                     console.log(gradient.passion("\n▸ Plan Summary"));
 
                     try {
                         const plan = Array.isArray(message.details.plan)
                             ? message.details.plan
                             : JSON.parse(message.details.plan);
-                        plan.forEach((task: any, index: number) => {
+                        readPlanTasks(plan).forEach((task, index) => {
                             console.log(chalk.bold.cyan(`\n${index + 1}. ${task.goal}`));
-                            if (task.instructions && Array.isArray(task.instructions)) {
+                            if (task.instructions) {
                                 task.instructions.forEach((instruction: string) => {
                                     console.log(`   ${chalk.gray("•")} ${instruction}`);
                                 });
                             }
                         });
                         console.log(""); // add spacing
-                    } catch (e) {
+                    } catch {
                         // If parsing fails, fall back to standard formatting
                         formatDetails(message.details);
                     }
@@ -357,7 +367,7 @@ export async function streamRun(workflowId: string, runId: string, program: any,
 }
 
 // Helper function to format message content
-function formatMessageContent(content: any): string {
+function formatMessageContent(content: unknown): string {
     if (typeof content === "string") {
         // Replace escaped newlines with actual newlines
         return content.replace(/\\n/g, "\n");
@@ -368,7 +378,7 @@ function formatMessageContent(content: any): string {
 }
 
 // Helper function to format details in a cleaner way
-function formatDetails(details: any): void {
+function formatDetails(details: unknown): void {
     // Check if details are empty or minimal
     const detailsStr = typeof details === "string" ? details : JSON.stringify(details);
 
@@ -445,7 +455,7 @@ function formatDetails(details: any): void {
                 // For complex objects, fall back to pretty-printed JSON
                 console.log(formatColorizedJSON(details));
             }
-        } catch (err) {
+        } catch {
             // Fall back to colorized JSON if formatting fails
             console.log(formatColorizedJSON(details));
         }
@@ -458,7 +468,7 @@ function formatDetails(details: any): void {
 }
 
 // Helper function to format JSON with colors
-function formatColorizedJSON(obj: any): string {
+function formatColorizedJSON(obj: unknown): string {
     const jsonString = JSON.stringify(obj, null, 2);
 
     // Colorize different parts of the JSON
@@ -468,4 +478,36 @@ function formatColorizedJSON(obj: any): string {
         .replace(/: (\d+)/g, (_, value) => `: ${chalk.yellow(value)}`)
         .replace(/: (true|false)/g, (_, value) => `: ${chalk.magenta(value)}`)
         .replace(/: null/g, `: ${chalk.red("null")}`);
+}
+
+interface PlanDetails {
+    plan: unknown[] | string;
+}
+
+interface PlanTask {
+    goal: string;
+    instructions?: string[];
+}
+
+function hasPlanDetails(details: unknown): details is PlanDetails {
+    return isRecord(details) && (Array.isArray(details.plan) || typeof details.plan === "string");
+}
+
+function readPlanTasks(value: unknown): PlanTask[] {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+    return value.flatMap((task) => {
+        if (!isRecord(task)) {
+            return [];
+        }
+        const goal = getStringOption(task.goal);
+        if (!goal) {
+            return [];
+        }
+        const instructions = Array.isArray(task.instructions)
+            ? task.instructions.filter((instruction): instruction is string => typeof instruction === "string")
+            : undefined;
+        return [{ goal, instructions }];
+    });
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -13,7 +13,8 @@
     "lint": "biome lint src",
     "build": "pnpm exec tsmod build && pnpm exec rollup -c",
     "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo",
-    "test": "vitest run"
+    "test": "vitest run",
+    "typecheck:test": "tsc -p tsconfig.test.json --noEmit"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^28.0.3",

--- a/packages/client/rollup.config.js
+++ b/packages/client/rollup.config.js
@@ -16,6 +16,14 @@ export default {
         // Add any packages you want to keep external (e.g., use via import map)
         "@vertesia/common", "eventsource", "ajv"
     ],
+    // Treat TypeScript diagnostics from @rollup/plugin-typescript as build errors
+    // instead of warnings, so type issues fail the build.
+    onwarn(warning, defaultHandler) {
+        if (warning.plugin === 'typescript') {
+            throw new Error(warning.message ?? String(warning));
+        }
+        defaultHandler(warning);
+    },
     plugins: [
         nodeResolve({
             browser: true,  // Prefer browser-compatible versions of packages

--- a/packages/client/src/AccountApi.ts
+++ b/packages/client/src/AccountApi.ts
@@ -42,7 +42,7 @@ export default class AccountApi extends ApiTopic {
      * Get all projects for account
     */
     projects(): Promise<ProjectRef[]> {
-        return this.get('/projects').then((res: AccountProjectsResponse) => res.data);
+        return this.get<AccountProjectsResponse>('/projects').then((res) => res.data);
     }
 
     members(): Promise<User[]> {
@@ -85,7 +85,7 @@ export default class AccountApi extends ApiTopic {
      * @returns InviteDeclineResponse
      * */
     rejectInvite(id: string): Promise<InviteDeclineResponse> {
-        return this.delete(`/invites/${id}`);
+        return this.del(`/invites/${id}`);
     }
 
     /**

--- a/packages/client/src/AppsApi.ts
+++ b/packages/client/src/AppsApi.ts
@@ -95,7 +95,7 @@ export default class AppsApi extends ApiTopic {
      * @returns 
      */
     getAppInstallationByName(appName: string): Promise<AppInstallationWithManifest | null> {
-        return this.get(`/installations/name/${appName}`).catch((err: ServerError) => {
+        return this.get<AppInstallationWithManifest>(`/installations/name/${appName}`).catch((err: ServerError) => {
             if (err.status === 404) {
                 return null;
             } else {

--- a/packages/client/src/CommandsApi.ts
+++ b/packages/client/src/CommandsApi.ts
@@ -13,7 +13,7 @@ export default class CommandsApi extends ApiTopic {
     }
 
     async isNamespaceAvailable(name: string): Promise<boolean> {
-        return this.get(`/namespaces/${name}/is_available`).then((response) => response.available);
+        return this.get<{ available: boolean }>(`/namespaces/${name}/is_available`).then((response) => response.available);
     }
 
     async initSamples(): Promise<GenericCommandResponse> {

--- a/packages/client/src/InteractionBase.ts
+++ b/packages/client/src/InteractionBase.ts
@@ -2,7 +2,7 @@ import { InteractionExecutionResult, InteractionUpdatePayload, InteractionExecut
 import { VertesiaClient, VertesiaClientProps } from "./client.js";
 import { executeInteraction } from "./execute.js";
 
-export class InteractionBase<P = any> {
+export class InteractionBase<P = unknown> {
     client: VertesiaClient;
 
     constructor(public id: string, clientOrOpts: VertesiaClient | VertesiaClientProps) {

--- a/packages/client/src/InteractionOutput.test.ts
+++ b/packages/client/src/InteractionOutput.test.ts
@@ -190,9 +190,10 @@ describe('InteractionOutput', () => {
 
         it('should be marked with IS_INTERACTION_OUTPUT symbol', () => {
             const output = InteractionOutput.from(sampleResults);
+            const markedOutput = output as { [IS_INTERACTION_OUTPUT]?: boolean };
 
             // Check that the symbol marker is present
-            expect((output as any)[IS_INTERACTION_OUTPUT]).toBe(true);
+            expect(markedOutput[IS_INTERACTION_OUTPUT]).toBe(true);
         });
 
         it('should return the same instance when calling from() on an already wrapped array', () => {

--- a/packages/client/src/InteractionOutput.ts
+++ b/packages/client/src/InteractionOutput.ts
@@ -1,4 +1,4 @@
-import { CompletionResult } from '@llumiverse/common';
+import { CompletionResult, JSONObject } from '@llumiverse/common';
 import { ExecutionRun, InteractionExecutionResult } from '@vertesia/common';
 
 /**
@@ -7,13 +7,13 @@ import { ExecutionRun, InteractionExecutionResult } from '@vertesia/common';
  */
 export const IS_INTERACTION_OUTPUT = Symbol('InteractionOutput');
 
-export function enhanceInteractionExecutionResult<ResultT = any, ParamsT = any>(r: InteractionExecutionResult<ParamsT>): EnhancedInteractionExecutionResult<ResultT, ParamsT> {
-    (r as any).result = InteractionOutput.from<ResultT>(r.result);
+export function enhanceInteractionExecutionResult<ResultT = unknown, ParamsT = unknown>(r: InteractionExecutionResult<ParamsT>): EnhancedInteractionExecutionResult<ResultT, ParamsT> {
+    r.result = InteractionOutput.from<ResultT>(r.result);
     return r as EnhancedInteractionExecutionResult<ResultT, ParamsT>;
 }
 
-export function enhanceExecutionRun<ResultT = any, ParamsT = any>(r: ExecutionRun<ParamsT>): EnhancedExecutionRun<ResultT, ParamsT> {
-    (r as any).result = InteractionOutput.from<ResultT>(r.result);
+export function enhanceExecutionRun<ResultT = unknown, ParamsT = unknown>(r: ExecutionRun<ParamsT>): EnhancedExecutionRun<ResultT, ParamsT> {
+    r.result = InteractionOutput.from<ResultT>(r.result);
     return r as EnhancedExecutionRun<ResultT, ParamsT>;
 }
 
@@ -44,7 +44,7 @@ export function enhanceExecutionRun<ResultT = any, ParamsT = any>(r: ExecutionRu
  * interface OtherType { title: string; }
  * ```
  */
-export class InteractionOutput<T = any> {
+export class InteractionOutput<T = unknown> {
     /**
      * The raw completion results array.
      * Access this when you need to work with the underlying CompletionResult[] directly.
@@ -73,12 +73,12 @@ export class InteractionOutput<T = any> {
      * const text = output.text();     // string
      * ```
      */
-    static from<T = any>(results: CompletionResult[] | InteractionOutputArray<T> | Record<string, any> | string | null | undefined): InteractionOutputArray<T> {
+    static from<T = unknown>(results: CompletionResult[] | InteractionOutputArray<T> | JSONObject | string | null | undefined): InteractionOutputArray<T> {
         if (!results) {
             return createInteractionOutput<T>([]);
         }
         // Check if already wrapped using the symbol marker        
-        if ((results as any)[IS_INTERACTION_OUTPUT]) {
+        if (isInteractionOutputMarker(results)) {
             return results as InteractionOutputArray<T>;
         }
         if (Array.isArray(results)) {
@@ -90,8 +90,8 @@ export class InteractionOutput<T = any> {
         }
     }
 
-    static isInteractionOutputArray(obj: any): boolean {
-        return obj && obj[IS_INTERACTION_OUTPUT] === true;
+    static isInteractionOutputArray(obj: unknown): boolean {
+        return isInteractionOutputMarker(obj);
     }
 
     get isEmpty() {
@@ -136,14 +136,14 @@ export class InteractionOutput<T = any> {
      * @returns The first JSON result typed as T (the class generic type)
      * @throws Error if no JSON result found and text cannot be parsed as JSON
      */
-    object(): T {
+    object<U = T>(): U {
         const jsonResult = this.results.find(r => r.type === 'json');
         if (jsonResult) {
-            return jsonResult.value as T;
+            return jsonResult.value as U;
         }
 
         // Fallback: try to parse the other text parts as JSON
-        return parseCompletionResultAsJson(this.results);
+        return parseCompletionResultAsJson<U>(this.results);
     }
 
     /**
@@ -248,13 +248,21 @@ export class InteractionOutput<T = any> {
  * Type representing a CompletionResult array enhanced with InteractionOutput methods.
  * This is the return type of InteractionOutput.from() - it acts as both an array and has convenience methods.
  */
-export type InteractionOutputArray<T = any> = CompletionResult[] & InteractionOutput<T>;
+export type InteractionOutputArray<T = unknown> = CompletionResult[] & InteractionOutput<T>;
 
-export interface EnhancedInteractionExecutionResult<ResultT = any, ParamsT = any> extends InteractionExecutionResult<ParamsT> {
+type InteractionOutputMarker = {
+    [IS_INTERACTION_OUTPUT]?: boolean;
+};
+
+function isInteractionOutputMarker(obj: unknown): obj is InteractionOutputMarker {
+    return !!obj && typeof obj === 'object' && (obj as InteractionOutputMarker)[IS_INTERACTION_OUTPUT] === true;
+}
+
+export interface EnhancedInteractionExecutionResult<ResultT = unknown, ParamsT = unknown> extends InteractionExecutionResult<ParamsT> {
     result: InteractionOutputArray<ResultT>;
 }
 
-export interface EnhancedExecutionRun<ResultT = any, ParamsT = any> extends ExecutionRun<ParamsT> {
+export interface EnhancedExecutionRun<ResultT = unknown, ParamsT = unknown> extends ExecutionRun<ParamsT> {
     result: InteractionOutputArray<ResultT>;
 }
 
@@ -282,7 +290,7 @@ export interface EnhancedExecutionRun<ResultT = any, ParamsT = any> extends Exec
  * const img = output.image();     // string
  * ```
  */
-export function createInteractionOutput<T = any>(results: CompletionResult[]): InteractionOutputArray<T> {
+export function createInteractionOutput<T = unknown>(results: CompletionResult[]): InteractionOutputArray<T> {
     const wrapper = new InteractionOutput<T>(results);
 
     return new Proxy(results, {
@@ -294,7 +302,7 @@ export function createInteractionOutput<T = any>(results: CompletionResult[]): I
 
             // Check if the wrapper has this property/method
             if (prop in wrapper) {
-                const value = (wrapper as any)[prop];
+                const value = Reflect.get(wrapper, prop, wrapper) as unknown;
                 // If it's a function, bind it to the wrapper so 'this' works correctly
                 if (typeof value === 'function') {
                     return value.bind(wrapper);
@@ -309,15 +317,15 @@ export function createInteractionOutput<T = any>(results: CompletionResult[]): I
 }
 
 
-function parseCompletionResultAsJson(data: CompletionResult[]) {
+function parseCompletionResultAsJson<T>(data: CompletionResult[]): T {
     let lastError: Error | undefined;
     for (const part of data) {
         if (part.type === "text") {
             const text = part.value.trim();
             try {
-                return JSON.parse(text);
-            } catch (error: any) {
-                lastError = error;
+                return JSON.parse(text) as T;
+            } catch (error: unknown) {
+                lastError = error instanceof Error ? error : new Error(String(error));
             }
         }
     }

--- a/packages/client/src/InteractionsApi.ts
+++ b/packages/client/src/InteractionsApi.ts
@@ -13,6 +13,10 @@ import { checkRateLimit, executeInteraction, executeInteractionAsync, executeInt
 import { InteractionCatalogApi } from "./InteractionCatalogApi.js";
 import { EnhancedInteractionExecutionResult, enhanceInteractionExecutionResult } from "./InteractionOutput.js";
 
+function hasIdPayload(payload: unknown): payload is { id: string } {
+    return !!payload && typeof payload === "object" && "id" in payload && typeof payload.id === "string";
+}
+
 export default class InteractionsApi extends ApiTopic {
     catalog: InteractionCatalogApi;
 
@@ -149,10 +153,10 @@ export default class InteractionsApi extends ApiTopic {
      * @throws 500 if interaction execution fails
      * @throws 500 if interaction execution times out
      **/
-    async execute<ResultT = any, ParamsT = any>(id: string, payload: InteractionExecutionPayload = {},
+    async execute<ResultT = unknown, ParamsT = unknown>(id: string, payload: InteractionExecutionPayload = {},
         onChunk?: (chunk: string) => void): Promise<EnhancedInteractionExecutionResult<ResultT, ParamsT>> {
         const r = await executeInteraction<ParamsT>(this.client as VertesiaClient, id, payload, onChunk).catch(err => {
-            if (err instanceof ServerError && err.payload?.id) {
+            if (err instanceof ServerError && hasIdPayload(err.payload)) {
                 throw err.updateDetails({ run_id: err.payload.id });
             } else {
                 throw err;
@@ -176,10 +180,10 @@ export default class InteractionsApi extends ApiTopic {
      * @param onChunk
      * @returns
      */
-    async executeByName<ResultT = any, ParamsT = any>(nameWithTag: string, payload: InteractionExecutionPayload = {},
+    async executeByName<ResultT = unknown, ParamsT = unknown>(nameWithTag: string, payload: InteractionExecutionPayload = {},
         onChunk?: (chunk: string) => void): Promise<EnhancedInteractionExecutionResult<ResultT, ParamsT>> {
         const r = await executeInteractionByName<ParamsT>(this.client as VertesiaClient, nameWithTag, payload, onChunk).catch(err => {
-            if (err instanceof ServerError && err.payload?.id) {
+            if (err instanceof ServerError && hasIdPayload(err.payload)) {
                 throw err.updateDetails({ run_id: err.payload.id });
             } else {
                 throw err;

--- a/packages/client/src/OAuthServerApi.ts
+++ b/packages/client/src/OAuthServerApi.ts
@@ -24,8 +24,8 @@ export default class OAuthServerApi extends ClientBase {
         return this.parent.createRequest(url, init);
     }
 
-    handleResponse(req: Request, res: Response, params: IRequestParamsWithPayload | undefined): Promise<any> {
-        return this.parent.handleResponse(req, res, params);
+    handleResponse<T = unknown>(req: Request, res: Response, params: IRequestParamsWithPayload | undefined): T | Promise<T> {
+        return this.parent.handleResponse<T>(req, res, params);
     }
 
     createAuthorizationRequest(payload: CreateOAuthAuthorizationRequestPayload): Promise<OAuthAuthorizationRequest> {

--- a/packages/client/src/ProjectsApi.ts
+++ b/packages/client/src/ProjectsApi.ts
@@ -70,7 +70,7 @@ export default class ProjectsApi extends ApiTopic {
      * Returns null if the tool is not found.
      */
     getToolByName(projectId: string, toolName: string): Promise<ProjectToolInfo | null> {
-        return this.get(`/${projectId}/tools/${toolName}`).catch((err: ServerError) => {
+        return this.get<ProjectToolInfo>(`/${projectId}/tools/${toolName}`).catch((err: ServerError) => {
             if (err.status === 404) {
                 return null;
             }
@@ -127,11 +127,11 @@ class IntegrationsConfigurationApi extends ApiTopic {
     }
 
     list(projectId: string): Promise<ProjectIntegrationListEntry[]> {
-        return this.get(`/${projectId}/integrations`).then((res: ProjectIntegrationListResponse) => res.integrations);
+        return this.get<ProjectIntegrationListResponse>(`/${projectId}/integrations`).then((res) => res.integrations);
     }
 
     retrieve(projectId: string, integrationId: SupportedIntegrations): Promise<ProjectIntegrationConfigResponse | undefined> {
-        return this.get(`/${projectId}/integrations/${integrationId}`).catch(err => {
+        return this.get<ProjectIntegrationConfigResponse>(`/${projectId}/integrations/${integrationId}`).catch(err => {
             if (err.status === 404) {
                 return undefined;
             }

--- a/packages/client/src/RunsApi.ts
+++ b/packages/client/src/RunsApi.ts
@@ -66,12 +66,12 @@ export class RunsApi extends ApiTopic {
      * @param id
      * @returns InteractionResult
      **/
-    async retrieve<ResultT = any, ParamsT = any>(id: string): Promise<EnhancedExecutionRun<ResultT, ParamsT>> {
-        const r = await this.get("/" + id);
+    async retrieve<ResultT = unknown, ParamsT = unknown>(id: string): Promise<EnhancedExecutionRun<ResultT, ParamsT>> {
+        const r = await this.get<ExecutionRun<ParamsT>>("/" + id);
         return enhanceExecutionRun<ResultT, ParamsT>(r);
     }
 
-    retrievePopulated<P = any>(id: string): Promise<PopulatedExecutionRun<P>> {
+    retrievePopulated<P = unknown>(id: string): Promise<PopulatedExecutionRun<P>> {
         return this.get("/" + id, {
             query: { populate: "true" },
         });
@@ -88,7 +88,7 @@ export class RunsApi extends ApiTopic {
         return this.get(`/filter-options/${field}`, { query });
     }
 
-    async create<ResultT = any, ParamsT = any>(payload: RunCreatePayload): Promise<EnhancedExecutionRun<ResultT, ParamsT>> {
+    async create<ResultT = unknown, ParamsT = unknown>(payload: RunCreatePayload): Promise<EnhancedExecutionRun<ResultT, ParamsT>> {
         const sessionTags = (this.client as VertesiaClient).sessionTags;
         if (sessionTags) {
             let tags = Array.isArray(sessionTags) ? sessionTags : [sessionTags];
@@ -99,7 +99,7 @@ export class RunsApi extends ApiTopic {
             }
             payload = { ...payload, tags };
         }
-        const r = await this.post("/", {
+        const r = await this.post<ExecutionRun<ParamsT>>("/", {
             payload,
         });
         return enhanceExecutionRun<ResultT, ParamsT>(r);

--- a/packages/client/src/SecretsApi.ts
+++ b/packages/client/src/SecretsApi.ts
@@ -15,12 +15,12 @@ export default class SecretsApi extends ApiTopic {
     }
 
     list(projectId: string, query?: Omit<ListSecretsQuery, "project_id">): Promise<SecretRecord[]> {
-        return this.get('/', { query: { ...query, project_id: projectId } })
-            .then((res: { secrets: SecretRecord[] }) => res.secrets);
+        return this.get<{ secrets: SecretRecord[] }>('/', { query: { ...query, project_id: projectId } })
+            .then((res) => res.secrets);
     }
 
     retrieve(projectId: string, secretId: string, query?: { kind?: SecretKind }): Promise<SecretRecord | undefined> {
-        return this.get(`/${secretId}`, { query: { ...query, project_id: projectId } }).catch(err => {
+        return this.get<SecretRecord>(`/${secretId}`, { query: { ...query, project_id: projectId } }).catch(err => {
             if (err.status === 404) {
                 return undefined;
             }

--- a/packages/client/src/TrainingApi.ts
+++ b/packages/client/src/TrainingApi.ts
@@ -10,11 +10,11 @@ export default class TrainingApi extends ApiTopic {
     }
 
     listSessions(query: ListTrainingSessionsQuery = {}): Promise<TrainingSessionRef[]> {
-        return this.get('/', { query: query as any });
+        return this.get('/', { query: { ...query } });
     }
 
     listSessionNames(query: ListTrainingSessionsQuery = {}): Promise<{ id: string, name: string }[]> {
-        return this.get('/names', { query: query as any });
+        return this.get('/names', { query: { ...query } });
     }
 
     createSession(payload: TrainingSessionCreatePayload): Promise<TrainingSession> {
@@ -25,7 +25,7 @@ export default class TrainingApi extends ApiTopic {
         return this.get('/' + sessionId)
     }
 
-    addToSession(sessionId: string, runs: string[]): Promise<any> {
+    addToSession(sessionId: string, runs: string[]): Promise<unknown> {
         return this.post('/' + sessionId + '/add', { payload: { runs } })
     }
 
@@ -64,7 +64,7 @@ export default class TrainingApi extends ApiTopic {
         });
     }
 
-    setDataset(sessionId: string, name: string = "default"): Promise<any> {
+    setDataset(sessionId: string, name: string = "default"): Promise<unknown> {
         return this.post('/' + sessionId + '/dataset', { payload: { dataset: name } })
     }
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -177,7 +177,7 @@ export class VertesiaClient extends AbstractFetchClient<VertesiaClient> {
                 } else {
                     this.tokenServerUrl = "https://sts.dev1.vertesia.io";
                 }
-            } catch (e) {
+            } catch {
                 this.tokenServerUrl = "https://sts.dev1.vertesia.io";
             }
         } else {

--- a/packages/client/src/execute.ts
+++ b/packages/client/src/execute.ts
@@ -93,7 +93,7 @@ function handleStreaming(client: VertesiaClient, runId: string, onChunk: (chunk:
                     try {
                         const data = JSON.parse(ev.data);
                         if (data) {
-                            onChunk && onChunk(data);
+                            onChunk?.(data);
                         }
                     } catch (err) {
                         reject(err);

--- a/packages/client/src/execute.ts
+++ b/packages/client/src/execute.ts
@@ -19,7 +19,7 @@ export async function EventSourceProvider(): Promise<typeof EventSource> {
  * @param payload InteractionExecutionPayload
  * @param onChunk callback to be called when the next chunk of the response is available
  */
-export async function executeInteraction<P = any>(client: VertesiaClient,
+export async function executeInteraction<P = unknown>(client: VertesiaClient,
     interactionId: string,
     payload: InteractionExecutionPayload = {},
     onChunk?: (chunk: string) => void): Promise<InteractionExecutionResult<P>> {
@@ -52,12 +52,12 @@ export async function executeInteraction<P = any>(client: VertesiaClient,
  * @param onChunk
  * @returns
  */
-export async function executeInteractionByName<P = any>(client: VertesiaClient,
+export async function executeInteractionByName<P = unknown>(client: VertesiaClient,
     interaction: string,
     payload: InteractionExecutionPayload = {},
     onChunk?: (chunk: string) => void): Promise<InteractionExecutionResult<P>> {
     const stream = !!onChunk;
-    const response = await client.post('/api/v1/execute', {
+    const response = await client.post<InteractionExecutionResult<P>>('/api/v1/execute', {
         payload: {
             ...payload,
             interaction,

--- a/packages/client/src/store/AgentsApi.ts
+++ b/packages/client/src/store/AgentsApi.ts
@@ -509,10 +509,12 @@ export class AgentsApi extends ApiTopic {
         id: string,
         options?: {
             includeHistory?: boolean;
+            hydratePayloads?: boolean;
         },
     ): Promise<WorkflowRunWithDetails> {
         const query: Record<string, string> = {};
         if (options?.includeHistory) query.include_history = 'true';
+        if (options?.hydratePayloads) query.hydrate_payloads = 'true';
         return this.get(`/${id}/details`, { query });
     }
 
@@ -600,10 +602,11 @@ export class AgentsApi extends ApiTopic {
     getChildDetails(
         id: string,
         childWorkflowId: string,
-        options?: { includeHistory?: boolean },
+        options?: { includeHistory?: boolean; hydratePayloads?: boolean },
     ): Promise<WorkflowRunWithDetails> {
         const query: Record<string, string> = {};
         if (options?.includeHistory) query.include_history = 'true';
+        if (options?.hydratePayloads) query.hydrate_payloads = 'true';
         return this.get(`/${id}/children/${childWorkflowId}/details`, { query });
     }
 

--- a/packages/client/src/store/AgentsApi.ts
+++ b/packages/client/src/store/AgentsApi.ts
@@ -70,10 +70,10 @@ export class AgentsApi extends ApiTopic {
     start<TData = Record<string, unknown>>(
         payload: CreateAgentRunPayload<TData>,
     ): Promise<AgentRun<TData>>;
-    start<TData = Record<string, any>>(
+    start<TData = Record<string, unknown>>(
         payload: CreateProcessRunPayload<TData>,
     ): Promise<ProcessRun>;
-    start<TData = Record<string, any>>(
+    start<TData = Record<string, unknown>>(
         payload: CreateAgentRunPayload<TData> | CreateProcessRunPayload<TData>,
     ): Promise<AgentRun<TData> | ProcessRun> {
         return this.post('/', { payload });
@@ -85,9 +85,9 @@ export class AgentsApi extends ApiTopic {
      *
      * @internal
      */
-    recordRun<TData = Record<string, any>>(payload: RecordAgentRunPayload<TData>): Promise<AgentRun<TData>>;
-    recordRun<TData = Record<string, any>>(payload: RecordProcessRunPayload<TData>): Promise<ProcessRun>;
-    recordRun<TData = Record<string, any>>(payload: RecordRunPayload<TData>): Promise<AgentRun<TData> | ProcessRun> {
+    recordRun<TData = Record<string, unknown>>(payload: RecordAgentRunPayload<TData>): Promise<AgentRun<TData>>;
+    recordRun<TData = Record<string, unknown>>(payload: RecordProcessRunPayload<TData>): Promise<ProcessRun>;
+    recordRun<TData = Record<string, unknown>>(payload: RecordRunPayload<TData>): Promise<AgentRun<TData> | ProcessRun> {
         return this.post('/record', { payload });
     }
 
@@ -198,7 +198,7 @@ export class AgentsApi extends ApiTopic {
         return this.post(`/${id}/fork`, {});
     }
 
-    getContext(id: string): Promise<{ run_id: string; current_node: string; context: Record<string, any> }> {
+    getContext(id: string): Promise<{ run_id: string; current_node: string; context: Record<string, unknown> }> {
         return this.get(`/${id}/context`);
     }
 
@@ -219,7 +219,7 @@ export class AgentsApi extends ApiTopic {
         return this.post(`/${id}/retry-node`, { payload: payload ?? {} });
     }
 
-    answerTask(id: string, taskId: string, result: Record<string, any>): Promise<{ message: string }> {
+    answerTask(id: string, taskId: string, result: Record<string, unknown>): Promise<{ message: string }> {
         return this.post(`/${id}/answer-task`, { payload: { task_id: taskId, result } });
     }
 

--- a/packages/client/src/store/AnalyzeDocApi.ts
+++ b/packages/client/src/store/AnalyzeDocApi.ts
@@ -1,4 +1,4 @@
-import { ApiTopic, ClientBase } from "@vertesia/api-fetch-client";
+import { ApiTopic, ClientBase, type IRequestParams } from "@vertesia/api-fetch-client";
 import { AdaptedTable, AdaptTablesRequest, DocAnalyzerResultResponse, DocAnalyzeRunStatusResponse, DocImage, DocTableCsv, DocTableJson, ExportTableFormats, GetAdaptedTablesRequestQuery, PdfToRichtextOptions, WorkflowRunStatus } from "@vertesia/common";
 
 export class AnalyzeDocApi extends ApiTopic {
@@ -26,12 +26,12 @@ export class AnalyzeDocApi extends ApiTopic {
         const path = runId ? `/adapt_tables/${runId}` : "/adapt_tables";
         
         // Build query parameters
-        const queryParams: any = {};
+        const queryParams: NonNullable<IRequestParams["query"]> = {};
         if (query?.format) queryParams.format = query.format;
         if (query?.raw !== undefined) queryParams.raw = query.raw;
         
         // If format is CSV, set response type to text to avoid automatic JSON parsing
-        const options: any = { query: queryParams };
+        const options: IRequestParams & { responseType?: "text" } = { query: queryParams };
         if (query?.format === 'csv') {
             options.responseType = 'text';
         }
@@ -44,7 +44,7 @@ export class AnalyzeDocApi extends ApiTopic {
     }
 
     async getTables(format?: ExportTableFormats): Promise<DocTableCsv[] | DocTableJson[]> {
-        const options: any = {};
+        const options: IRequestParams = {};
         if (format) {
             options.query = {format: format}
         }

--- a/packages/client/src/store/FilesApi.ts
+++ b/packages/client/src/store/FilesApi.ts
@@ -37,7 +37,7 @@ export class FilesApi extends ApiTopic {
     }
 
     async deleteFile(path: string, prefix?: boolean): Promise<DeleteFileResult> {
-        return this.delete(`/${path}`, { query: { prefix } });
+        return this.del(`/${path}`, { query: { prefix } });
     }
 
     /**

--- a/packages/client/src/store/ObjectsApi.ts
+++ b/packages/client/src/store/ObjectsApi.ts
@@ -42,6 +42,10 @@ import { StreamSource } from "../StreamSource.js";
 import { AnalyzeDocApi } from "./AnalyzeDocApi.js";
 import { ZenoClient } from "./client.js";
 
+type ContentObjectWritePayload = Omit<CreateContentObjectPayload, "content"> & {
+    content?: ContentSource | File | StreamSource;
+};
+
 export class ObjectsApi extends ApiTopic {
     declare client: ZenoClient;
 
@@ -79,7 +83,7 @@ export class ObjectsApi extends ApiTopic {
      * @param payload Search/filter parameters
      * @returns Matching content objects
      */
-    list<T = any>(
+    list<T = unknown>(
         payload: ObjectSearchPayload = {},
     ): Promise<ContentObjectItem<T>[]> {
         const limit = payload.limit || 100;
@@ -206,20 +210,23 @@ export class ObjectsApi extends ApiTopic {
     }
 
     async create(
-        payload: CreateContentObjectPayload,
+        payload: ContentObjectWritePayload,
         options?: {
             collection_id?: string;
             processing_priority?: ContentObjectProcessingPriority;
         },
     ): Promise<ContentObject> {
+        const { content, ...payloadWithoutContent } = payload;
         const createPayload: CreateContentObjectPayload = {
-            ...payload,
+            ...payloadWithoutContent,
         };
         if (
-            payload.content instanceof StreamSource ||
-            payload.content instanceof File
+            content instanceof StreamSource ||
+            content instanceof File
         ) {
-            createPayload.content = await this.upload(payload.content);
+            createPayload.content = await this.upload(content);
+        } else {
+            createPayload.content = content;
         }
 
         const headers: Record<string, string> = {};
@@ -294,7 +301,7 @@ export class ObjectsApi extends ApiTopic {
      */
     async update(
         id: string,
-        payload: Partial<CreateContentObjectPayload>,
+        payload: Partial<ContentObjectWritePayload>,
         options?: {
             createRevision?: boolean;
             revisionLabel?: string;
@@ -304,16 +311,19 @@ export class ObjectsApi extends ApiTopic {
             ifMatch?: string;
         },
     ): Promise<ContentObject> {
+        const { content, ...payloadWithoutContent } = payload;
         const updatePayload: Partial<CreateContentObjectPayload> = {
-            ...payload,
+            ...payloadWithoutContent,
         };
 
         // Handle file upload if content is provided as File or StreamSource
         if (
-            payload.content instanceof StreamSource ||
-            payload.content instanceof File
+            content instanceof StreamSource ||
+            content instanceof File
         ) {
-            updatePayload.content = await this.upload(payload.content);
+            updatePayload.content = await this.upload(content);
+        } else {
+            updatePayload.content = content;
         }
 
         const headers: Record<string, string> = {};
@@ -372,7 +382,7 @@ export class ObjectsApi extends ApiTopic {
         return this.del(`/${idOrIds}`);
     }
 
-    bulkUpdate(updates: Record<string, Record<string, any>>): Promise<BulkObjectUpdateResult> {
+    bulkUpdate(updates: Record<string, Record<string, unknown>>): Promise<BulkObjectUpdateResult> {
         const ids = Object.keys(updates);
         return this.client.runOperation({
             name: 'update',

--- a/packages/client/src/store/WorkflowsApi.ts
+++ b/packages/client/src/store/WorkflowsApi.ts
@@ -81,6 +81,7 @@ export class WorkflowsApi extends ApiTopic {
         options?: {
             includeHistory?: boolean;
             historyFormat?: 'events' | 'tasks' | 'agent';
+            hydratePayloads?: boolean;
         }
     ): Promise<WorkflowRunWithDetails> {
         const query: Record<string, any> = {};
@@ -93,6 +94,10 @@ export class WorkflowsApi extends ApiTopic {
         // Support new historyFormat parameter
         if (options?.historyFormat !== undefined) {
             query.history_format = options.historyFormat;
+        }
+
+        if (options?.hydratePayloads !== undefined) {
+            query.hydrate_payloads = options.hydratePayloads;
         }
 
         return this.get(`/runs/${workflowId}/${runId}`, { query });

--- a/packages/client/src/store/WorkflowsApi.ts
+++ b/packages/client/src/store/WorkflowsApi.ts
@@ -1,4 +1,4 @@
-import { ApiTopic, ClientBase } from "@vertesia/api-fetch-client";
+import { ApiTopic, ClientBase, type IRequestParams } from "@vertesia/api-fetch-client";
 import {
     ActivityCatalog,
     AgentEvent,
@@ -20,6 +20,7 @@ import {
     PromptSizeAnalyticsResponse,
     RunsByAgentAnalyticsResponse,
     SignalAgentResponse,
+    SignalAgentPayload,
     TimeToFirstResponseAnalyticsResponse,
     TokenUsageAnalyticsResponse,
     ToolAnalyticsResponse,
@@ -42,6 +43,7 @@ import {
     WorkflowRunWithDetails,
     WorkflowToolParametersQuery,
     WorkflowUpdatePublishResponse,
+    UploadWorkflowRulePayload,
 } from "@vertesia/common";
 import { VertesiaClient } from "../client.js";
 import { EventSourceProvider } from "../execute.js";
@@ -71,7 +73,7 @@ export class WorkflowsApi extends ApiTopic {
         return this.post(`/runs`, { payload: payload });
     }
 
-    sendSignal(workflowId: string, runId: string, signal: string, payload?: any): Promise<SignalAgentResponse> {
+    sendSignal(workflowId: string, runId: string, signal: string, payload?: SignalAgentPayload | null): Promise<SignalAgentResponse> {
         return this.post(`/runs/${workflowId}/${runId}/signal/${signal}`, { payload });
     }
 
@@ -83,7 +85,7 @@ export class WorkflowsApi extends ApiTopic {
             historyFormat?: 'events' | 'tasks' | 'agent';
         }
     ): Promise<WorkflowRunWithDetails> {
-        const query: Record<string, any> = {};
+        const query: NonNullable<IRequestParams["query"]> = {};
 
         // Support legacy includeHistory parameter
         if (options?.includeHistory !== undefined) {
@@ -307,7 +309,7 @@ export class WorkflowsApi extends ApiTopic {
                         }
                     };
 
-                    sse.onerror = (err: any) => {
+                    sse.onerror = (err: unknown) => {
                         if (isClosed) return;
 
                         console.warn(`SSE stream error for run ${runId}:`, err);
@@ -388,7 +390,7 @@ export class WorkflowsApi extends ApiTopic {
         runId: string,
         onMessage?: (message: CompactMessage) => void,
         since?: number
-    ): Promise<{ cleanup: () => void; sendSignal: (signalName: string, data: any) => void }> {
+    ): Promise<{ cleanup: () => void; sendSignal: (signalName: string, data: unknown) => void }> {
         return new Promise((resolve, reject) => {
             let reconnectAttempts = 0;
             const maxReconnectAttempts = 10;
@@ -450,7 +452,7 @@ export class WorkflowsApi extends ApiTopic {
                                         ws = null;
                                     }
                                 },
-                                sendSignal: (signalName: string, data: any) => {
+                                sendSignal: (signalName: string, data: unknown) => {
                                     if (ws?.readyState === WebSocket.OPEN) {
                                         const message: WebSocketClientMessage = {
                                             type: 'signal',
@@ -726,7 +728,7 @@ export class WorkflowsRulesApi extends ApiTopic {
         return this.get(`/${id}`);
     }
 
-    update(id: string, payload: any): Promise<WorkflowRule> {
+    update(id: string, payload: UploadWorkflowRulePayload): Promise<WorkflowRule> {
         return this.put(`/${id}`, {
             payload,
         });
@@ -745,7 +747,7 @@ export class WorkflowsRulesApi extends ApiTopic {
     execute(
         id: string,
         objectIds?: string[],
-        vars?: Record<string, any>,
+        vars?: Record<string, unknown>,
     ): Promise<({ run_id: string; workflow_id: string } | undefined)[]> {
         const payload: ExecuteWorkflowPayload = {
             objectIds,
@@ -770,7 +772,7 @@ export class WorkflowsDefinitionApi extends ApiTopic {
         return this.get(`/${id}`);
     }
 
-    update(id: string, payload: any): Promise<DSLWorkflowDefinition> {
+    update(id: string, payload: DSLWorkflowSpec): Promise<DSLWorkflowDefinition> {
         return this.put(`/${id}`, {
             payload,
         });

--- a/packages/client/tsconfig.test.json
+++ b/packages/client/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": true,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "lib"
+  ]
+}

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "lint": "biome lint src",
     "test": "vitest run",
+    "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
     "build": "pnpm exec tsmod build && pnpm exec rollup -c",
     "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
   },

--- a/packages/common/rollup.config.js
+++ b/packages/common/rollup.config.js
@@ -16,6 +16,14 @@ export default {
         // Add any packages you want to keep external (e.g., use via import map)
         "json-schema", "ajv",
     ],
+    // Treat TypeScript diagnostics from @rollup/plugin-typescript as build errors
+    // instead of warnings, so type issues fail the build.
+    onwarn(warning, defaultHandler) {
+        if (warning.plugin === 'typescript') {
+            throw new Error(warning.message ?? String(warning));
+        }
+        defaultHandler(warning);
+    },
     plugins: [
         nodeResolve({
             browser: true,  // Prefer browser-compatible versions of packages

--- a/packages/common/src/apps.ts
+++ b/packages/common/src/apps.ts
@@ -360,9 +360,9 @@ export interface RemoteActivityDefinition {
     /** Description of what the activity does */
     description?: string;
     /** JSON Schema for the activity input parameters */
-    input_schema?: Record<string, any>;
+    input_schema?: Record<string, unknown>;
     /** JSON Schema for the activity output */
-    output_schema?: Record<string, any>;
+    output_schema?: Record<string, unknown>;
     /**
      * The activity execution URL. Can be absolute or relative to the tool server base URL.
      * If not provided, the collection-specific activities endpoint is used.
@@ -751,7 +751,7 @@ export interface AppInstallation {
     id: string;
     project: string; // the project where the app is installed
     manifest: string; // the app manifest
-    settings?: Record<string, any>; // settings for the app installation
+    settings?: Record<string, unknown>; // settings for the app installation
     /**
      * Admin-managed allowlist of tool names permitted for this installation.
      * When undefined, all tools from the app are permitted.
@@ -804,7 +804,7 @@ export type AppOAuthProviderParams = Record<string, OAuthClientCredentials>;
 
 export interface AppInstallationPayload {
     app_id: string;
-    settings?: Record<string, any>;
+    settings?: Record<string, unknown>;
     /**
      * OAuth credentials for each collection, keyed by collection.id.
      * Legacy callers may still use collection.name for older manifests.
@@ -874,7 +874,7 @@ export interface ProjectToolInfo {
      * The app installation settings.
      * Only included for agent tokens, not user tokens (security: may contain API keys).
      */
-    settings?: Record<string, any>;
+    settings?: Record<string, unknown>;
 }
 
 /**

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -1,5 +1,5 @@
 export interface FindPayload {
-    query: Record<string, any>;
+    query: Record<string, unknown>;
     offset?: number;
     limit?: number;
     select?: string;
@@ -11,8 +11,8 @@ export interface FindPayload {
 export interface GenericCommandResponse {
     status: string;
     message: string;
-    err?: any;
-    details?: any;
+    err?: unknown;
+    details?: unknown;
 }
 
 export interface DeleteByIdResult {
@@ -51,7 +51,7 @@ export interface BulkOperationPayload {
     /**
      * The operation parameters.
      */
-    params: Record<string, any>;
+    params: Record<string, unknown>;
 }
 
 export interface BulkOperationResult<TOperation extends string = "generic"> {

--- a/packages/common/src/environment.ts
+++ b/packages/common/src/environment.ts
@@ -98,7 +98,7 @@ export interface ExecutionEnvironment {
      * Stored alongside the encrypted key so the UI can display which key is configured.
      */
     apikey_hint?: string;
-    config?: any;
+    config?: unknown;
     /**
      * Additional provider-specific settings passed through to the driver.
      * For example, custom headers for Apigee-proxied endpoints.

--- a/packages/common/src/group.ts
+++ b/packages/common/src/group.ts
@@ -12,7 +12,7 @@ export interface UserGroup {
     created_by?: string;
     updated_by?: string;
     /** Custom properties for dynamic permission matching */
-    properties?: Record<string, any>;
+    properties?: Record<string, unknown>;
     /** BLP clearance level — merged with user clearance using max() */
     clearance?: number;
     /** Compartments — merged with user compartments using array union */
@@ -33,7 +33,7 @@ export interface UpdateUserGroupPayload {
     name: string;
     description?: string;
     tags?: string[];
-    properties?: Record<string, any>;
+    properties?: Record<string, unknown>;
     clearance?: number;
     compartments?: string[];
 }
@@ -42,7 +42,7 @@ export interface UserGroupRef {
     id: string;
     name: string;
     tags?: string[];
-    properties?: Record<string, any>;
+    properties?: Record<string, unknown>;
     clearance?: number;
     compartments?: string[];
 }

--- a/packages/common/src/interaction.ts
+++ b/packages/common/src/interaction.ts
@@ -585,7 +585,7 @@ export interface NamedInteractionExecutionPayload extends InteractionExecutionPa
 // ================= async execution payloads ====================
 export type ToolRef = string | { name: string; description: string };
 
-interface AsyncExecutionPayloadBase extends Omit<NamedInteractionExecutionPayload, "toolDefinitions" | "stream"> {
+interface AsyncExecutionPayloadBase extends Omit<NamedInteractionExecutionPayload, "toolDefinitions" | "stream">, Record<string, unknown> {
     type: "conversation" | "interaction";
 
     /**

--- a/packages/common/src/interaction.ts
+++ b/packages/common/src/interaction.ts
@@ -33,7 +33,7 @@ import { PrincipalType } from "./apikey.js";
 export interface InteractionExecutionError {
     code: string;
     message: string;
-    data?: any;
+    data?: unknown;
     retryable?: boolean;
 }
 
@@ -514,7 +514,7 @@ export interface InteractionUpdatePayload
             "result_schema" | "id" | "created_at" | "updated_at" | "created_by" | "updated_by" | "project"
         >
     > {
-    result_schema?: JSONSchema | null;
+    result_schema?: JSONSchema | SchemaRef | null;
 }
 
 export interface InteractionPublishPayload {
@@ -533,10 +533,10 @@ export interface InteractionExecutionPayload {
      * If a `@memory` property exists on the input data then the value will be used as the value of a memory pack location.
      * and the other properties of the data will contain the memory pack mapping.
      */
-    data?: Record<string, any> | `memory:${string}`;
+    data?: Record<string, unknown> | `memory:${string}`;
     config?: InteractionExecutionConfiguration;
     //Use null to explicitly state no schema, will not fallback to interaction schema
-    result_schema?: JSONSchema | null;
+    result_schema?: JSONSchema | SchemaRef | null;
     stream?: boolean;
     do_validate?: boolean;
     tags?: string | string[]; // tags to be added to the execution run
@@ -778,7 +778,7 @@ export interface AsyncConversationExecutionPayload extends AsyncExecutionPayload
      * When a workstream is spawned, the parent's `data` is preserved here so that
      * child tools can access it via metadata.parent_metadata.
      */
-    parent_metadata?: Record<string, any>;
+    parent_metadata?: Record<string, unknown>;
 
     /**
      * When true, subagent/workstream tool calls use fire-and-forget `startChild()`
@@ -949,7 +949,7 @@ export interface ToolResultContent {
     /**
      * Can contain metadata returned by the tool executor.
      */
-    meta?: Record<string, any>;
+    meta?: Record<string, unknown>;
 }
 
 export interface ToolResult extends ToolResultContent {
@@ -994,7 +994,7 @@ export interface RunSource {
     client_ip: string;
 }
 
-export interface BaseExecutionRun<P = any> {
+export interface BaseExecutionRun<P = unknown> {
     readonly id: string;
     /**
      * Only used by runs that were created by a virtual run to point toward the virtual run parent
@@ -1026,7 +1026,7 @@ export interface BaseExecutionRun<P = any> {
     ttl: number;
     status: ExecutionRunStatus;
     finish_reason?: string;
-    prompt?: any;
+    prompt?: unknown;
     token_use?: ExecutionTokenUsage;
     chunks?: number;
     execution_time?: number; // ms
@@ -1055,11 +1055,11 @@ export interface BaseExecutionRun<P = any> {
     workflow?: ExecutionRunWorkflow;
 }
 
-export interface ExecutionRun<P = any> extends BaseExecutionRun<P> {
+export interface ExecutionRun<P = unknown> extends BaseExecutionRun<P> {
     interaction?: Interaction;
 }
 
-export interface PopulatedExecutionRun<P = any> extends BaseExecutionRun<P> {
+export interface PopulatedExecutionRun<P = unknown> extends BaseExecutionRun<P> {
     interaction?: Interaction;
 }
 
@@ -1102,7 +1102,7 @@ export interface PromptModalities {
     hasImage: boolean;
 }
 
-export interface InteractionExecutionResult<P = any> extends Omit<ExecutionRun<P>, "account" | "project" | "interaction"> {
+export interface InteractionExecutionResult<P = unknown> extends Omit<ExecutionRun<P>, "account" | "project" | "interaction"> {
     account: string;
     project: string;
     interaction?: string;
@@ -1111,7 +1111,7 @@ export interface InteractionExecutionResult<P = any> extends Omit<ExecutionRun<P
     options?: StatelessExecutionOptions;
 }
 
-export interface LegacyInteractionExecutionResult<P = any>
+export interface LegacyInteractionExecutionResult<P = unknown>
     extends Omit<InteractionExecutionResult<P>, 'result' | 'account' | 'project'> {
     account: string | AccountRef;
     project: string | ProjectRef;

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -373,7 +373,7 @@ export interface Project {
     description?: string;
     account: string;
     configuration: ProjectConfiguration;
-    integrations?: Map<string, any>;
+    integrations?: Map<string, unknown>;
     plugins: string[];
     created_by: string,
     updated_by: string,

--- a/packages/common/src/prompt.ts
+++ b/packages/common/src/prompt.ts
@@ -25,7 +25,7 @@ export interface PromptSegmentDef<
     id?: string;
     type: PromptSegmentDefType;
     template?: T; // the template id in case of a prompt template
-    configuration?: any; // the configuration if any in case of builtin prompts
+    configuration?: unknown; // the configuration if any in case of builtin prompts
 }
 
 export interface PromptSegmentRef<

--- a/packages/common/src/query.ts
+++ b/packages/common/src/query.ts
@@ -139,9 +139,9 @@ export interface ComplexSearchQuery extends ObjectSearchQuery {
      */
     score_aggregation?: scoreAggregationTypes;
 
-    match?: Record<string, any>;
+    match?: Record<string, unknown>;
 }
 
 export interface ComplexCollectionSearchQuery extends CollectionSearchPayload {
-    match?: Record<string, any>;
+    match?: Record<string, unknown>;
 }

--- a/packages/common/src/store/agent-run.ts
+++ b/packages/common/src/store/agent-run.ts
@@ -451,6 +451,7 @@ export interface StreamAgentRunQuery extends AgentRunUpdatesQuery {
 
 export interface AgentRunDetailsQuery {
     include_history?: boolean;
+    hydrate_payloads?: boolean;
 }
 
 export type AgentArtifactVisibility = 'user' | 'internal' | 'all';

--- a/packages/common/src/store/agent-run.ts
+++ b/packages/common/src/store/agent-run.ts
@@ -132,7 +132,7 @@ export interface RunBase {
  * @typeParam TData - The interaction's expected input data type.
  * @typeParam TProperties - The content type's property schema.
  */
-export interface AgentRunBase<TData = Record<string, any>, TProperties = Record<string, any>> {
+export interface AgentRunBase<TData = Record<string, unknown>, TProperties = Record<string, unknown>> {
     /** Interaction ID or code (e.g. "sys:generic_question"). */
     interaction: string;
 
@@ -190,7 +190,7 @@ export interface AgentRunBase<TData = Record<string, any>, TProperties = Record<
  * @typeParam TData - The interaction's expected input data type.
  * @typeParam TProperties - The content type's property schema.
  */
-export interface AgentRun<TData = Record<string, any>, TProperties = Record<string, any>> extends RunBase, AgentRunBase<TData, TProperties> {
+export interface AgentRun<TData = Record<string, unknown>, TProperties = Record<string, unknown>> extends RunBase, AgentRunBase<TData, TProperties> {
     run_kind: 'agent';
     run_type: 'autonomous';
 
@@ -287,13 +287,13 @@ export interface ProcessRun extends RunBase {
 }
 
 export type AnyAgentRun = AgentRun | ProcessRun;
-export type AutonomousRunResponse<TData = Record<string, any>, TProperties = Record<string, any>> = AgentRun<TData, TProperties>;
+export type AutonomousRunResponse<TData = Record<string, unknown>, TProperties = Record<string, unknown>> = AgentRun<TData, TProperties>;
 export type SupervisedRunResponse = ProcessRun & { run_type: 'supervised' };
 export type ProgrammaticRunResponse = ProcessRun & { run_type: 'programmatic' };
 /**
  * @discriminator run_type
  */
-export type AgentRunResponse<TData = Record<string, any>, TProperties = Record<string, any>> =
+export type AgentRunResponse<TData = Record<string, unknown>, TProperties = Record<string, unknown>> =
     | AutonomousRunResponse<TData, TProperties>
     | SupervisedRunResponse
     | ProgrammaticRunResponse;
@@ -304,7 +304,7 @@ export type AgentRunResponse<TData = Record<string, any>, TProperties = Record<s
  * @typeParam TData - The interaction's expected input data type.
  * @typeParam TProperties - The content type's property schema.
  */
-export interface CreateAgentRunPayload<TData = Record<string, any>, TProperties = Record<string, any>>
+export interface CreateAgentRunPayload<TData = Record<string, unknown>, TProperties = Record<string, unknown>>
     extends AgentRunBase<TData, TProperties> {
     /** Search scope for RAG queries */
     search_scope?: AgentSearchScope;
@@ -328,7 +328,7 @@ export interface CreateAgentRunPayload<TData = Record<string, any>, TProperties 
     started_by?: string;
 }
 
-export interface ProcessRunInputPayload<TData = Record<string, any>, TSource = RunSource> {
+export interface ProcessRunInputPayload<TData = Record<string, unknown>, TSource = RunSource> {
     process_id?: string;
     /** Optional published process version to pin. Defaults to the latest/head revision. */
     process_version?: number;
@@ -342,7 +342,7 @@ export interface ProcessRunInputPayload<TData = Record<string, any>, TSource = R
     started_by?: string;
 }
 
-export interface CreateProcessRunPayload<TData = Record<string, any>, TSource = RunSource> extends ProcessRunInputPayload<TData, TSource> {
+export interface CreateProcessRunPayload<TData = Record<string, unknown>, TSource = RunSource> extends ProcessRunInputPayload<TData, TSource> {
     run_type: ProcessRunType;
 }
 
@@ -357,7 +357,7 @@ export interface RecordRunWorkflowPayload {
  * @internal Used by workflow activities that need to create a stable run
  * document for a workflow they already own.
  */
-export interface RecordAgentRunPayload<TData = Record<string, any>> extends RecordRunWorkflowPayload {
+export interface RecordAgentRunPayload<TData = Record<string, unknown>> extends RecordRunWorkflowPayload {
     run_kind?: 'agent';
     interaction: string;
     first_workflow_run_id: string;
@@ -371,13 +371,13 @@ export interface RecordAgentRunPayload<TData = Record<string, any>> extends Reco
  * @internal Used by process workflows to reserve a child ProcessRun before
  * starting its Temporal child workflow.
  */
-export interface RecordProcessRunPayload<TData = Record<string, any>, TSource = RunSource>
+export interface RecordProcessRunPayload<TData = Record<string, unknown>, TSource = RunSource>
     extends ProcessRunInputPayload<TData, TSource>, RecordRunWorkflowPayload {
     run_kind: 'process';
     run_type?: ProcessRunType;
 }
 
-export type RecordRunPayload<TData = Record<string, any>, TSource = RunSource> =
+export type RecordRunPayload<TData = Record<string, unknown>, TSource = RunSource> =
     | RecordAgentRunPayload<TData>
     | RecordProcessRunPayload<TData, TSource>;
 

--- a/packages/common/src/store/collections.ts
+++ b/packages/common/src/store/collections.ts
@@ -12,9 +12,9 @@ export interface CreateCollectionPayload {
     description?: string;
     skip_head_sync?: boolean;
     tags?: string[];
-    type?: string;
-    query?: Record<string, any>;
-    properties?: Record<string, any>;
+    type?: string | null;
+    query?: Record<string, unknown>;
+    properties?: Record<string, unknown>;
     parent?: string | null;
     table_layout?: ColumnLayout[] | null;
     allowed_types?: string[];
@@ -59,8 +59,8 @@ export interface CollectionItem extends BaseObject {
 }
 
 export interface Collection extends CollectionItem {
-    properties?: Record<string, any>;
-    query?: Record<string, any>;
+    properties?: Record<string, unknown>;
+    query?: Record<string, unknown>;
     security?: Record<string, string[]>; // ACL for collection access
     /** BLP sensitivity level — propagated to member documents (max across collections) */
     sensitivity?: number;

--- a/packages/common/src/store/doc-analyzer.ts
+++ b/packages/common/src/store/doc-analyzer.ts
@@ -4,7 +4,7 @@ import { WorkflowExecutionPayload, WorkflowRunStatus } from "./workflow.js";
 export interface PdfToRichtextOptions {
     features?: string[];
     debug?: boolean;
-    [key: string]: any;
+    [key: string]: unknown;
 }
 
 export interface PdfToRichTextWorkflowPayload extends Omit<WorkflowExecutionPayload, "vars"> {
@@ -172,7 +172,7 @@ export interface GetAdaptedTablesRequestQuery {
  */
 export interface AdaptedTable {
     comment?: string;
-    data: Record<string, any>[];
+    data: Record<string, unknown>[];
 }
 
 export type AdaptedTableResponse = Record<string, AdaptedTable>;

--- a/packages/common/src/store/dsl-workflow.ts
+++ b/packages/common/src/store/dsl-workflow.ts
@@ -33,7 +33,7 @@ export type WorkflowInput =
 /**
  * The payload sent when starting a workflow from the temporal client to the workflow instance.
  */
-export interface DSLWorkflowExecutionPayload extends WorkflowExecutionPayload {
+export interface DSLWorkflowExecutionPayload extends WorkflowExecutionPayload<Record<string, unknown>> {
     /**
      * The workflow definition to be used by the DSL workflow.
      * If a dsl workflow is executed and no definition is provided the workflow will fail.

--- a/packages/common/src/store/dsl-workflow.ts
+++ b/packages/common/src/store/dsl-workflow.ts
@@ -320,6 +320,10 @@ export interface DSLWorkflowDefinition extends BaseObject, DSLWorkflowSpecBase {
     steps?: DSLWorkflowStep[];
 }
 
+export interface DSLWorkflowDefinitionResponse extends DSLWorkflowDefinition {
+    spec_format: 'steps' | 'activities';
+}
+
 export interface WorkflowDefinitionRef {
     id: string;
     name: string;

--- a/packages/common/src/store/dsl-workflow.ts
+++ b/packages/common/src/store/dsl-workflow.ts
@@ -72,7 +72,7 @@ export type WorkflowSearchAttributes = Record<string, WorkflowSearchAttributeVal
 /**
  * The payload for a DSL activity execution.
  */
-export interface DSLActivityExecutionPayload<ParamsT extends Record<string, any>> extends WorkflowExecutionPayload {
+export interface DSLActivityExecutionPayload<ParamsT extends object> extends WorkflowExecutionPayload {
     activity: DSLActivitySpec;
     params: ParamsT;
     workflow_name: string;
@@ -93,7 +93,7 @@ export interface ActivityFetchSpec {
     /**
      * The query to be executed by the data provider
      */
-    query: Record<string, any>;
+    query: Record<string, unknown>;
     /**
      * a string of space separated field names.
      * Prefix a field name with "-" to exclude it from the result.
@@ -121,7 +121,7 @@ export interface DSLWorkflowStepBase {
     type: "activity" | "workflow";
 }
 
-export interface DSLActivitySpec<PARAMS extends Record<string, any> = Record<string, any>> {
+export interface DSLActivitySpec<PARAMS extends object = Record<string, unknown>> {
     /**
      * The name of the activity function
      */
@@ -156,7 +156,7 @@ export interface DSLActivitySpec<PARAMS extends Record<string, any> = Record<str
      * {$eq: {name: value}},
      * Ex: {$eq: {wfVarName: value}}
      */
-    condition?: Record<string, any>;
+    condition?: Record<string, unknown>;
 
     /**
      * The import spec is used to import data from workflow variables.
@@ -175,7 +175,7 @@ export interface DSLActivitySpec<PARAMS extends Record<string, any> = Record<str
     /**
      * Projection to apply to the result. Not all activities support this.
      */
-    projection?: never | Record<string, any>;
+    projection?: never | Record<string, unknown>;
 
     // ---------- Optional features not implemented in a first step ------------
     /**
@@ -196,7 +196,7 @@ export interface DSLActivitySpec<PARAMS extends Record<string, any> = Record<str
     options?: DSLActivityOptions;
 }
 
-export interface DSLActivityStep<PARAMS extends Record<string, any> = Record<string, any>> extends DSLActivitySpec<PARAMS>, DSLWorkflowStepBase {
+export interface DSLActivityStep<PARAMS extends object = Record<string, unknown>> extends DSLActivitySpec<PARAMS>, DSLWorkflowStepBase {
     type: "activity";
 }
 
@@ -208,7 +208,7 @@ export interface DSLChildWorkflowStep extends DSLWorkflowStepBase {
      * The parameters to pass to the child workflow.
      * These parameters will be merged over the parent workflow vars and passed altogether to the child workflow.
      */
-    vars?: Record<string, any>;
+    vars?: Record<string, unknown>;
     // whether or not to wait for the workflow to finish.
     // default is false. (the parent workflow will await for the workflow to finish)
     async?: boolean;
@@ -224,14 +224,14 @@ export interface DSLChildWorkflowStep extends DSLWorkflowStepBase {
      * The child workflow will only execute if the condition is satisfied.
      * Example: {$eq: {wfVarName: value}}
      */
-    condition?: Record<string, any>;
+    condition?: Record<string, unknown>;
     /**
      * In case the dslWorkflow is used as a child workflow the spec is used to define the child workflow.
      * If spec is defined then the name must be "dslWorkflow"
      */
     spec?: DSLWorkflowSpec;
     options?: {
-        memo?: Record<string, any>;
+        memo?: Record<string, unknown>;
         retry?: DSLRetryPolicy;
         searchAttributes?: WorkflowSearchAttributes;
         taskQueue?: string;
@@ -266,7 +266,7 @@ export interface DSLWorkflowSpecBase {
 
     // a dictionary of vars to initialize the workflow execution vars
     // Initial vars cannot contains references to other vars
-    vars: Record<string, any>;
+    vars: Record<string, unknown>;
     // activity options that apply to all activities within the workflow
     options?: DSLActivityOptions;
     // the name of the variable that will hold the workflow result
@@ -315,7 +315,7 @@ export function withDSLWorkflowSpecDiscriminator(spec: DSLWorkflowSpecBase): DSL
 
 export interface DSLWorkflowDefinition extends BaseObject, DSLWorkflowSpecBase {
     // an optional JSON schema to describe the input vars of the workflow.
-    input_schema?: Record<string, any>;
+    input_schema?: Record<string, unknown>;
     activities?: DSLActivitySpec[];
     steps?: DSLWorkflowStep[];
 }
@@ -335,7 +335,7 @@ export const WorkflowDefinitionRefPopulate = "id name description tags created_a
  * Payload sent to a remote activity endpoint on a tool server.
  * This is POSTed by the `executeRemoteActivity` bridge activity.
  */
-export interface RemoteActivityExecutionPayload<ParamsT extends Record<string, any> = Record<string, any>> {
+export interface RemoteActivityExecutionPayload<ParamsT extends object = Record<string, unknown>> {
     /** The activity name (unprefixed, as known by the tool server) */
     activity_name: string;
     /** The resolved activity parameters */
@@ -349,7 +349,7 @@ export interface RemoteActivityExecutionPayload<ParamsT extends Record<string, a
  */
 export interface RemoteActivityExecutionResponse {
     /** The result data (stored into workflow vars via the step's `output` field) */
-    result: any;
+    result: unknown;
     /** Whether the execution failed */
     is_error?: boolean;
     /** Error message if is_error is true */

--- a/packages/common/src/store/process.ts
+++ b/packages/common/src/store/process.ts
@@ -117,8 +117,8 @@ export interface NodeDefinition {
      */
     result_schema?: JSONSchema;
     prompt?: string;
-    input?: Record<string, any>;
-    config?: Record<string, any>;
+    input?: Record<string, unknown>;
+    config?: Record<string, unknown>;
     title?: string;
     description?: string;
     /**
@@ -156,7 +156,7 @@ export interface NodeDefinition {
 
 export interface ProcessContextDefinition {
     schema: JSONSchema;
-    initial: Record<string, any>;
+    initial: Record<string, unknown>;
 }
 
 export interface ProcessDefinitionBody {
@@ -221,7 +221,7 @@ export interface NodeHistoryEntry {
     entered_at: Date | string;
     exited_at?: Date | string;
     status: 'running' | 'completed' | 'skipped' | 'failed' | 'cancelled';
-    context_diff?: Record<string, any>;
+    context_diff?: Record<string, unknown>;
     data_ref?: string;
     sequence?: number;
     child_run_id?: string;
@@ -243,7 +243,7 @@ export interface ProcessHistoryCheckpoint {
 }
 
 export interface ProcessState {
-    context: Record<string, any>;
+    context: Record<string, unknown>;
     current_node: string;
     node_history: NodeHistoryEntry[];
     node_history_ref?: ProcessHistoryRef;

--- a/packages/common/src/store/rendering.ts
+++ b/packages/common/src/store/rendering.ts
@@ -12,7 +12,7 @@ import { WorkflowExecutionStatus, WorkflowRunStatus } from "./workflow.js";
 // ============================================================================
 
 /** Base vars shared by all rendition types */
-interface BaseRenditionVars {
+interface BaseRenditionVars extends Record<string, unknown> {
     mime_type?: string;
     /** Custom upload path — overrides the default renditions/{etag}/{name} path */
     outputPath?: string;

--- a/packages/common/src/store/schedule.ts
+++ b/packages/common/src/store/schedule.ts
@@ -44,7 +44,7 @@ export interface AgentSchedule {
     timezone?: string;
 
     /** Variables to pass to the agent workflow */
-    vars?: Record<string, any>;
+    vars?: Record<string, unknown>;
 
     /** Optional task queue override for the workflow */
     task_queue?: string;
@@ -97,7 +97,7 @@ export interface CreateSchedulePayload {
     timezone?: string;
 
     /** Variables to pass to the agent workflow */
-    vars?: Record<string, any>;
+    vars?: Record<string, unknown>;
 
     /** Optional task queue override */
     task_queue?: string;
@@ -126,7 +126,7 @@ export interface UpdateSchedulePayload {
     timezone?: string;
 
     /** Updated variables */
-    vars?: Record<string, any>;
+    vars?: Record<string, unknown>;
 
     /** Updated task queue */
     task_queue?: string;

--- a/packages/common/src/store/signals.ts
+++ b/packages/common/src/store/signals.ts
@@ -1,6 +1,6 @@
 export interface UserInputSignal {
     message: string;
-    metadata?: Record<string, any>;
+    metadata?: Record<string, unknown>;
     auth_token?: string;
     /**
      * Attachments to be processed as store objects.

--- a/packages/common/src/store/store.ts
+++ b/packages/common/src/store/store.ts
@@ -2,6 +2,7 @@ import { ComputedFacetResponse } from "../facets.js";
 import { SearchPayload } from "../payload.js";
 import { SupportedEmbeddingTypes } from "../project.js";
 import { ComplexSearchQuery } from "../query.js";
+import { JSONObject } from "../json.js";
 import { BaseObject } from "./common.js";
 
 export enum ContentObjectApiHeaders {
@@ -140,7 +141,7 @@ export interface ContentObjectApiResponse extends ContentObjectItemApiResponse {
     inherited_properties?: InheritedPropertyMetadata[];
 }
 
-export interface ContentObject<T = any> extends ContentObjectItem<T> {
+export interface ContentObject<T = JSONObject> extends ContentObjectItem<T> {
     text?: string; // the text representation of the object
     text_etag?: string;
     embeddings: Partial<Record<SupportedEmbeddingTypes, Embedding>>;
@@ -325,7 +326,7 @@ export interface RevisionInfo {
 /**
  * The content object item is a simplified version of the ContentObject that is returned by the store API when listing objects.
  */
-export interface ContentObjectItem<T = Record<string, any>> extends BaseObject {
+export interface ContentObjectItem<T = JSONObject> extends BaseObject {
     parent?: string; // the id of the direct parent object. The root object doesn't have the parent field set.
 
     /** An optional path based location for the object */
@@ -405,7 +406,7 @@ export interface ContentObjectItem<T = Record<string, any>> extends BaseObject {
 /**
  * When creating from an uploaded file the content should be an URL to the uploaded file
  */
-export interface CreateContentObjectPayload<T = any>
+export interface CreateContentObjectPayload<T = JSONObject>
     extends Partial<
         Omit<
             ContentObject<T>,
@@ -481,7 +482,7 @@ export interface ColumnLayout {
     /**
      * A default value to be used if the field is not present in the object
      */
-    default?: any;
+    default?: unknown;
 }
 export interface ContentObjectType extends ContentObjectTypeItem { }
 export interface ContentObjectTypeItem extends BaseObject {
@@ -495,7 +496,7 @@ export interface ContentObjectTypeItem extends BaseObject {
      * this is only included in ContentObjectTypeItem if explicitly requested
      * It is always included in ContentObjectType
      */
-    object_schema?: Record<string, any>; // an optional JSON schema for the object properties.
+    object_schema?: Record<string, unknown>; // an optional JSON schema for the object properties.
 
     /**
      * Determines if the content will be validated against the object schema a generation time and save/update time.
@@ -543,11 +544,11 @@ export interface WorkflowRule extends WorkflowRuleItem {
     /*
      * mongo matching rules for a content event
      */
-    match?: Record<string, any>;
+    match?: Record<string, unknown>;
     /**
      * Activities configuration if any.
      */
-    config?: Record<string, any>;
+    config?: Record<string, unknown>;
 
     /**
      * Debug mode for the rule
@@ -602,7 +603,7 @@ export interface GetRenditionResponse {
 }
 
 export interface ObjectSearchResponse {
-    results: ContentObjectItem<Record<string, unknown>>[];
+    results: ContentObjectItem[];
     facets: ComputedFacetResponse;
     aggregations?: Record<string, unknown>;
 }

--- a/packages/common/src/store/task.ts
+++ b/packages/common/src/store/task.ts
@@ -12,7 +12,7 @@ export interface TaskField {
     required?: boolean;
     label?: string;
     options?: string[];
-    default?: any;
+    default?: unknown;
 }
 
 export interface TaskSource {
@@ -31,7 +31,7 @@ export interface Task {
     status: DurableTaskStatus;
     assignee?: string;
     fields: TaskField[];
-    result?: Record<string, any>;
+    result?: Record<string, unknown>;
     source: TaskSource;
     due_at?: Date;
     created_at: Date;
@@ -58,7 +58,7 @@ export interface UpdateTaskPayload {
 }
 
 export interface CompleteTaskPayload {
-    result: Record<string, any>;
+    result: Record<string, unknown>;
 }
 
 export interface ListTasksQuery {

--- a/packages/common/src/store/workflow.ts
+++ b/packages/common/src/store/workflow.ts
@@ -1,7 +1,7 @@
 import type { ModelOptions } from "@llumiverse/common";
 import { ConversationVisibility, InteractionRef, UserChannel } from "../interaction.js";
-import { JSONObject, JSONValue } from "../json.js";
 import { JSONSchema } from "../json-schema.js";
+import { JSONObject, JSONValue } from "../json.js";
 import type { WorkflowInput } from "./dsl-workflow.js";
 
 export enum ContentEventName {
@@ -163,7 +163,7 @@ export interface WorkflowExecutionPayload<T = Record<string, unknown>> extends W
     auth_token: string;
 }
 
-export function getDocumentIds(payload: WorkflowExecutionPayload): string[] {
+export function getDocumentIds(payload: WorkflowExecutionPayload<Record<string, unknown>>): string[] {
     // Check new input format first
     if (payload.input?.inputType === 'objectIds') {
         return payload.input.objectIds;

--- a/packages/common/src/store/workflow.ts
+++ b/packages/common/src/store/workflow.ts
@@ -1,6 +1,6 @@
 import type { ModelOptions } from "@llumiverse/common";
 import { ConversationVisibility, InteractionRef, UserChannel } from "../interaction.js";
-import { JSONValue } from "../json.js";
+import { JSONObject, JSONValue } from "../json.js";
 import { JSONSchema } from "../json-schema.js";
 import type { WorkflowInput } from "./dsl-workflow.js";
 
@@ -31,7 +31,7 @@ export interface WorkflowAncestor {
     run_depth: number;
 }
 
-export interface WorkflowExecutionBaseParams<T = Record<string, any>> {
+export interface WorkflowExecutionBaseParams<T = Record<string, unknown>> {
     /**
      * The ref of the user who initiated the workflow.
      */
@@ -113,7 +113,7 @@ export interface WebHookSpec {
      * When custom data is provided, the workflow result will always be nested
      * to prevent field collisions. Use result_path to control where it's nested.
      */
-    data?: Record<string, any>;
+    data?: Record<string, unknown>;
     /**
      * Path where the workflow result should be nested in the webhook body.
      * Defaults to "result" when custom data is provided.
@@ -133,7 +133,7 @@ export interface WebHookSpec {
     result_path?: string;
 }
 
-export interface WorkflowExecutionPayload<T = Record<string, any>> extends WorkflowExecutionBaseParams<T> {
+export interface WorkflowExecutionPayload<T = Record<string, unknown>> extends WorkflowExecutionBaseParams<T> {
     /**
      * The event which started the workflow who created the activity.
      */
@@ -197,7 +197,7 @@ export interface ExecuteWorkflowPayload {
     /**
      * Parameters to pass to the workflow
      */
-    vars?: Record<string, any>;
+    vars?: Record<string, unknown>;
 
     /**
      * Make the workflow ID unique by always adding a random token to the ID.
@@ -311,7 +311,7 @@ export interface ListWorkflowRunsPayload {
 export interface SignalEventProperties {
     direction: 'receiving' | 'sending';
     signalName?: string;
-    input?: any;
+    input?: unknown;
     sender?: {
         workflowId?: string;
         runId?: string;
@@ -343,7 +343,7 @@ export interface WorkflowRunEvent {
     activity?: {
         name?: string;
         id?: string;
-        input?: any;
+        input?: unknown;
         scheduledEventId?: string;
         startedEventId?: string;
     };
@@ -354,8 +354,8 @@ export interface WorkflowRunEvent {
         runId?: string,
         scheduledEventId?: string,
         startedEventId?: string,
-        input?: any,
-        result?: any,
+        input?: unknown,
+        result?: unknown,
     };
 
     signal?: SignalEventProperties;
@@ -368,7 +368,7 @@ export interface WorkflowRunEvent {
 
     error?: EventError;
 
-    result?: any;
+    result?: unknown;
 }
 
 // Task status enum for processed history
@@ -397,14 +397,14 @@ interface TaskBase {
     type: TaskType;
     activityId: string;
     activityName?: string;
-    input?: any;
+    input?: unknown;
     scheduled: string | null;
     status: TaskStatus;
     attempts: number;
     started: string | null;
     completed: string | null;
     error: string | null;
-    result: any;
+    result: unknown;
     /** Temporal run ID that produced this task (set when aggregating across continueAsNew runs). */
     runId?: string;
 }
@@ -535,11 +535,11 @@ export interface WorkflowRun {
     workflow_id?: string;
     initiated_by?: string;
     interaction_name?: string;
-    input?: any;
-    result?: any;
-    error?: any,
+    input?: unknown;
+    result?: unknown;
+    error?: unknown,
     has_reported_errors?: boolean;
-    raw?: any;
+    raw?: unknown;
     /**
      * The Vertesia Workflow Type of this Workflow Run.
      *  - For DSL workflows (`type:dslWorkflow`), the vertesia_type refers to the "Workflow Rule Name" specified in the
@@ -585,7 +585,7 @@ export interface PendingActivity {
 export interface WorkflowRunWithDetails extends WorkflowRun {
     history?: WorkflowHistory;
     memo?: {
-        [key: string]: any;
+        [key: string]: unknown;
     } | null;
     pendingActivities?: PendingActivity[];
 }
@@ -644,7 +644,7 @@ export interface WorkflowInteractionVars {
      * Multiple channels can be active simultaneously.
      */
     user_channels?: UserChannel[],
-    data?: Record<string, any>,
+    data?: JSONObject,
     tool_names: string[],
     config: {
         environment: string,
@@ -670,7 +670,7 @@ export interface MultiDocumentsInteractionParams extends Omit<WorkflowExecutionP
     config: {
         interactionName: string;
         action: DocumentActionConfig;
-        data: Record<string, any>;
+        data: Record<string, unknown>;
     };
 }
 
@@ -712,7 +712,7 @@ export interface AgentMessage {
     workflow_run_id: string;
     type: AgentMessageType;
     message: string;
-    details?: any;
+    details?: AgentMessageDetails;
     workstream_id?: string;
 }
 
@@ -732,6 +732,30 @@ export enum AgentMessageType {
     STREAMING_CHUNK = 12,
     BATCH_PROGRESS = 13,
     RESTARTING = 14,
+}
+
+export interface AgentMessageDetails extends Record<string, unknown> {
+    event_class?: string;
+    tool?: string;
+    tools?: string[];
+    streamed?: boolean;
+    display_role?: string;
+    activity_id?: string;
+    activity_group_id?: string;
+    batch_id?: string;
+    tool_run_id?: string;
+    tool_status?: ToolCallDetails["tool_status"];
+    tool_iteration?: number;
+    observation?: unknown;
+    workflow_run_id?: string;
+    outputFiles?: string[];
+    files?: ConversationFile[] | string[];
+    plan?: PlanTask[];
+    streaming_id?: string;
+    chunk_index?: number;
+    is_final?: boolean;
+    _optimistic?: boolean;
+    _messageId?: string;
 }
 
 // ============================================
@@ -788,33 +812,37 @@ export interface PlanMessageDetails {
 // Type guards — check both message type and details shape for safety
 
 export function isToolCallMessage(msg: AgentMessage): msg is AgentMessage & { details: ToolCallDetails } {
+    const details = msg.details as Record<string, unknown> | undefined;
     return msg.type === AgentMessageType.THOUGHT &&
-        !!msg.details &&
-        typeof msg.details === 'object' &&
-        typeof msg.details.tool === 'string';
+        !!details &&
+        typeof details === 'object' &&
+        typeof details.tool === 'string';
 }
 
 export function isDocumentEventMessage(msg: AgentMessage): msg is AgentMessage & { details: DocumentEventDetails } {
+    const details = msg.details as Record<string, unknown> | undefined;
     return msg.type === AgentMessageType.UPDATE &&
-        !!msg.details &&
-        typeof msg.details === 'object' &&
-        (msg.details.event_class === 'document_created' || msg.details.event_class === 'document_updated') &&
-        typeof msg.details.document_id === 'string';
+        !!details &&
+        typeof details === 'object' &&
+        (details.event_class === 'document_created' || details.event_class === 'document_updated') &&
+        typeof details.document_id === 'string';
 }
 
 export function isFileProcessingMessage(msg: AgentMessage): msg is AgentMessage & { details: FileProcessingDetails } {
+    const details = msg.details as Record<string, unknown> | undefined;
     return msg.type === AgentMessageType.SYSTEM &&
-        !!msg.details &&
-        typeof msg.details === 'object' &&
-        msg.details.system_type === 'file_processing' &&
-        Array.isArray(msg.details.files);
+        !!details &&
+        typeof details === 'object' &&
+        details.system_type === 'file_processing' &&
+        Array.isArray(details.files);
 }
 
 export function isPlanMessage(msg: AgentMessage): msg is AgentMessage & { details: PlanMessageDetails } {
+    const details = msg.details as Record<string, unknown> | undefined;
     return msg.type === AgentMessageType.PLAN &&
-        !!msg.details &&
-        typeof msg.details === 'object' &&
-        Array.isArray(msg.details.plan);
+        !!details &&
+        typeof details === 'object' &&
+        Array.isArray(details.plan);
 }
 
 export function isRequestInputMessage(msg: AgentMessage): msg is AgentMessage & { details: RequestInputDetails } {
@@ -855,7 +883,7 @@ export interface CompactMessage {
     /** Workstream ID (only when not "main") */
     w?: string;
     /** Type-specific details */
-    d?: unknown;
+    d?: AgentMessageDetails | null;
     /** Is final chunk (only for STREAMING_CHUNK, 0 or 1) */
     f?: 0 | 1;
     /** Timestamp (only for stored/persisted messages) */
@@ -990,7 +1018,7 @@ export function createCompactMessage(
     options: {
         message?: string;
         workstreamId?: string;
-        details?: unknown;
+        details?: AgentMessageDetails;
         isFinal?: boolean;
         timestamp?: number;
     } = {}
@@ -1021,7 +1049,7 @@ export function toAgentMessage(compact: CompactMessage, workflowRunId: string = 
         workstream_id: compact.w || 'main',
     };
 
-    if (compact.d !== undefined) message.details = compact.d;
+    if (compact.d !== undefined && compact.d !== null) message.details = compact.d;
 
     // For streaming chunks, restore is_final and streaming_id in details
     // (streaming_id removed from wire format, use workstream_id as grouping key)
@@ -1175,7 +1203,7 @@ export function getWorkflowUpdatesKey(workflowRunId: string): string {
 export interface PlanTask {
     id: number;
     goal: string;
-    instructions: string[];
+    instructions?: string[];
     comment?: string;
     status?: "pending" | "in_progress" | "completed" | "skipped";
 }
@@ -1193,7 +1221,7 @@ export const LOW_PRIORITY_TASK_QUEUE = "low_priority";
 export interface WebSocketSignalMessage {
     type: 'signal';
     signalName: string;
-    data: any;
+    data: unknown;
     requestId?: string | number;
 }
 

--- a/packages/common/src/store/workflow.ts
+++ b/packages/common/src/store/workflow.ts
@@ -613,6 +613,7 @@ export interface WorkflowRunUpdatesResponse {
 export interface WorkflowRunDetailsQuery {
     include_history?: boolean;
     history_format?: 'events' | 'tasks' | 'agent';
+    hydrate_payloads?: boolean;
 }
 
 export interface WorkflowRunUpdatesQuery {

--- a/packages/common/src/sts-token-types.ts
+++ b/packages/common/src/sts-token-types.ts
@@ -143,6 +143,6 @@ export interface IssueTokenResponse {
 
 export interface ValidateTokenResponse {
     valid: boolean;
-    payload?: any;
+    payload?: unknown;
     error?: string;
 }

--- a/packages/common/src/tool-execution.ts
+++ b/packages/common/src/tool-execution.ts
@@ -39,7 +39,7 @@ export interface ToolExecutionMetadata {
     /**
      * App-specific settings
      */
-    app_settings?: Record<string, any>;
+    app_settings?: Record<string, unknown>;
     /**
      * Endpoint overrides from workflow config (takes precedence over JWT endpoints)
      */
@@ -47,5 +47,5 @@ export interface ToolExecutionMetadata {
     /**
      * Additional metadata fields
      */
-    [key: string]: any;
+    [key: string]: unknown;
 }

--- a/packages/common/src/user.ts
+++ b/packages/common/src/user.ts
@@ -20,7 +20,7 @@ export interface User {
     source?: 'firebase' | 'scim';
     updated_by?: string;
     /** Custom properties for dynamic permission matching */
-    properties?: Record<string, any>;
+    properties?: Record<string, unknown>;
     /** BLP clearance level — determines max document sensitivity the user can access */
     clearance?: number;
     /** Compartments the user belongs to — restricts access to documents in matching compartments */
@@ -35,7 +35,7 @@ export interface UpdateUserPayload {
     language?: string;
     phone?: string;
     last_selected_account?: string;
-    properties?: Record<string, any>;
+    properties?: Record<string, unknown>;
     clearance?: number;
     compartments?: string[];
 }

--- a/packages/common/src/utils/schemas.ts
+++ b/packages/common/src/utils/schemas.ts
@@ -34,7 +34,7 @@ export function removeExtraProperties<T>(schema: T): T {
             removeExtraProperties(item);
         }
     } else if (typeof schema === 'object') {
-        const obj = schema as Record<string, any>;
+        const obj = schema as Record<string, unknown>;
 
         // If this looks like a property definition (has editor/format for document/media),
         // enrich it with type and description hints before stripping.
@@ -59,7 +59,7 @@ export function removeExtraProperties<T>(schema: T): T {
  * Returns true if the schema property represents a document reference
  * (identified by editor: "document" or format: "document" / "media").
  */
-function isDocumentProperty(obj: Record<string, any>): boolean {
+function isDocumentProperty(obj: Record<string, unknown>): boolean {
     return obj.editor === 'document' ||
         obj.format === 'document' ||
         obj.format === 'media';
@@ -78,7 +78,7 @@ export const DOCUMENT_STORE_HINT = "Use 'store:<document_id>' format to referenc
  * - Sets type to "string" if not already set
  * - Appends a store: prefix hint to the description
  */
-function enrichDocumentProperty(obj: Record<string, any>): void {
+function enrichDocumentProperty(obj: Record<string, unknown>): void {
     // Set type to string if missing (document references are string IDs)
     if (!obj.type) {
         obj.type = 'string';
@@ -89,7 +89,7 @@ function enrichDocumentProperty(obj: Record<string, any>): void {
     // after serialization when only the description survives.
     if (!obj.description) {
         obj.description = DOCUMENT_STORE_HINT;
-    } else if (!obj.description.includes(DOCUMENT_STORE_HINT)) {
+    } else if (typeof obj.description === 'string' && !obj.description.includes(DOCUMENT_STORE_HINT)) {
         obj.description = `${obj.description} ${DOCUMENT_STORE_HINT}`;
     }
 }

--- a/packages/common/tsconfig.test.json
+++ b/packages/common/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": true,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "lib"
+  ]
+}

--- a/packages/converters/package.json
+++ b/packages/converters/package.json
@@ -12,6 +12,7 @@
     "scripts": {
         "lint": "biome lint src",
         "test": "vitest run",
+        "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
         "build": "pnpm exec tsmod build --esm",
         "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
     },

--- a/packages/converters/src/image.ts
+++ b/packages/converters/src/image.ts
@@ -18,9 +18,21 @@ type SharpInputType = Buffer
     | Float64Array
     | string
     | NodeJS.ReadableStream
+
+type DestroyableReadableStream = NodeJS.ReadableStream & { destroy?: () => void };
+type DestroyableWritableStream = NodeJS.WritableStream & { destroy?: () => void };
+
+function isReadableStream(input: SharpInputType): input is DestroyableReadableStream {
+    return typeof (input as { pipe?: unknown }).pipe === 'function';
+}
+
 export function createImageTransformer(input: SharpInputType, opts: TransformOptions) {
-    const isInputStream = !!(input as NodeJS.ReadableStream).pipe;
-    let sh = isInputStream ? (input as NodeJS.ReadableStream).pipe(sharp()) : sharp(input as any);
+    let sh: sharp.Sharp;
+    if (isReadableStream(input)) {
+        sh = input.pipe(sharp());
+    } else {
+        sh = sharp(input as Exclude<SharpInputType, NodeJS.ReadableStream>);
+    }
     if (opts.max_hw) {
         sh = sh.resize({
             width: opts.max_hw,
@@ -45,14 +57,15 @@ export async function transformImage(input: SharpInputType, output: NodeJS.Writa
     sh.pipe(output);
 
     return new Promise((resolve, reject) => {
-        const handleError = (err: any) => {
+        const handleError = (err: unknown) => {
             console.error('Failed to transform', err);
             try {
-                if ((input as any).pipe && (input as any).destroy) {
-                    (input as any).destroy();
+                const outputStream = output as DestroyableWritableStream;
+                if (isReadableStream(input)) {
+                    input.destroy?.();
                 }
-                if ((output as any).destroy) {
-                    (output as any).destroy();
+                if (outputStream.destroy) {
+                    outputStream.destroy();
                 }
                 sh.destroy();
             } finally {
@@ -60,7 +73,9 @@ export async function transformImage(input: SharpInputType, output: NodeJS.Writa
             }
         }
         output.on('error', handleError);
-        (input as any).pipe && (input as any).on && (input as any).on('error', handleError);
+        if (isReadableStream(input)) {
+            input.on('error', handleError);
+        }
         output.on("finish", () => {
             resolve(sh);
         });

--- a/packages/converters/tsconfig.test.json
+++ b/packages/converters/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": true,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "lib"
+  ]
+}

--- a/packages/create-plugin/src/process-template.ts
+++ b/packages/create-plugin/src/process-template.ts
@@ -66,7 +66,7 @@ function isCodeFile(filePath: string): boolean {
  * Replace variables in text files (HTML, JSON, Markdown, etc.)
  * Uses {{VARIABLE}} placeholder pattern
  */
-function replaceInTextFile(content: string, answers: Record<string, any>): { content: string; modified: boolean } {
+function replaceInTextFile(content: string, answers: Record<string, unknown>): { content: string; modified: boolean } {
   let modified = false;
 
   for (const [key, value] of Object.entries(answers)) {
@@ -86,7 +86,7 @@ function replaceInTextFile(content: string, answers: Record<string, any>): { con
  * 1. const CONFIG__variableName = value; - Constant value replacement
  * 2. TEMPLATE__IdentifierName - Identifier name replacement (functions, classes, variables)
  */
-function replaceInCodeFile(content: string, answers: Record<string, any>): { content: string; modified: boolean } {
+function replaceInCodeFile(content: string, answers: Record<string, unknown>): { content: string; modified: boolean } {
   let modified = false;
 
   for (const [key, value] of Object.entries(answers)) {
@@ -98,7 +98,7 @@ function replaceInCodeFile(content: string, answers: Record<string, any>): { con
       'gm'
     );
     if (content.match(configPattern)) {
-      content = content.replace(configPattern, (match, prefix, oldValue, suffix) => {
+      content = content.replace(configPattern, (_match, prefix, _oldValue, suffix) => {
         return `${prefix}${JSON.stringify(value)}${suffix}`;
       });
       modified = true;
@@ -128,7 +128,7 @@ function replaceInCodeFile(content: string, answers: Record<string, any>): { con
 export function replaceVariables(
   projectName: string,
   templateConfig: TemplateConfig,
-  answers: Record<string, any>
+  answers: Record<string, unknown>
 ): void {
   if (!templateConfig.files) {
     return;
@@ -174,7 +174,7 @@ export function replaceVariables(
  */
 export function adjustPackageJson(
   projectName: string,
-  answers: Record<string, any>,
+  answers: Record<string, unknown>,
   isDev: boolean,
   packageManager: string
 ): void {
@@ -259,7 +259,7 @@ export function adjustPackageJson(
 export function handleConditionalRemoves(
   projectName: string,
   templateConfig: TemplateConfig,
-  answers: Record<string, any>
+  answers: Record<string, unknown>
 ): void {
   if (!templateConfig.conditionalRemove) return;
 

--- a/packages/create-plugin/src/prompts.ts
+++ b/packages/create-plugin/src/prompts.ts
@@ -3,14 +3,19 @@
  */
 import prompts from 'prompts';
 import chalk from 'chalk';
-import { TemplateConfig } from './template-config.js';
+import { PromptConfig, TemplateConfig } from './template-config.js';
 import { applyMapTransform, applyTransform, concatValues } from './transforms.js';
+
+type ProcessedPromptConfig = Omit<PromptConfig, 'validate'> & {
+  choices?: Array<{ value: unknown }>;
+  validate?: string | ((value: string) => boolean | string);
+};
 
 /**
  * Prompt user for configuration values
  * @param nonInteractive - If true, skip prompts and use default/initial values
  */
-export async function promptUser(projectName: string, templateConfig: TemplateConfig, nonInteractive = false): Promise<Record<string, any>> {
+export async function promptUser(projectName: string, templateConfig: TemplateConfig, nonInteractive = false): Promise<Record<string, unknown>> {
   if (!templateConfig.prompts) {
     return {};
   }
@@ -19,8 +24,8 @@ export async function promptUser(projectName: string, templateConfig: TemplateCo
   const filteredPrompts = templateConfig.prompts.filter(p => p.name !== 'PROJECT_NAME');
 
   // Process prompts - replace ${PROJECT_NAME} and other variables in initial values
-  const processedPrompts = filteredPrompts.map(p => {
-    const prompt: any = { ...p };
+  const processedPrompts: ProcessedPromptConfig[] = filteredPrompts.map(p => {
+    const prompt: ProcessedPromptConfig = { ...p };
 
     // Replace ${PROJECT_NAME} in initial values
     if (typeof prompt.initial === 'string') {
@@ -54,7 +59,7 @@ export async function promptUser(projectName: string, templateConfig: TemplateCo
     return prompt;
   });
 
-  let answers: Record<string, any> = { PROJECT_NAME: projectName };
+  let answers: Record<string, unknown> = { PROJECT_NAME: projectName };
 
   if (nonInteractive) {
     // Use default/initial values for all prompts
@@ -72,7 +77,7 @@ export async function promptUser(projectName: string, templateConfig: TemplateCo
   } else {
     console.log(chalk.blue('⚙️  Configure your project:\n'));
 
-    const userAnswers = await prompts(processedPrompts, {
+    const userAnswers = await prompts(processedPrompts as Parameters<typeof prompts>[0], {
       onCancel: () => {
         throw new Error('Installation cancelled by user');
       }

--- a/packages/fusion-ux/package.json
+++ b/packages/fusion-ux/package.json
@@ -23,7 +23,8 @@
     "build": "pnpm exec rimraf ./lib && tsc -b && pnpm exec rollup -c",
     "lint": "biome lint src",
     "lint:fix": "biome lint --write src",
-    "test": "vitest run"
+    "test": "vitest run",
+    "typecheck:test": "tsc -p tsconfig.test.json --noEmit"
   },
   "dependencies": {
     "@vertesia/common": "workspace:*",

--- a/packages/fusion-ux/src/fusion-fragment/FieldRenderer.tsx
+++ b/packages/fusion-ux/src/fusion-fragment/FieldRenderer.tsx
@@ -178,12 +178,19 @@ export function FieldRenderer({
   }, [isNull, field.highlight, isEditable, isHovered]);
 
   return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: hover handlers used for visual feedback only; interactive click+keyboard only added when isEditable is true.
     <div
       style={styles.container}
       title={field.tooltip}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       onClick={handleClick}
+      onKeyDown={isEditable ? (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          handleClick();
+        }
+      } : undefined}
       role={isEditable ? 'button' : undefined}
       tabIndex={isEditable ? 0 : undefined}
     >

--- a/packages/fusion-ux/src/fusion-fragment/SectionRenderer.tsx
+++ b/packages/fusion-ux/src/fusion-fragment/SectionRenderer.tsx
@@ -177,10 +177,18 @@ export function SectionRenderer({
 
   return (
     <div style={styles.section}>
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: onClick is no-op when not collapsible; interactive role/keyboard only added when isCollapsible is true. */}
       <div
         style={headerStyle}
         onClick={handleHeaderClick}
+        onKeyDown={isCollapsible ? (e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleHeaderClick();
+          }
+        } : undefined}
         role={isCollapsible ? 'button' : undefined}
+        tabIndex={isCollapsible ? 0 : undefined}
         aria-expanded={isCollapsible ? !isCollapsed : undefined}
       >
         {isCollapsible && <ChevronIcon collapsed={isCollapsed} />}

--- a/packages/fusion-ux/tsconfig.test.json
+++ b/packages/fusion-ux/tsconfig.test.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": true,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "src",
+    "test"
+  ],
+  "exclude": [
+    "node_modules",
+    "lib"
+  ]
+}

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "lint": "biome lint src",
     "test": "vitest run",
+    "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
     "build": "pnpm exec tsmod build && pnpm exec rollup -c",
     "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
   },

--- a/packages/json/rollup.config.js
+++ b/packages/json/rollup.config.js
@@ -15,6 +15,14 @@ export default {
     external: [
         // Add any packages you want to keep external (e.g., use via import map)
     ],
+    // Treat TypeScript diagnostics from @rollup/plugin-typescript as build errors
+    // instead of warnings, so type issues fail the build.
+    onwarn(warning, defaultHandler) {
+        if (warning.plugin === 'typescript') {
+            throw new Error(warning.message ?? String(warning));
+        }
+        defaultHandler(warning);
+    },
     plugins: [
         nodeResolve({
             browser: true,  // Prefer browser-compatible versions of packages

--- a/packages/json/src/walk.test.ts
+++ b/packages/json/src/walk.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "vitest";
 import { ObjectWalker, AsyncObjectWalker } from "./walk.js";
 
+/** Permissive recursive type for navigating untyped walker results in test assertions. */
+type Tree = { readonly [key: string]: Tree };
+
 describe('walk object', () => {
 
     test('find string values', () => {
@@ -24,7 +27,7 @@ describe('walk object', () => {
         const values = ["foo", "bar", "baz", "file"].sort().join(',');
         const found: string[] = [];
         new ObjectWalker().walk(obj, {
-            onValue(key, value) {
+            onValue(_key, value) {
                 if (typeof value === "string") {
                     found.push(value);
                 }
@@ -56,7 +59,7 @@ describe('walk object', () => {
                 return String(value)
             }
             return value;
-        });
+        }) as Tree;
         expect(r.age).toBe("42");
         expect(r.children[0].age).toBe("12");
         expect(r.children[1].age).toBe("15");
@@ -70,7 +73,7 @@ describe('walk object', () => {
                 return String(value)
             }
             return value;
-        });
+        }) as unknown as Tree;
         expect(r.length).toBe(4);
         expect(r[0]).toBe("123");
         expect(r[1].x).toBe("1");
@@ -80,7 +83,7 @@ describe('walk object', () => {
 
     test('async map', async () => {
         const obj = { ar: [123, { x: 1 }, { y: { a: 1, b: [2] } }] };
-        const r: any = await new AsyncObjectWalker().map(obj, async (_key, value) => {
+        const r = await new AsyncObjectWalker().map(obj, async (_key, value) => {
             if (typeof value === "number") {
                 return new Promise((resolve) => {
                     return setTimeout(() => {
@@ -89,12 +92,12 @@ describe('walk object', () => {
                 });
             }
             return value;
-        });
+        }) as Tree;
         expect(Array.isArray(r.ar)).toBe(true);
         expect(r.ar.length).toBe(obj.ar.length);
         expect(r.ar[0]).toBe("123");
         expect(r.ar[1].x).toBe("1");
-        const y: any = r.ar[2].y;
+        const y = r.ar[2].y;
         expect(y.a).toBe("1");
         console.log(y.b);
         expect(Array.isArray(y.b)).toBe(true);

--- a/packages/json/src/walk.ts
+++ b/packages/json/src/walk.ts
@@ -1,19 +1,29 @@
 
 export type ObjectKey = string | number | undefined;
 export interface ObjectVisitor {
-    onStartObject?: (key: ObjectKey, value: any) => void;
-    onEndObject?: (key: ObjectKey, value: any) => void;
-    onStartIteration?: (key: ObjectKey, value: Iterable<any>) => void;
-    onEndIteration?: (key: ObjectKey, value: Iterable<any>) => void;
-    onValue?: (key: ObjectKey, value: any) => void;
+    onStartObject?: (key: ObjectKey, value: Record<string, unknown>) => void;
+    onEndObject?: (key: ObjectKey, value: Record<string, unknown>) => void;
+    onStartIteration?: (key: ObjectKey, value: Iterable<unknown>) => void;
+    onEndIteration?: (key: ObjectKey, value: Iterable<unknown>) => void;
+    onValue?: (key: ObjectKey, value: unknown) => void;
 }
 
 export interface AsyncObjectVisitor {
-    onStartObject?: (key: ObjectKey, value: any) => Promise<void>;
-    onEndObject?: (key: ObjectKey, value: any) => Promise<void>;
-    onStartIteration?: (key: ObjectKey, value: Iterable<any>) => Promise<void>;
-    onEndIteration?: (key: ObjectKey, value: Iterable<any>) => Promise<void>;
-    onValue?: (key: ObjectKey, value: any) => Promise<void>;
+    onStartObject?: (key: ObjectKey, value: Record<string, unknown>) => Promise<void>;
+    onEndObject?: (key: ObjectKey, value: Record<string, unknown>) => Promise<void>;
+    onStartIteration?: (key: ObjectKey, value: Iterable<unknown>) => Promise<void>;
+    onEndIteration?: (key: ObjectKey, value: Iterable<unknown>) => Promise<void>;
+    onValue?: (key: ObjectKey, value: unknown) => Promise<void>;
+}
+
+type MutableContainer = Record<string | number, unknown> | unknown[];
+
+function isIterable(value: unknown): value is Iterable<unknown> {
+    return value !== null && typeof value === 'object' && Symbol.iterator in value;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype;
 }
 
 export class ObjectWalker {
@@ -21,25 +31,25 @@ export class ObjectWalker {
     constructor(supportIterators = false) {
         this.supportIterators = supportIterators;
     }
-    walk(obj: any, visitor: ObjectVisitor) {
+    walk(obj: unknown, visitor: ObjectVisitor) {
         this._walk(undefined, obj, visitor);
     }
-    _walk(key: ObjectKey, obj: any, visitor: ObjectVisitor) {
+    _walk(key: ObjectKey, obj: unknown, visitor: ObjectVisitor) {
         const type = typeof obj;
         if (!obj || type !== 'object' || obj instanceof Date) {
             visitor.onValue && visitor.onValue(key, obj);
         } else if (Array.isArray(obj)) {
             this._walkIterable(key, obj, visitor);
-        } else if (this.supportIterators && obj[Symbol.iterator] === 'function') {
+        } else if (this.supportIterators && isIterable(obj)) {
             this._walkIterable(key, obj, visitor);
-        } else if (obj.constructor === Object) { // a plain object
+        } else if (isPlainRecord(obj)) { // a plain object
             this._walkObject(key, obj, visitor);
         } else { // a random object - we treat it as a value
             visitor.onValue && visitor.onValue(key, obj);
         }
     }
 
-    _walkIterable(key: ObjectKey, obj: any, visitor: ObjectVisitor) {
+    _walkIterable(key: ObjectKey, obj: Iterable<unknown>, visitor: ObjectVisitor) {
         visitor.onStartIteration && visitor.onStartIteration(key, obj);
         let i = 0;
         for (const value of obj) {
@@ -48,7 +58,7 @@ export class ObjectWalker {
         visitor.onEndIteration && visitor.onEndIteration(key, obj);
     }
 
-    _walkObject(key: ObjectKey, obj: any, visitor: ObjectVisitor) {
+    _walkObject(key: ObjectKey, obj: Record<string, unknown>, visitor: ObjectVisitor) {
         visitor.onStartObject && visitor.onStartObject(key, obj);
         for (const k of Object.keys(obj)) {
             this._walk(k, obj[k], visitor);
@@ -56,7 +66,7 @@ export class ObjectWalker {
         visitor.onEndObject && visitor.onEndObject(key, obj);
     }
 
-    map(obj: any, mapFn: (key: ObjectKey, value: any) => any) {
+    map(obj: unknown, mapFn: (key: ObjectKey, value: unknown) => unknown): unknown {
         const visitor = new MapVisitor(mapFn);
         this.walk(obj, visitor);
         return visitor.result;
@@ -69,25 +79,25 @@ export class AsyncObjectWalker {
     constructor(supportIterators = false) {
         this.supportIterators = supportIterators;
     }
-    async walk(obj: any, visitor: AsyncObjectVisitor) {
+    async walk(obj: unknown, visitor: AsyncObjectVisitor) {
         await this._walk(undefined, obj, visitor);
     }
-    async _walk(key: ObjectKey, obj: any, visitor: AsyncObjectVisitor) {
+    async _walk(key: ObjectKey, obj: unknown, visitor: AsyncObjectVisitor) {
         const type = typeof obj;
         if (!obj || type !== 'object' || obj instanceof Date) {
             visitor.onValue && (await visitor.onValue(key, obj));
         } else if (Array.isArray(obj)) {
             await this._walkIterable(key, obj, visitor);
-        } else if (this.supportIterators && obj[Symbol.iterator] === 'function') {
+        } else if (this.supportIterators && isIterable(obj)) {
             await this._walkIterable(key, obj, visitor);
-        } else if (obj.constructor === Object) { // a plain object
+        } else if (isPlainRecord(obj)) { // a plain object
             await this._walkObject(key, obj, visitor);
         } else { // a random object - we treat it as a value
             visitor.onValue && (await visitor.onValue(key, obj));
         }
     }
 
-    async _walkIterable(key: ObjectKey, obj: any, visitor: AsyncObjectVisitor) {
+    async _walkIterable(key: ObjectKey, obj: Iterable<unknown>, visitor: AsyncObjectVisitor) {
         visitor.onStartIteration && (await visitor.onStartIteration(key, obj));
         let i = 0;
         for (const value of obj) {
@@ -96,7 +106,7 @@ export class AsyncObjectWalker {
         visitor.onEndIteration && (await visitor.onEndIteration(key, obj));
     }
 
-    async _walkObject(key: ObjectKey, obj: any, visitor: AsyncObjectVisitor) {
+    async _walkObject(key: ObjectKey, obj: Record<string, unknown>, visitor: AsyncObjectVisitor) {
         visitor.onStartObject && (await visitor.onStartObject(key, obj));
         for (const k of Object.keys(obj)) {
             await this._walk(k, obj[k], visitor);
@@ -104,7 +114,7 @@ export class AsyncObjectWalker {
         visitor.onEndObject && (await visitor.onEndObject(key, obj));
     }
 
-    async map(obj: any, mapFn: (key: ObjectKey, value: any) => Promise<any>) {
+    async map(obj: unknown, mapFn: (key: ObjectKey, value: unknown) => Promise<unknown>): Promise<unknown> {
         const visitor = new AsyncMapVisitor(mapFn);
         await this.walk(obj, visitor);
         return visitor.result;
@@ -112,19 +122,33 @@ export class AsyncObjectWalker {
 }
 
 class MapVisitor implements ObjectVisitor {
-    result: any;
-    current: any;
-    stack: any[] = [];
-    constructor(private mapFn: (key: ObjectKey, value: any) => any) { }
+    result: unknown;
+    current: MutableContainer | undefined;
+    stack: MutableContainer[] = [];
+    constructor(private mapFn: (key: ObjectKey, value: unknown) => unknown) { }
+
+    private setValue(key: ObjectKey, value: unknown) {
+        if (key === undefined) {
+            this.result = value;
+        } else if (this.current) {
+            if (Array.isArray(this.current) && typeof key === 'number') {
+                this.current[key] = value;
+            } else if (!Array.isArray(this.current)) {
+                this.current[key] = value;
+            }
+        }
+    }
 
     onStartObject(key: ObjectKey) {
+        const obj: Record<string, unknown> = {};
         if (key === undefined) {
-            this.result = {};
-            this.current = this.result;
+            this.result = obj;
+            this.current = obj;
         } else {
-            this.stack.push(this.current);
-            const obj = {};
-            this.current[key] = obj;
+            if (this.current) {
+                this.stack.push(this.current);
+            }
+            this.setValue(key, obj);
             this.current = obj;
         }
     }
@@ -133,13 +157,15 @@ class MapVisitor implements ObjectVisitor {
     }
 
     onStartIteration(key: ObjectKey) {
+        const ar: unknown[] = [];
         if (key === undefined) {
-            this.result = [];
-            this.current = this.result;
+            this.result = ar;
+            this.current = ar;
         } else {
-            this.stack.push(this.current);
-            const ar: any[] = [];
-            this.current[key] = ar;
+            if (this.current) {
+                this.stack.push(this.current);
+            }
+            this.setValue(key, ar);
             this.current = ar;
         }
     }
@@ -148,30 +174,44 @@ class MapVisitor implements ObjectVisitor {
         this.current = this.stack.pop();
     }
 
-    onValue(key: ObjectKey, value: any) {
+    onValue(key: ObjectKey, value: unknown) {
         const r = this.mapFn(key, value);
         if (key === undefined) {
             this.result = r;
         } else if (r !== undefined) {
-            this.current[key] = r;
+            this.setValue(key, r);
         }
     }
 }
 
 class AsyncMapVisitor implements AsyncObjectVisitor {
-    result: any;
-    current: any;
-    stack: any[] = [];
-    constructor(private mapFn: (key: ObjectKey, value: any) => Promise<any>) { }
+    result: unknown;
+    current: MutableContainer | undefined;
+    stack: MutableContainer[] = [];
+    constructor(private mapFn: (key: ObjectKey, value: unknown) => Promise<unknown>) { }
+
+    private setValue(key: ObjectKey, value: unknown) {
+        if (key === undefined) {
+            this.result = value;
+        } else if (this.current) {
+            if (Array.isArray(this.current) && typeof key === 'number') {
+                this.current[key] = value;
+            } else if (!Array.isArray(this.current)) {
+                this.current[key] = value;
+            }
+        }
+    }
 
     async onStartObject(key: ObjectKey) {
+        const obj: Record<string, unknown> = {};
         if (key === undefined) {
-            this.result = {};
-            this.current = this.result;
+            this.result = obj;
+            this.current = obj;
         } else {
-            this.stack.push(this.current);
-            const obj = {};
-            this.current[key] = obj;
+            if (this.current) {
+                this.stack.push(this.current);
+            }
+            this.setValue(key, obj);
             this.current = obj;
         }
     }
@@ -180,13 +220,15 @@ class AsyncMapVisitor implements AsyncObjectVisitor {
     }
 
     async onStartIteration(key: ObjectKey) {
+        const ar: unknown[] = [];
         if (key === undefined) {
-            this.result = [];
-            this.current = this.result;
+            this.result = ar;
+            this.current = ar;
         } else {
-            this.stack.push(this.current);
-            const ar: any[] = [];
-            this.current[key] = ar;
+            if (this.current) {
+                this.stack.push(this.current);
+            }
+            this.setValue(key, ar);
             this.current = ar;
         }
     }
@@ -195,12 +237,12 @@ class AsyncMapVisitor implements AsyncObjectVisitor {
         this.current = this.stack.pop();
     }
 
-    async onValue(key: ObjectKey, value: any) {
+    async onValue(key: ObjectKey, value: unknown) {
         const r = await this.mapFn(key, value);
         if (key === undefined) {
             this.result = r;
         } else if (r !== undefined) {
-            this.current[key] = r;
+            this.setValue(key, r);
         }
     }
 }

--- a/packages/json/src/walk.ts
+++ b/packages/json/src/walk.ts
@@ -37,7 +37,7 @@ export class ObjectWalker {
     _walk(key: ObjectKey, obj: unknown, visitor: ObjectVisitor) {
         const type = typeof obj;
         if (!obj || type !== 'object' || obj instanceof Date) {
-            visitor.onValue && visitor.onValue(key, obj);
+            visitor.onValue?.(key, obj);
         } else if (Array.isArray(obj)) {
             this._walkIterable(key, obj, visitor);
         } else if (this.supportIterators && isIterable(obj)) {
@@ -45,25 +45,25 @@ export class ObjectWalker {
         } else if (isPlainRecord(obj)) { // a plain object
             this._walkObject(key, obj, visitor);
         } else { // a random object - we treat it as a value
-            visitor.onValue && visitor.onValue(key, obj);
+            visitor.onValue?.(key, obj);
         }
     }
 
     _walkIterable(key: ObjectKey, obj: Iterable<unknown>, visitor: ObjectVisitor) {
-        visitor.onStartIteration && visitor.onStartIteration(key, obj);
+        visitor.onStartIteration?.(key, obj);
         let i = 0;
         for (const value of obj) {
             this._walk(i++, value, visitor);
         }
-        visitor.onEndIteration && visitor.onEndIteration(key, obj);
+        visitor.onEndIteration?.(key, obj);
     }
 
     _walkObject(key: ObjectKey, obj: Record<string, unknown>, visitor: ObjectVisitor) {
-        visitor.onStartObject && visitor.onStartObject(key, obj);
+        visitor.onStartObject?.(key, obj);
         for (const k of Object.keys(obj)) {
             this._walk(k, obj[k], visitor);
         }
-        visitor.onEndObject && visitor.onEndObject(key, obj);
+        visitor.onEndObject?.(key, obj);
     }
 
     map(obj: unknown, mapFn: (key: ObjectKey, value: unknown) => unknown): unknown {
@@ -85,7 +85,7 @@ export class AsyncObjectWalker {
     async _walk(key: ObjectKey, obj: unknown, visitor: AsyncObjectVisitor) {
         const type = typeof obj;
         if (!obj || type !== 'object' || obj instanceof Date) {
-            visitor.onValue && (await visitor.onValue(key, obj));
+            await visitor.onValue?.(key, obj);
         } else if (Array.isArray(obj)) {
             await this._walkIterable(key, obj, visitor);
         } else if (this.supportIterators && isIterable(obj)) {
@@ -93,25 +93,25 @@ export class AsyncObjectWalker {
         } else if (isPlainRecord(obj)) { // a plain object
             await this._walkObject(key, obj, visitor);
         } else { // a random object - we treat it as a value
-            visitor.onValue && (await visitor.onValue(key, obj));
+            await visitor.onValue?.(key, obj);
         }
     }
 
     async _walkIterable(key: ObjectKey, obj: Iterable<unknown>, visitor: AsyncObjectVisitor) {
-        visitor.onStartIteration && (await visitor.onStartIteration(key, obj));
+        await visitor.onStartIteration?.(key, obj);
         let i = 0;
         for (const value of obj) {
             await this._walk(i++, value, visitor);
         }
-        visitor.onEndIteration && (await visitor.onEndIteration(key, obj));
+        await visitor.onEndIteration?.(key, obj);
     }
 
     async _walkObject(key: ObjectKey, obj: Record<string, unknown>, visitor: AsyncObjectVisitor) {
-        visitor.onStartObject && (await visitor.onStartObject(key, obj));
+        await visitor.onStartObject?.(key, obj);
         for (const k of Object.keys(obj)) {
             await this._walk(k, obj[k], visitor);
         }
-        visitor.onEndObject && (await visitor.onEndObject(key, obj));
+        await visitor.onEndObject?.(key, obj);
     }
 
     async map(obj: unknown, mapFn: (key: ObjectKey, value: unknown) => Promise<unknown>): Promise<unknown> {

--- a/packages/json/tsconfig.test.json
+++ b/packages/json/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": true,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "lib"
+  ]
+}

--- a/packages/memory-cli/examples/example1.ts
+++ b/packages/memory-cli/examples/example1.ts
@@ -1,5 +1,5 @@
 //@ts-ignore
-import { vars, exec, media, content, tmpdir, pdf } from "@vertesia/memory-commands";
+import { vars, exec, media, content, pdf } from "@vertesia/memory-commands";
 
 console.log('!!!!!!', vars);
 

--- a/packages/memory-cli/src/cli.ts
+++ b/packages/memory-cli/src/cli.ts
@@ -6,7 +6,7 @@ import { readFileSync } from 'fs';
 
 const packageDir = dirname(dirname(fileURLToPath(import.meta.url)));
 
-let _package: any;
+let _package: unknown;
 function getPackage() {
     if (_package === undefined) {
         _package = JSON.parse(readFileSync(`${packageDir}/package.json`, 'utf8'));

--- a/packages/memory-cli/src/command.ts
+++ b/packages/memory-cli/src/command.ts
@@ -14,7 +14,7 @@ export function setupMemoCommand(command: Command, publish?: (file: string, name
         .option('-o, --out <file>', 'The output file. Defaults to "memory.tar".')
         .option('-t, --test', 'Test the memory script without building it.')
         .argument('<recipe>', 'The recipe script to build the memory from.')
-        .action((_arg: string, options: Record<string, any>, command: Command) => {
+        .action((_arg: string, options: Record<string, unknown>, command: Command) => {
             memoAction(command, { ...options, publish }).catch((err: Error) => {
                 console.error("Failed to run command: ", err);
                 process.exit(1);
@@ -25,7 +25,7 @@ export function setupMemoCommand(command: Command, publish?: (file: string, name
     exportCmd.option('--map <mapping>', 'The mapping to use. An inline JSON object or a path to a JSOn file prefixed with @')
         .option('-i, --indent <spaces>', 'The number of spaces to indent the JSON result. No indentation is done by default.')
         .argument('<pack>', 'The uncompressed memory pack to use (i.e. a .tar file).')
-        .action((arg: string, options: Record<string, any>, command: Command) => {
+        .action((arg: string, options: Record<string, unknown>, command: Command) => {
             exportAction(command, arg, options).catch((err: Error) => {
                 console.error("Failed to run command: ", err);
                 process.exit(1);
@@ -37,7 +37,7 @@ export function setupMemoCommand(command: Command, publish?: (file: string, name
     return command;
 }
 
-function memoAction(command: Command, options: Record<string, any>) {
+function memoAction(command: Command, options: Record<string, unknown>) {
     const { script, vars } = parseArgs(command.args);
     if (options.indent) {
         options.indent = parseInt(options.indent);
@@ -58,7 +58,7 @@ function parseArgs(args: string[]) {
         process.exit(1);
     }
     let script: string | undefined;
-    const vars: Record<string, any> = {};
+    const vars: Record<string, unknown> = {};
     let lastKey: string | undefined;
     let lastCommittedOption: string | undefined;
     for (const arg of args) {
@@ -90,12 +90,12 @@ function parseArgs(args: string[]) {
     return { script, vars };
 }
 
-async function exportAction(_command: Command, packFile: string, options: Record<string, any>) {
+async function exportAction(_command: Command, packFile: string, options: Record<string, unknown>) {
     let mapParam = options.map;
     if (mapParam.startsWith('@')) {
         mapParam = await readFile(mapParam.substring(1), "utf-8");
     }
-    const mapping: Record<string, any> = JSON.parse(mapParam);
+    const mapping: Record<string, unknown> = JSON.parse(mapParam);
     const pack = await loadMemoryPack(packFile);
     const obj = await pack.exportObject(mapping);
     console.log(JSON.stringify(obj, null, options.indent || 2));

--- a/packages/memory-commands/src/build.ts
+++ b/packages/memory-commands/src/build.ts
@@ -22,11 +22,11 @@ export function build(script: string, options: BuildOptions = {}): Promise<void>
 
 async function _build(builder: Builder, script: string, transpileDir?: string): Promise<void> {
     const resolvedScript = resolve(script);
-    let module: any;
+    let module: unknown;
     if (resolvedScript.endsWith('.ts')) {
         try {
             module = await importTsFile(resolvedScript, transpileDir);
-        } catch (er: any) {
+        } catch (er: unknown) {
             console.error(er);
             process.exit(1);
         }

--- a/packages/memory-commands/src/ts-loader.ts
+++ b/packages/memory-commands/src/ts-loader.ts
@@ -58,12 +58,12 @@ function transpileFile(source: string, target: string, options: ts.CompilerOptio
 function tryDeleteFile(file: string) {
     try {
         rmSync(file)
-    } catch (_er: any) {
+    } catch (_er: unknown) {
         // ignore
     }
 }
 
-export function importTsFile(file: string, outdir: string = '.'): Promise<any> {
+export function importTsFile(file: string, outdir: string = '.'): Promise<unknown> {
     if (!file.endsWith('.ts')) {
         throw new Error("Not a type script file: " + file);
     }

--- a/packages/memory/src/Builder.ts
+++ b/packages/memory/src/Builder.ts
@@ -30,7 +30,7 @@ export interface BuildOptions {
     /**
      * Vars to be injected into the script context as the vars object
      */
-    vars?: Record<string, any>;
+    vars?: Record<string, unknown>;
 
     /**
      * Optional publish action
@@ -46,7 +46,7 @@ export interface BuildOptions {
 }
 
 export interface Commands {
-    vars: () => Record<string, any>;
+    vars: () => Record<string, unknown>;
     tmpdir: () => string;
     exec: (cmd: string, options?: ExecOptions) => Promise<void | string>;
     from: (location: string, options?: FromOptions) => Promise<void>;
@@ -69,7 +69,7 @@ export class Builder implements Commands {
         return Builder.instance;
     }
 
-    _vars: Record<string, any>;
+    _vars: Record<string, unknown>;
     _tmpdir?: string;
     memory: MemoryPackBuilder;
 
@@ -79,7 +79,7 @@ export class Builder implements Commands {
         Builder.instance = this;
     }
 
-    vars(): Record<string, any> {
+    vars(): Record<string, unknown> {
         return this._vars;
     }
 
@@ -157,7 +157,7 @@ export class Builder implements Commands {
         }
     }
 
-    async build(object: Record<string, any>) {
+    async build(object: Record<string, unknown>) {
         try {
             const outputNames = this._getOutputNames();
             const publishName = outputNames.publishName;
@@ -208,7 +208,7 @@ export class Builder implements Commands {
 
 }
 
-function resolveContextObject(object: Record<string, any>): Promise<Record<string, any>> {
+function resolveContextObject(object: Record<string, unknown>): Promise<Record<string, unknown>> {
     return new AsyncObjectWalker().map(object, async (_key, value) => {
         if (value instanceof ContentObject) {
             return await value.getText();
@@ -223,7 +223,7 @@ function createTmpBaseName(tmpdir: string) {
 }
 
 
-export function buildMemoryPack(recipeFn: (commands: Commands) => Promise<Record<string, any>>, options: BuildOptions): Promise<string> {
+export function buildMemoryPack(recipeFn: (commands: Commands) => Promise<Record<string, unknown>>, options: BuildOptions): Promise<string> {
     const builder = new Builder(options);
     return recipeFn({
         vars: builder.vars.bind(builder),

--- a/packages/memory/src/Builder.ts
+++ b/packages/memory/src/Builder.ts
@@ -174,7 +174,7 @@ export class Builder implements Commands {
                     rmSync(fileName);
                 }
             }
-            this.options.quiet || console.log(`Memory saved to ${target}`);
+            if (!this.options.quiet) console.log(`Memory saved to ${target}`);
             return target;
         } finally {
             if (this._tmpdir) {

--- a/packages/memory/src/ContentObject.ts
+++ b/packages/memory/src/ContentObject.ts
@@ -25,7 +25,7 @@ export class ContentObject implements ContentSource {
         const out = fs.createWriteStream(file);
         const stream = input.pipe(out);
         return new Promise((resolve, reject) => {
-            const handleError = (err: any) => {
+            const handleError = (err: unknown) => {
                 reject(err);
                 out.close();
             }
@@ -46,13 +46,13 @@ export class ContentObject implements ContentSource {
         return t;
     }
 
-    getJsonValue(): Promise<any> {
+    getJsonValue(): Promise<unknown> {
         return this.getText();
     }
 }
 
 export class JsonObject extends ContentObject {
-    async getJsonValue(): Promise<any> {
+    async getJsonValue(): Promise<unknown> {
         return JSON.parse(await this.getText());
     }
 }

--- a/packages/memory/src/MemoryPack.ts
+++ b/packages/memory/src/MemoryPack.ts
@@ -17,13 +17,13 @@ export interface ProjectionProperties {
     [key: string]: boolean | 0 | 1;
 }
 
-function applyProjection(projection: ProjectionProperties, object: any) {
+function applyProjection(projection: ProjectionProperties, object: unknown) {
     const keys = Object.keys(projection);
     if (keys.length < 1) {
         return object;
     }
     const isInclusion = !!projection[keys[0]];
-    const out: any = {};
+    const out: unknown = {};
     if (isInclusion) {
         for (const key of Object.keys(object)) {
             if (projection[key]) {
@@ -44,7 +44,7 @@ function applyProjection(projection: ProjectionProperties, object: any) {
 
 export abstract class MemoryPack {
     abstract readonly file: string;
-    abstract getMetadata(projection?: ProjectionProperties): Promise<Record<string, any>>;
+    abstract getMetadata(projection?: ProjectionProperties): Promise<Record<string, unknown>>;
     abstract getEntry(path: string): MemoryEntry | null;
     abstract getEntryContent(path: string): Promise<Buffer | null>;
     abstract getEntryText(path: string, encoding?: BufferEncoding): Promise<string | null>;
@@ -53,9 +53,9 @@ export abstract class MemoryPack {
     abstract getEntriesContent(filters?: string[]): Promise<Buffer[]>;
     abstract getEntriesText(filters?: string[], encoding?: BufferEncoding): Promise<string[]>;
 
-    async exportObject(mapping: Record<string, any>): Promise<Record<string, any>> {
-        let metadata: any;
-        const result: Record<string, any> = {};
+    async exportObject(mapping: Record<string, unknown>): Promise<Record<string, unknown>> {
+        let metadata: unknown;
+        const result: Record<string, unknown> = {};
         for (const key of Object.keys(mapping)) {
             const value = mapping[key];
             if (typeof value === 'string') {
@@ -123,7 +123,7 @@ export class TarMemoryPack extends MemoryPack {
             throw new Error("Invalid memory tar file. Context entry not found");
         }
     }
-    async getMetadata(projection?: ProjectionProperties): Promise<Record<string, any>> {
+    async getMetadata(projection?: ProjectionProperties): Promise<Record<string, unknown>> {
         const content = await this.index.getContent(MEMORY_METADATA_ENTRY);
         if (content) {
             let metadata = JSON.parse(content.toString('utf-8'));
@@ -216,7 +216,7 @@ function getTextEncodingForPath(path: string) {
 }
 
 
-function resolveProperty(obj: Record<string, any>, key: string) {
+function resolveProperty(obj: Record<string, unknown>, key: string) {
     if (key.includes('.')) {
         const keys = key.split('.');
         let value = obj;

--- a/packages/memory/src/MemoryPackBuilder.ts
+++ b/packages/memory/src/MemoryPackBuilder.ts
@@ -9,7 +9,7 @@ export interface FromOptions {
 }
 
 export class MemoryPackBuilder {
-    baseMetadata: Record<string, any> = {};
+    baseMetadata: Record<string, unknown> = {};
     entries: { [path: string]: ContentSource } = {};
 
     constructor(public builder: Builder) {

--- a/packages/memory/src/commands/exec.ts
+++ b/packages/memory/src/commands/exec.ts
@@ -56,7 +56,7 @@ export function executePipe(commands: Command[], finalOutput: Writable | undefin
         let input: Stream | undefined;
         let child: ChildProcess | undefined;
         for (const cmd of commands) {
-            verbose && console.log(`Running: ${cmd.name} ${cmd.args?.join(' ')}`);
+            if (verbose) console.log(`Running: ${cmd.name} ${cmd.args?.join(' ')}`);
             child = spawn(cmd.name, cmd.args, {
                 // in, out, err
                 stdio: ['pipe', 'pipe', 'inherit'],
@@ -74,7 +74,7 @@ export function executePipe(commands: Command[], finalOutput: Writable | undefin
             child.on("exit", (code: number | null, signal: string | null) => {
                 resolve(code !== null ? code : signal);
             });
-            finalOutput && child.stdout?.pipe(finalOutput);
+            if (finalOutput) child.stdout?.pipe(finalOutput);
         } else {
             reject(new Error("no child spawned"));
         }

--- a/packages/tools-sdk/package.json
+++ b/packages/tools-sdk/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "lint": "biome lint src",
     "test": "vitest run",
+    "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
     "build": "pnpm exec tsmod build",
     "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
   },

--- a/packages/tools-sdk/src/ActivityCollection.test.ts
+++ b/packages/tools-sdk/src/ActivityCollection.test.ts
@@ -1,6 +1,13 @@
 import { RemoteActivityExecutionPayload } from "@vertesia/common";
+import type { Context } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ActivityCollection, ActivityDefinition } from "./ActivityCollection.js";
+
+type MockContext = Context & {
+    json: ReturnType<typeof vi.fn>;
+    req: { header: ReturnType<typeof vi.fn>; url: string };
+    set: ReturnType<typeof vi.fn>;
+};
 
 vi.mock("./auth.js", () => ({
     authorize: vi.fn().mockResolvedValue({ token: "test-token" }),
@@ -93,7 +100,7 @@ describe("ActivityCollection", () => {
     });
 
     describe("execute", () => {
-        const createMockContext = () => {
+        const createMockContext = (): MockContext => {
             const jsonFn = vi.fn().mockReturnThis();
             return {
                 json: jsonFn,
@@ -102,7 +109,7 @@ describe("ActivityCollection", () => {
                     url: "http://localhost/api/activities",
                 },
                 set: vi.fn(),
-            } as any;
+            } as unknown as MockContext;
         };
 
         const payload: RemoteActivityExecutionPayload = {

--- a/packages/tools-sdk/src/ActivityCollection.ts
+++ b/packages/tools-sdk/src/ActivityCollection.ts
@@ -14,15 +14,15 @@ export type ActivityExecutionContext = ToolExecutionContext;
 /**
  * Function signature for a remote activity handler.
  */
-export type ActivityFn<ParamsT extends Record<string, any> = Record<string, any>> = (
+export type ActivityFn<ParamsT extends object = Record<string, unknown>> = (
     payload: RemoteActivityExecutionPayload<ParamsT>,
     context: ActivityExecutionContext
-) => Promise<any>;
+) => Promise<unknown>;
 
 /**
  * An activity definition within an ActivityCollection.
  */
-export interface ActivityDefinition<ParamsT extends Record<string, any> = Record<string, any>> {
+export interface ActivityDefinition<ParamsT extends object = Record<string, unknown>> {
     /** Activity name (snake_case) */
     name: string;
     /** Display title */
@@ -30,9 +30,9 @@ export interface ActivityDefinition<ParamsT extends Record<string, any> = Record
     /** Description of what the activity does */
     description?: string;
     /** JSON Schema for the activity input parameters */
-    input_schema?: Record<string, any>;
+    input_schema?: Record<string, unknown>;
     /** JSON Schema for the activity output */
-    output_schema?: Record<string, any>;
+    output_schema?: Record<string, unknown>;
     /** The activity handler function */
     run: ActivityFn<ParamsT>;
 }

--- a/packages/tools-sdk/src/SkillCollection.ts
+++ b/packages/tools-sdk/src/SkillCollection.ts
@@ -164,19 +164,14 @@ export class SkillCollection implements ICollection<SkillDefinition> {
      * @param ctx - Hono context
      * @param preParsedPayload - Optional pre-parsed payload (used when routing from root endpoint)
      */
-    async execute(ctx: Context, preParsedPayload?: ToolExecutionPayload<Record<string, any>>): Promise<Response> {
+    async execute(ctx: Context, preParsedPayload?: ToolExecutionPayload): Promise<Response> {
         const toolCtx = ctx as ToolContext;
-        let payload: ToolExecutionPayload<Record<string, any>> | undefined = preParsedPayload;
+        const payload = preParsedPayload ?? toolCtx.payload;
         try {
             if (!payload) {
-                // Check if body was already parsed and validated by middleware
-                if (toolCtx.payload) {
-                    payload = toolCtx.payload;
-                } else {
-                    throw new HTTPException(400, {
-                        message: 'Invalid or missing skill execution payload. Expected { tool_use: { id, tool_name, tool_input? }, metadata? }'
-                    });
-                }
+                throw new HTTPException(400, {
+                    message: 'Invalid or missing skill execution payload. Expected { tool_use: { id, tool_name, tool_input? }, metadata? }'
+                });
             }
 
             const toolName = payload.tool_use.tool_name;
@@ -200,7 +195,8 @@ export class SkillCollection implements ICollection<SkillDefinition> {
                 });
             }
 
-            const data = payload.tool_use.tool_input || {};
+            const input = payload.tool_use.tool_input;
+            const data = typeof input === 'object' && input !== null && !Array.isArray(input) ? input as Record<string, unknown> : {};
             const result = await this.renderSkill(skill, data);
 
             // TODO: If skill.execution is set, run via Daytona
@@ -216,8 +212,10 @@ export class SkillCollection implements ICollection<SkillDefinition> {
                     execution: skill.execution,
                 }
             } satisfies ToolExecutionResult & { tool_use_id: string });
-        } catch (err: any) {
-            const status = err.status || 500;
+        } catch (err: unknown) {
+            const status = err instanceof HTTPException ? err.status : 500;
+            const message = err instanceof Error ? err.message : "Error executing skill";
+            const stack = err instanceof Error ? err.stack : undefined;
             const toolName = payload?.tool_use?.tool_name;
             const toolUseId = payload?.tool_use?.id;
 
@@ -226,17 +224,17 @@ export class SkillCollection implements ICollection<SkillDefinition> {
                     collection: this.name,
                     skill: toolName,
                     toolUseId,
-                    error: err.message,
+                    error: message,
                     status,
                     toolInput: payload?.tool_use?.tool_input,
-                    stack: err.stack,
+                    stack,
                 });
             }
 
             return ctx.json({
                 tool_use_id: toolUseId || "unknown",
                 is_error: true,
-                content: err.message || "Error executing skill",
+                content: message,
             }, status);
         }
     }
@@ -267,9 +265,9 @@ export class SkillCollection implements ICollection<SkillDefinition> {
 // ================== Skill Parser ==================
 
 interface SkillFrontmatter {
-    name: string;
+    name?: string;
     title?: string;
-    description: string;
+    description?: string;
     keywords?: string[];
     tools?: string[];
     data_patterns?: string[];
@@ -367,7 +365,7 @@ export function parseSkillFile(
  * Simple YAML frontmatter parser (handles basic key: value and arrays)
  */
 function parseYamlFrontmatter(yaml: string): SkillFrontmatter {
-    const result: Record<string, any> = {};
+    const result: Record<string, unknown> = {};
     const lines = yaml.split('\n');
 
     for (const line of lines) {
@@ -394,7 +392,27 @@ function parseYamlFrontmatter(yaml: string): SkillFrontmatter {
         }
     }
 
-    return result as SkillFrontmatter;
+    return {
+        name: asString(result.name),
+        title: asString(result.title),
+        description: asString(result.description),
+        keywords: asStringArray(result.keywords),
+        tools: asStringArray(result.tools),
+        data_patterns: asStringArray(result.data_patterns),
+        language: asString(result.language),
+        packages: asStringArray(result.packages),
+        system_packages: asStringArray(result.system_packages),
+        widgets: asStringArray(result.widgets),
+        scripts: asStringArray(result.scripts),
+    };
+}
+
+function asString(value: unknown): string | undefined {
+    return typeof value === 'string' ? value : undefined;
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+    return Array.isArray(value) && value.every((item) => typeof item === 'string') ? value : undefined;
 }
 
 /**

--- a/packages/tools-sdk/src/ToolCollection.ts
+++ b/packages/tools-sdk/src/ToolCollection.ts
@@ -14,13 +14,13 @@ export interface ToolCollectionProperties extends CollectionProperties {
     /**
      * The tools
      */
-    tools: Tool<any>[];
+    tools: Tool[];
 }
 
 /**
  * Implements a tools collection endpoint
  */
-export class ToolCollection implements ICollection<Tool<any>> {
+export class ToolCollection implements ICollection<Tool> {
 
     /**
      * A kebab case collection name. Must only contains alphanumeric and dash characters,
@@ -57,12 +57,12 @@ export class ToolCollection implements ICollection<Tool<any>> {
         this.tools = new ToolRegistry(name, tools);
     }
 
-    [Symbol.iterator](): Iterator<Tool<any>> {
+    [Symbol.iterator](): Iterator<Tool> {
         let index = 0;
         const tools = this.tools.getTools();
 
         return {
-            next(): IteratorResult<Tool<any>> {
+            next(): IteratorResult<Tool> {
                 if (index < tools.length) {
                     return { value: tools[index++], done: false };
                 } else {
@@ -72,12 +72,12 @@ export class ToolCollection implements ICollection<Tool<any>> {
         };
     }
 
-    map<U>(callback: (tool: Tool<any>, index: number) => U): U[] {
+    map<U>(callback: (tool: Tool, index: number) => U): U[] {
         return this.tools.getTools().map(callback);
     }
 
-    async execute(ctx: Context, preParsedPayload?: ToolExecutionPayload<any>): Promise<Response> {
-        let payload: ToolExecutionPayload<any> | undefined = preParsedPayload;
+    async execute(ctx: Context, preParsedPayload?: ToolExecutionPayload): Promise<Response> {
+        let payload: ToolExecutionPayload | undefined = preParsedPayload;
         try {
             if (!payload) {
                 payload = await readPayload(ctx);
@@ -101,8 +101,10 @@ export class ToolCollection implements ICollection<Tool<any>> {
                 ...r,
                 tool_use_id: payload.tool_use.id
             } satisfies ToolExecutionResponse);
-        } catch (err: any) { // HTTPException ?
-            const status = err.status || 500;
+        } catch (err: unknown) { // HTTPException ?
+            const status = err instanceof HTTPException ? err.status : 500;
+            const message = err instanceof Error ? err.message : "Error executing tool";
+            const stack = err instanceof Error ? err.stack : undefined;
             const toolName = payload?.tool_use?.tool_name;
             const toolUseId = payload?.tool_use?.id;
 
@@ -110,14 +112,14 @@ export class ToolCollection implements ICollection<Tool<any>> {
                 collection: this.name,
                 tool: toolName,
                 toolUseId,
-                error: err.message,
+                error: message,
                 status,
-                stack: err.stack,
+                stack,
             });
 
             return ctx.json({
                 tool_use_id: toolUseId || "undefined",
-                error: err.message || "Error executing tool",
+                error: message,
                 status
             } satisfies ToolExecutionResponseError, status)
         }
@@ -135,7 +137,7 @@ export class ToolCollection implements ICollection<Tool<any>> {
 }
 
 
-function readPayload(ctx: Context): ToolExecutionPayload<any> {
+function readPayload(ctx: Context): ToolExecutionPayload {
     const toolCtx = ctx as ToolContext;
 
     // Check if body was already parsed and validated by middleware
@@ -166,8 +168,8 @@ function readPayload(ctx: Context): ToolExecutionPayload<any> {
  * @param toolsDir - Path to the tools directory (e.g., /path/to/collection/tools)
  * @returns Promise resolving to array of Tool objects
  */
-export async function loadToolsFromDirectory(toolsDir: string): Promise<Tool<any>[]> {
-    const tools: Tool<any>[] = [];
+export async function loadToolsFromDirectory(toolsDir: string): Promise<Tool[]> {
+    const tools: Tool[] = [];
 
     if (!existsSync(toolsDir)) {
         console.warn(`Tools directory not found: ${toolsDir}`);
@@ -213,4 +215,3 @@ export async function loadToolsFromDirectory(toolsDir: string): Promise<Tool<any
 
     return tools;
 }
-

--- a/packages/tools-sdk/src/ToolRegistry.ts
+++ b/packages/tools-sdk/src/ToolRegistry.ts
@@ -7,9 +7,9 @@ export class ToolRegistry {
 
     // The category name usinfg this registry
     category: string;
-    registry: Record<string, Tool<any>> = {};
+    registry: Record<string, Tool> = {};
 
-    constructor(category: string, tools: Tool<any>[] = []) {
+    constructor(category: string, tools: Tool[] = []) {
         this.category = category;
         for (const tool of tools) {
             this.registry[tool.name] = tool;
@@ -22,7 +22,7 @@ export class ToolRegistry {
      * @returns Filtered tool definitions
      */
     getDefinitions(context?: ToolUseContext): AgentToolDefinition[] {
-        const mapTool = (tool: Tool<any>): AgentToolDefinition => ({
+        const mapTool = (tool: Tool): AgentToolDefinition => ({
             url: `tools/${this.category}`,
             name: tool.name,
             description: tool.description,
@@ -41,23 +41,23 @@ export class ToolRegistry {
         return tools.map(mapTool);
     }
 
-    getTool<ParamsT extends Record<string, any>>(name: string): Tool<ParamsT> {
+    getTool<ParamsT extends object>(name: string): Tool<ParamsT> {
         const tool = this.registry[name]
         if (tool === undefined) {
             throw new ToolNotFoundError(name);
         }
-        return tool;
+        return tool as unknown as Tool<ParamsT>;
     }
 
     getTools() {
         return Object.values(this.registry);
     }
 
-    registerTool<ParamsT extends Record<string, any>>(tool: Tool<ParamsT>): void {
-        this.registry[tool.name] = tool;
+    registerTool<ParamsT extends object>(tool: Tool<ParamsT>): void {
+        this.registry[tool.name] = tool as unknown as Tool;
     }
 
-    runTool<ParamsT extends Record<string, any>>(payload: ToolExecutionPayload<ParamsT>, context: ToolExecutionContext): Promise<ToolExecutionResult> {
+    runTool<ParamsT extends object>(payload: ToolExecutionPayload<ParamsT>, context: ToolExecutionContext): Promise<ToolExecutionResult> {
         const toolName = payload.tool_use.tool_name;
         return this.getTool(toolName).run(payload, context);
     }

--- a/packages/tools-sdk/src/auth.ts
+++ b/packages/tools-sdk/src/auth.ts
@@ -71,10 +71,11 @@ export async function authorize(ctx: Context, endpointOverrides?: EndpointOverri
         const session = new AuthSession(value, payload, endpointOverrides, toolContext);
         ctx.set("auth", session);
         return session;
-    } catch (err: any) {
+    } catch (err: unknown) {
         if (err instanceof HTTPException) throw err;
+        const message = err instanceof Error ? err.message : String(err);
         throw new HTTPException(401, {
-            message: err.message,
+            message,
             cause: err
         });
     }

--- a/packages/tools-sdk/src/server.ts
+++ b/packages/tools-sdk/src/server.ts
@@ -69,7 +69,7 @@ export function createToolServer(config: ToolServerConfig): Hono {
                 const body = JSON.parse(text);
                 const result = ToolExecutionPayloadSchema.safeParse(body);
                 if (result.success) {
-                    ctx.payload = result.data as ToolExecutionPayload<any>;
+                    ctx.payload = result.data as ToolExecutionPayload;
                     ctx.toolUseId = result.data.tool_use.id;
                     ctx.toolName = result.data.tool_use.tool_name;
                 }

--- a/packages/tools-sdk/src/server/activities.test.ts
+++ b/packages/tools-sdk/src/server/activities.test.ts
@@ -4,6 +4,9 @@ import { ActivityCollection, ActivityDefinition } from "../ActivityCollection.js
 import { createActivitiesRoute } from "./activities.js";
 import { ToolServerConfig } from "./types.js";
 
+/** Permissive recursive type for navigating JSON response bodies in tests. */
+type Tree = { readonly [key: string]: Tree };
+
 // Mock authorize to avoid JWT verification
 vi.mock("../auth.js", () => ({
     authorize: vi.fn().mockResolvedValue({ token: "test-token" }),
@@ -50,7 +53,7 @@ describe("Activities server routes", () => {
         it("returns all activity definitions across collections", async () => {
             const app = createApp(createTestCollections());
             const res = await app.request("/api/activities");
-            const body = await res.json() as any;
+            const body = await res.json() as unknown as Tree;
 
             expect(res.status).toBe(200);
             expect(body.activities).toHaveLength(2);
@@ -62,7 +65,7 @@ describe("Activities server routes", () => {
         it("returns empty when no collections configured", async () => {
             const app = createApp([]);
             const res = await app.request("/api/activities");
-            const body = await res.json() as any;
+            const body = await res.json() as unknown as Tree;
 
             expect(res.status).toBe(200);
             expect(body.activities).toHaveLength(0);
@@ -73,7 +76,7 @@ describe("Activities server routes", () => {
         it("returns activities for a specific collection", async () => {
             const app = createApp(createTestCollections());
             const res = await app.request("/api/activities/nlp");
-            const body = await res.json() as any;
+            const body = await res.json() as unknown as Tree;
 
             expect(res.status).toBe(200);
             expect(body.name).toBe("nlp");
@@ -103,7 +106,7 @@ describe("Activities server routes", () => {
             });
 
             expect(res.status).toBe(200);
-            const body = await res.json() as any;
+            const body = await res.json() as unknown as Tree;
             expect(body.result).toEqual({ score: 0.95 });
             expect(body.is_error).toBe(false);
         });
@@ -158,7 +161,7 @@ describe("Activities server routes", () => {
             });
 
             expect(res.status).toBe(200);
-            const body = await res.json() as any;
+            const body = await res.json() as unknown as Tree;
             expect(body.result).toEqual({ entities: ["foo"] });
         });
     });

--- a/packages/tools-sdk/src/server/activities.ts
+++ b/packages/tools-sdk/src/server/activities.ts
@@ -17,6 +17,10 @@ async function safeParseJson(c: Context): Promise<unknown> {
     }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return !!value && typeof value === 'object';
+}
+
 /**
  * Validates the structure of a RemoteActivityExecutionPayload.
  * Returns the parsed payload or throws HTTPException(400).
@@ -27,7 +31,7 @@ function parseActivityPayload(body: unknown): RemoteActivityExecutionPayload {
             message: 'Invalid or missing activity execution payload.'
         });
     }
-    const obj = body as Record<string, any>;
+    const obj = body as Record<string, unknown>;
     if (typeof obj.activity_name !== 'string' || !obj.activity_name) {
         throw new HTTPException(400, {
             message: 'Missing required field: activity_name'
@@ -35,8 +39,8 @@ function parseActivityPayload(body: unknown): RemoteActivityExecutionPayload {
     }
     return {
         activity_name: obj.activity_name,
-        params: obj.params || {},
-        metadata: obj.metadata || {},
+        params: isRecord(obj.params) ? obj.params : {},
+        metadata: isRecord(obj.metadata) ? obj.metadata : {},
     };
 }
 

--- a/packages/tools-sdk/src/server/mcp.ts
+++ b/packages/tools-sdk/src/server/mcp.ts
@@ -37,15 +37,16 @@ function createMCPEndpoints(providers: MCPProviderConfig[]): Hono {
     return endpoint;
 }
 
-async function readJsonBody(ctx: Context): Promise<Record<string, any>> {
+async function readJsonBody(ctx: Context): Promise<Record<string, unknown>> {
     try {
         const text = await ctx.req.text();
         const jsonContent = text?.trim() || '';
         if (!jsonContent) return {};
-        return JSON.parse(jsonContent) as Record<string, any>;
-    } catch (err: any) {
+        return JSON.parse(jsonContent) as Record<string, unknown>;
+    } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
         throw new HTTPException(400, {
-            message: "Failed to parse JSON body: " + err.message
+            message: "Failed to parse JSON body: " + message
         });
     }
 }

--- a/packages/tools-sdk/src/server/skills.ts
+++ b/packages/tools-sdk/src/server/skills.ts
@@ -39,7 +39,7 @@ export function createSkillsRoute(app: Hono, basePath: string, config: ToolServe
                 title: s.title,
                 description: s.description,
             })),
-        } satisfies ToolCollectionDefinition & { collections: any[] });
+        } satisfies ToolCollectionDefinition & { collections: unknown[] });
     });
 
     // POST /api/skills - Route to the correct collection based on tool_name

--- a/packages/tools-sdk/src/server/tools.ts
+++ b/packages/tools-sdk/src/server/tools.ts
@@ -39,7 +39,7 @@ export function createToolsRoute(app: Hono, basePath: string, config: ToolServer
                 title: t.title,
                 description: t.description,
             })),
-        } satisfies ToolCollectionDefinition & { collections: any[]; reserveToolCount?: number });
+        } satisfies ToolCollectionDefinition & { collections: unknown[]; reserveToolCount?: number });
     });
 
     // POST /api/tools - Route to the correct collection based on tool_name

--- a/packages/tools-sdk/src/server/types.ts
+++ b/packages/tools-sdk/src/server/types.ts
@@ -7,14 +7,16 @@ import { ToolCollection } from "../ToolCollection.js";
 import { ToolExecutionPayload } from "../types.js";
 import { JSONSchema } from "@llumiverse/common";
 import { AppUIConfig, InCodeProcessDefinition, ProjectConfiguration } from "@vertesia/common";
+import { AuthSession } from "../auth.js";
 import { ContentTypesCollection } from "../ContentTypesCollection.js";
+import { MCPConnectionDetails } from "../types.js";
 
 /**
  * Extended context with parsed payload for tool/skill execution
  */
 export interface ToolContext extends Context {
     /** The parsed request payload */
-    payload?: ToolExecutionPayload<any>;
+    payload?: ToolExecutionPayload;
     /** The tool_use.id from the payload */
     toolUseId?: string;
     /** The tool_use.tool_name from the payload */
@@ -27,11 +29,7 @@ export interface ToolContext extends Context {
 export interface MCPProviderConfig {
     name: string;
     description?: string;
-    createMCPConnection: (session: any, config: Record<string, any>) => Promise<{
-        name: string;
-        url: string;
-        token: string;
-    }>;
+    createMCPConnection: (session: AuthSession, config: Record<string, unknown>) => Promise<MCPConnectionDetails>;
 }
 
 /**

--- a/packages/tools-sdk/src/types.ts
+++ b/packages/tools-sdk/src/types.ts
@@ -4,7 +4,7 @@ import { AgentToolDefinition, AuthTokenPayload, MCPToolAnnotations, ProjectConfi
 
 export type { ToolExecutionMetadata };
 
-export type ICollection<T = any> = CollectionProperties & Iterable<T>
+export type ICollection<T = object> = CollectionProperties & Iterable<T>
 
 export interface CollectionProperties {
     /**
@@ -48,7 +48,7 @@ export interface ToolExecutionResult extends ToolResultContent {
     /**
      * Medata can be used to return more info on the tool execution like stats or user messages.
      */
-    meta?: Record<string, any>;
+    meta?: Record<string, unknown>;
 }
 
 export interface ToolExecutionResponse extends ToolExecutionResult, ToolResult {
@@ -74,10 +74,10 @@ export interface ToolExecutionResponseError {
     /**
      * Additional context information
      */
-    data?: Record<string, any>;
+    data?: Record<string, unknown>;
 }
 
-export interface ToolExecutionPayload<ParamsT extends Record<string, any>> {
+export interface ToolExecutionPayload<ParamsT extends object = object> {
     tool_use: ToolUse<ParamsT>,
     /**
      * Optional metadata related to the current execution request
@@ -85,7 +85,7 @@ export interface ToolExecutionPayload<ParamsT extends Record<string, any>> {
     metadata?: ToolExecutionMetadata,
 }
 
-export type ToolFn<ParamsT extends Record<string, any>> = (payload: ToolExecutionPayload<ParamsT>, context: ToolExecutionContext) => Promise<ToolExecutionResult>;
+export type ToolFn<ParamsT extends object = object> = (payload: ToolExecutionPayload<ParamsT>, context: ToolExecutionContext) => Promise<ToolExecutionResult>;
 
 export interface ToolUseContext {
     project_id?: string,
@@ -93,11 +93,11 @@ export interface ToolUseContext {
     project_name?: string,
     project_ns?: string,
     configuration?: ProjectConfiguration;
-    vars?: Record<string, any>;
+    vars?: Record<string, unknown>;
 }
 
-export interface Tool<ParamsT extends Record<string, any>> extends ToolDefinition {
-    run: ToolFn<ParamsT>;
+export interface Tool<ParamsT extends object = object> extends ToolDefinition {
+    run(payload: ToolExecutionPayload<ParamsT>, context: ToolExecutionContext): Promise<ToolExecutionResult>;
     /**
      * Whether this tool is available by default.
      * - true/undefined: Tool is always available to agents
@@ -248,7 +248,7 @@ export interface SkillDefinition {
      */
     input_schema?: {
         type: 'object';
-        properties?: Record<string, any>;
+        properties?: Record<string, unknown>;
         required?: string[];
     };
     /**
@@ -299,7 +299,7 @@ export interface SkillExecutionPayload {
     /**
      * Data context for JST template rendering
      */
-    data?: Record<string, any>;
+    data?: Record<string, unknown>;
     /**
      * Whether to execute the code template (if present)
      */

--- a/packages/tools-sdk/tsconfig.test.json
+++ b/packages/tools-sdk/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": true,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "lib"
+  ]
+}

--- a/packages/ui/rollup.config.js
+++ b/packages/ui/rollup.config.js
@@ -18,7 +18,7 @@ const entries = fs.readdirSync(esmOutputDir).filter((name) => {
         if (fs.statSync(dir).isDirectory()) {
             return fs.existsSync(path.join(dir, 'index.js'));
         }
-    } catch (e) {
+    } catch {
         // ignore
     }
     return false;

--- a/packages/ui/src/__tests__/vitest-axe.d.ts
+++ b/packages/ui/src/__tests__/vitest-axe.d.ts
@@ -15,7 +15,6 @@ import 'vitest';
 import type { AxeMatchers } from 'vitest-axe';
 
 declare module 'vitest' {
-    // biome-ignore lint/correctness/noUnusedVariables: T is the standard Assertion generic; required for declaration merging.
-    interface Assertion<T = any> extends AxeMatchers {}
+    interface Assertion<T = unknown> extends AxeMatchers {}
     interface AsymmetricMatchersContaining extends AxeMatchers {}
 }

--- a/packages/ui/src/core/components/ComboBox.tsx
+++ b/packages/ui/src/core/components/ComboBox.tsx
@@ -124,7 +124,7 @@ export function ComboBox<T>({ menuAlign = "fill", menuGap, focusOnMount, onSelec
     });
     useEffect(() => {
         if (inputRef.current) {
-            focusOnMount && inputRef.current.focus();
+            if (focusOnMount) inputRef.current.focus();
         }
     }, [inputRef.current]);
     // the onSelect callback may change so we need to refresh it.

--- a/packages/ui/src/core/components/FileUpload.tsx
+++ b/packages/ui/src/core/components/FileUpload.tsx
@@ -1,5 +1,35 @@
 import { DragEventHandler, MutableRefObject, ReactNode, useRef } from "react";
 
+type DragCounterElement = HTMLElement & {
+    __dragOver_cnt__?: number;
+};
+
+interface FileSystemEntry {
+    name: string;
+    isFile: boolean;
+    isDirectory: boolean;
+}
+
+interface FileSystemFileEntry extends FileSystemEntry {
+    isFile: true;
+    file(callback: (file: File) => void): void;
+}
+
+interface FileSystemDirectoryEntry extends FileSystemEntry {
+    isDirectory: true;
+    createReader(): {
+        readEntries(callback: (entries: FileSystemEntry[]) => void): void;
+    };
+}
+
+function isFileEntry(entry: FileSystemEntry): entry is FileSystemFileEntry {
+    return entry.isFile;
+}
+
+function isDirectoryEntry(entry: FileSystemEntry): entry is FileSystemDirectoryEntry {
+    return entry.isDirectory;
+}
+
 /**
  * TODO: TS complains that:
  * Type 'FileList' can only be iterated through when using the '--downlevelIteration' flag or with a '--target' of 'es2015' or higher.
@@ -78,20 +108,23 @@ export function DropZone({ onUpload }: DropZoneProps) {
     );
 }
 
-function _onDragEnter(el: any) {
+function _onDragEnter(el: DragCounterElement | null) {
+    if (!el) return false;
     let cnt = el.__dragOver_cnt__ || 0;
     el.__dragOver_cnt__ = cnt + 1;
     return !cnt; // true if first drag o ver false if dragover already recorded
 }
 
-function _onDragLeave(el: any) {
+function _onDragLeave(el: DragCounterElement | null) {
+    if (!el) return false;
     let cnt = el.__dragOver_cnt__;
     if (!cnt) return false;
     el.__dragOver_cnt__ = cnt - 1;
     return cnt === 1; // true if leave false if not
 }
 
-function _onDrop(el: any) {
+function _onDrop(el: DragCounterElement | null) {
+    if (!el) return;
     delete el.__dragOver_cnt__;
 }
 
@@ -124,19 +157,19 @@ export function useDropZone<T extends HTMLElement = HTMLDivElement>({
         if (items) {
             const promises: Promise<File[]>[] = [];
 
-            const traverseFileTree = (item: any, path: string = ""): Promise<File[]> => {
+            const traverseFileTree = (item: FileSystemEntry, path: string = ""): Promise<File[]> => {
                 return new Promise((resolve) => {
-                    if (item.isFile) {
+                    if (isFileEntry(item)) {
                         item.file((file: File) => {
                             Object.defineProperty(file, "webkitRelativePath", { value: path + file.name });
                             resolve([file]);
                         });
-                    } else if (item.isDirectory) {
+                    } else if (isDirectoryEntry(item)) {
                         const dirReader = item.createReader();
                         const entries: Promise<File[]>[] = [];
 
                         const readEntries = () => {
-                            dirReader.readEntries((results: any[]) => {
+                            dirReader.readEntries((results) => {
                                 if (!results.length) {
                                     Promise.all(entries).then((filesArrays) => resolve(filesArrays.flat()));
                                 } else {
@@ -154,7 +187,7 @@ export function useDropZone<T extends HTMLElement = HTMLDivElement>({
             };
 
             for (let i = 0; i < items.length; i++) {
-                const entry = items[i].webkitGetAsEntry();
+                const entry = items[i].webkitGetAsEntry() as FileSystemEntry | null;
                 if (entry) {
                     promises.push(traverseFileTree(entry));
                 }

--- a/packages/ui/src/core/components/FormItem.tsx
+++ b/packages/ui/src/core/components/FormItem.tsx
@@ -5,7 +5,7 @@ import { VTooltip } from './shadcn/tooltip';
 import { Info } from 'lucide-react';
 
 interface FormItemProps {
-    label: any;
+    label: ReactNode;
     children: ReactNode;
     /** Explicit id for the control. When omitted and FormItem can wire a single
      *  element child, an id is auto-generated via useId(). */

--- a/packages/ui/src/core/components/InputList.tsx
+++ b/packages/ui/src/core/components/InputList.tsx
@@ -17,15 +17,15 @@ interface InputListProps {
 export function InputList({ value = [], onChange, className, delimiters = ", ", placeholder, autoFocus }: InputListProps) {
     const [text, setText] = useState<string>('');
 
-    const onBlur = (ev: any) => {
-        const v = ev.target.value;
+    const onBlur = (ev: React.FocusEvent<HTMLInputElement>) => {
+        const v = ev.currentTarget.value;
         if (v && v.trim()) {
             onChange([...value, v.trim()])
             setText('')
         }
     }
-    const onKeyDown = (ev: any) => {
-        const v = ev.target.value;
+    const onKeyDown = (ev: React.KeyboardEvent<HTMLInputElement>) => {
+        const v = ev.currentTarget.value;
         const isEmpty = !v.trim();
         const key = ev.key;
         if (key === 'Enter' || delimiters.indexOf(key) > -1) {
@@ -67,7 +67,7 @@ export function InputList({ value = [], onChange, className, delimiters = ", ", 
         }
     }
 
-    const _onClick = (index: any): void => {
+    const _onClick = (index: number): void => {
         if (value && value.length > 0) {
             value.splice(index, 1);
             onChange([...value]);

--- a/packages/ui/src/core/components/NumberInput.tsx
+++ b/packages/ui/src/core/components/NumberInput.tsx
@@ -30,10 +30,10 @@ const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(({ valu
         const value = ev.target.value;
         setTextValue(value)
         if (value === '') {
-            onChange && onChange(undefined, value)
+            onChange?.(undefined, value)
         } else {
             const num = parseFloat(value);
-            onChange && onChange(num, value)
+            onChange?.(num, value)
         }
     }
 

--- a/packages/ui/src/core/components/NumberInput.tsx
+++ b/packages/ui/src/core/components/NumberInput.tsx
@@ -47,7 +47,7 @@ const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(({ valu
 
     return (
         <input
-            onWheel={noScroll ? event => { (event.target as any).blur(); } : others.onWheel} /* avoid input change on wheel scroll */
+            onWheel={noScroll ? event => { event.currentTarget.blur(); } : others.onWheel} /* avoid input change on wheel scroll */
             type='number'
             value={textValue}
             onChange={_onChange}

--- a/packages/ui/src/core/components/Overlay.tsx
+++ b/packages/ui/src/core/components/Overlay.tsx
@@ -57,9 +57,14 @@ export function Overlay({
 
     return (
         <div className={`flex items-center justify-center w-full ${className}`}>
-            <div onClick={handleOpen} className={`w-full align-left cursor-pointer ${triggerClassName}`}>
+            <Button
+                variant="unstyled"
+                size="none"
+                onClick={handleOpen}
+                className={`w-full align-left cursor-pointer ${triggerClassName}`}
+            >
                 {children}
-            </div>
+            </Button>
             {
                 isOpen && (
                     <div className={`z-45 fixed inset-0 bg-black bg-opacity-50 ${backdropClassName}`}>

--- a/packages/ui/src/core/components/SelectList.tsx
+++ b/packages/ui/src/core/components/SelectList.tsx
@@ -2,7 +2,7 @@ import { Check } from "lucide-react";
 import clsx from "clsx";
 import { ReactNode, useMemo, useState } from "react";
 import { useUITranslation } from "@vertesia/ui/i18n";
-import { Input } from "./shadcn";
+import { Button, Input } from "./shadcn";
 
 const Default_Option_Style = "flex-1 px-2 py-2 hover:bg-accent nowrap";
 
@@ -88,10 +88,15 @@ interface SelectListOptionProps<T> {
 
 function SelectListOption<T>({ option, onSelect, layout, noCheck }: SelectListOptionProps<T>) {
     return (
-        <div className={clsx('group flex items-center cursor-pointer gap-x-2 hover:bg-muted',
-            layout.reverse && 'flex-row-reverse', layout.className)} onClick={() => onSelect(option)}>
+        <Button
+            variant="unstyled"
+            size="none"
+            className={clsx('group !flex w-full items-center cursor-pointer gap-x-2 hover:bg-muted',
+                layout.reverse && 'flex-row-reverse', layout.className)}
+            onClick={() => onSelect(option)}
+        >
             {noCheck ? null : <div className="">{layout.check}</div>}
             <div className='flex-1'>{layout.label}</div>
-        </div>
+        </Button>
     )
 }

--- a/packages/ui/src/core/components/SidePanel.tsx
+++ b/packages/ui/src/core/components/SidePanel.tsx
@@ -88,7 +88,9 @@ export function SidePanel({ isOpen, title, onClose, children, panelWidth = 768, 
                                     <div className="relative flex h-full">
                                         {/* Drag Handle */}
                                         {resizable && (
+                                            // biome-ignore lint/a11y/noStaticElementInteractions: drag handle is pointer-only (no keyboard equivalent for continuous resize); ARIA role omitted to avoid useAriaPropsForRole false positive.
                                             <div
+                                                aria-label="Resize panel"
                                                 className={`absolute ${dragHandleClass} top-0 bottom-0 w-3 cursor-ew-resize hover:bg-indigo-500 transition-colors flex items-center justify-center`}
                                                 onMouseDown={handleDragStart}
                                             >

--- a/packages/ui/src/core/components/TagsInput.tsx
+++ b/packages/ui/src/core/components/TagsInput.tsx
@@ -1,7 +1,9 @@
 import clsx from 'clsx';
 import { X } from 'lucide-react';
 import { useContext, useEffect, useRef, useState } from 'react';
+import { Button } from './shadcn/button';
 import { Popover, PopoverContent, PopoverContext, PopoverTrigger } from './shadcn/popover';
+import { onActivateKey } from '../utils/a11y.js';
 
 interface TagsInputProps {
     options: string[];
@@ -226,6 +228,8 @@ function TagsInputContent({
     return (
         <div className={clsx('relative', className)}>
             <PopoverTrigger asChild>
+                {/* biome-ignore lint/a11y/noStaticElementInteractions: PopoverTrigger asChild forwards button semantics + keyboard to this div; container click is a focus delegation pattern. */}
+                {/* biome-ignore lint/a11y/useKeyWithClickEvents: same — keyboard is handled by the input and PopoverTrigger. */}
                 <div
                     ref={triggerRef}
                     className={clsx(
@@ -333,7 +337,11 @@ function TagsInputContent({
                                                     highlightedItemRef.current = el;
                                                 }
                                             }}
+                                            role="option"
+                                            aria-selected={index === highlightedIndex}
+                                            tabIndex={0}
                                             onClick={() => handleSelect(option)}
+                                            onKeyDown={onActivateKey(() => handleSelect(option))}
                                             onMouseEnter={() => setHighlightedIndex(index)}
                                             className={clsx(
                                                 'px-3 py-2 text-sm cursor-pointer transition-colors',
@@ -352,23 +360,25 @@ function TagsInputContent({
                                     {filteredOptions.length > 0 && (
                                         <div className="border-t border-border" />
                                     )}
-                                    <div
+                                    <Button
                                         ref={(el) => {
                                             if (highlightedIndex === filteredOptions.length) {
                                                 highlightedItemRef.current = el;
                                             }
                                         }}
+                                        variant="unstyled"
+                                        size="none"
                                         onClick={() => handleCreate(searchTerm)}
                                         onMouseEnter={() => setHighlightedIndex(filteredOptions.length)}
                                         className={clsx(
-                                            'px-3 py-2 text-sm cursor-pointer transition-colors text-primary',
+                                            '!flex w-full justify-start px-3 py-2 text-sm cursor-pointer transition-colors text-primary',
                                             highlightedIndex === filteredOptions.length
                                                 ? 'bg-blue-500/20'
                                                 : 'hover:bg-accent/50'
                                         )}
                                     >
                                         {createText.replace('%value%', searchTerm)}
-                                    </div>
+                                    </Button>
                                 </>
                             )}
                         </>

--- a/packages/ui/src/core/components/popup/PopupController.ts
+++ b/packages/ui/src/core/components/popup/PopupController.ts
@@ -66,7 +66,7 @@ export class PopupController {
             // register in the next event loop cycle since the current one
             // is may be triggered by a click event
             window.setTimeout(function () {
-                closeOnClick && document.addEventListener('click', closeOnClick);
+                if (closeOnClick) document.addEventListener('click', closeOnClick);
             }, 0);
         }
         let closeOnEsc: ((ev: KeyboardEvent) => void) | undefined;
@@ -77,7 +77,7 @@ export class PopupController {
                 }
             }
             window.setTimeout(function () {
-                closeOnEsc && document.addEventListener('keydown', closeOnEsc);
+                if (closeOnEsc) document.addEventListener('keydown', closeOnEsc);
             }, 0);
         }
         const blockPageScroll = this.options.blockPageScroll;
@@ -90,8 +90,8 @@ export class PopupController {
             for (const parent of parents) {
                 parent.removeEventListener('scroll', updateHandler);
             }
-            closeOnClick && document.removeEventListener('click', closeOnClick);
-            closeOnEsc && document.removeEventListener('keydown', closeOnEsc);
+            if (closeOnClick) document.removeEventListener('click', closeOnClick);
+            if (closeOnEsc) document.removeEventListener('keydown', closeOnEsc);
             if (blockPageScroll) {
                 document.body.style.overflow = "";
                 document.body.style.height = "";
@@ -119,7 +119,7 @@ export class PopupController {
         element.style.visibility = "hidden";
         // update the popup position
         this.update();
-        this.options.onOpen && this.options.onOpen(this);
+        this.options.onOpen?.(this);
     }
 
     close() {
@@ -132,7 +132,7 @@ export class PopupController {
         if (!this.context) {
             return; // do nothing if the popup is not open
         }
-        this.options.onClose && this.options.onClose(this);
+        this.options.onClose?.(this);
         this.context.cleanup();
         //TODO
         this.context.element.style.display = "none";

--- a/packages/ui/src/core/components/popup/position.ts
+++ b/packages/ui/src/core/components/popup/position.ts
@@ -192,7 +192,7 @@ class PositionResolver {
 
     computePosition(constraints: Constraints, elemRect: DOMRect, anchorRect: DOMRect): Position {
         this.position(constraints.position, anchorRect, elemRect);
-        constraints.align && this.align(constraints.align, anchorRect, elemRect);
+        if (constraints.align) this.align(constraints.align, anchorRect, elemRect);
         if (!this.left && !this.top) {
             throw new Error("Invalid position. Cannot compute x,y coordinates");
         }

--- a/packages/ui/src/core/components/popup/utils.ts
+++ b/packages/ui/src/core/components/popup/utils.ts
@@ -72,7 +72,7 @@ export function getScrollableParents(element: HTMLElement, root: HTMLElement = d
     let parent = element.parentElement;
 
     while (parent && parent !== root) {
-        isScrollable(parent) && parents.push(parent);
+        if (isScrollable(parent)) parents.push(parent);
         parent = parent.parentElement;
     }
 

--- a/packages/ui/src/core/components/shadcn/MessageBox.tsx
+++ b/packages/ui/src/core/components/shadcn/MessageBox.tsx
@@ -10,7 +10,7 @@ interface MessageBoxProps {
 }
 export function MessageBox({ icon, status, title, children, className }: MessageBoxProps) {
 
-    let defaultIcon, titleColor, textColor, bgColor;
+    let defaultIcon: React.ReactNode, titleColor: string, textColor: string, bgColor: string;
     switch (status) {
         case 'error': {
             defaultIcon = <CircleX className="size-5 text-destructive" aria-hidden="true" />

--- a/packages/ui/src/core/components/shadcn/badge.tsx
+++ b/packages/ui/src/core/components/shadcn/badge.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "../libs/utils"
+import { onActivateKey } from "../../utils/a11y.js"
 
 // Base badge variants
 const badgeVariants = cva(
@@ -33,10 +34,13 @@ interface BaseBadgeProps
 
 // Base Badge component
 export function Badge({ className, variant, children, onClick, ...props }: BaseBadgeProps) {
+  const interactiveProps = onClick
+    ? { role: "button", tabIndex: 0, onClick, onKeyDown: onActivateKey(onClick) }
+    : {};
   return (
     <span
       className={cn(badgeVariants({ variant }), className)}
-      onClick={onClick}
+      {...interactiveProps}
       {...props}
     >
       {children}

--- a/packages/ui/src/core/components/shadcn/button.tsx
+++ b/packages/ui/src/core/components/shadcn/button.tsx
@@ -143,7 +143,7 @@ interface CopyButtonProps {
   'aria-label'?: string
   size?: "xs" | "sm" | "md" | "lg" | "xl" | "icon"
   toast?: {
-    toast: any,
+    toast: (options: { status: "success" | "error"; title: string; duration: number }) => void,
     message: string
   }
   className?: string

--- a/packages/ui/src/core/components/shadcn/button.tsx
+++ b/packages/ui/src/core/components/shadcn/button.tsx
@@ -49,6 +49,7 @@ const buttonVariants = cva(
         lg: "h-10 rounded-md px-3",
         xl: 'rounded-md px-3.5 py-2.5 text-sm gap-x-2',
         icon: "p-0 m-0 rounded-full",
+        none: "",
       },
     },
     defaultVariants: {

--- a/packages/ui/src/core/components/shadcn/dropdown.tsx
+++ b/packages/ui/src/core/components/shadcn/dropdown.tsx
@@ -288,6 +288,7 @@ export function Dropdown({ trigger, children, align = 'right', hover }: Dropdown
     // rtl-ok: 'center' uses symmetric left-1/2 + -translate-x-1/2 (same in LTR/RTL)
     const alignClass = align === 'right' ? 'end-0' : align === 'center' ? 'left-1/2 -translate-x-1/2' : 'start-0';
     return (
+      // biome-ignore lint/a11y/noStaticElementInteractions: hover wrapper only; the `trigger` child is responsible for focus/keyboard semantics.
       <div className="relative inline-flex" onMouseEnter={onEnter} onMouseLeave={onLeave}>
         {trigger}
         {open && (

--- a/packages/ui/src/core/components/shadcn/filters/comboBox/DateCombobox.tsx
+++ b/packages/ui/src/core/components/shadcn/filters/comboBox/DateCombobox.tsx
@@ -63,7 +63,7 @@ export const DateCombobox = ({
         }
     };
 
-    const handleDateChange = (date: any) => {
+    const handleDateChange = (date: unknown) => {
         if (isRange) {
             // Update local state immediately for visual feedback
             if (Array.isArray(date)) {

--- a/packages/ui/src/core/components/shadcn/filters/filterBar.tsx
+++ b/packages/ui/src/core/components/shadcn/filters/filterBar.tsx
@@ -5,7 +5,7 @@ import { Popover, PopoverTrigger, PopoverContent } from "../popover";
 import { Command, CommandInput, CommandList, CommandGroup, CommandItem, CommandEmpty } from "../command";
 import { ListFilter } from "lucide-react";
 
-import { Filter, FilterGroup } from "./types";
+import { Filter, FilterGroup, FilterOption } from "./types";
 import Filters from "./filters";
 
 import TextFilter from "./filter/TextFilter";
@@ -18,7 +18,11 @@ const FilterContext = React.createContext<{
   filters: Filter[];
   setFilters: Dispatch<SetStateAction<Filter[]>>;
   filterGroups: FilterGroup[];
-}>({} as any);
+}>({
+  filters: [],
+  setFilters: () => undefined,
+  filterGroups: [],
+});
 
 interface FilterProviderProps {
   filters: Filter[];
@@ -48,14 +52,14 @@ const FilterProvider = ({ filters, setFilters, filterGroups, children, inModal }
       const params = new URLSearchParams(searchParams.toString());
       if (filters.length > 0) {
         const filterString = filters.map(filter => {
-          let values;
+          let values: string;
           if (filter.type === 'stringList' && Array.isArray(filter.value) && typeof filter.value[0] === 'string') {
             values = `[${(filter.value as string[]).map(item => encodeURIComponent(item)).join(',')}]`;
           } else if (Array.isArray(filter.value)) {
             if (filter.multiple) {
-              values = `[${filter.value.map((item: any) => encodeURIComponent(item.value || item || '')).join(',')}]`;
+              values = `[${filter.value.map(item => encodeURIComponent(readFilterValue(item))).join(',')}]`;
             } else if (filter.value.length > 1) {
-              values = `[${filter.value.map((item: any) => encodeURIComponent(item.value || item || '')).join(',')}]`;
+              values = `[${filter.value.map(item => encodeURIComponent(readFilterValue(item))).join(',')}]`;
             } else {
               const firstValue = filter.value[0];
               if (typeof firstValue === 'string') {
@@ -108,7 +112,7 @@ const FilterProvider = ({ filters, setFilters, filterGroups, children, inModal }
           values = [decodeURIComponent(valuesString)];
         }
 
-        let filterValue;
+        let filterValue: FilterOption[] | string[];
 
         if (group.type === 'stringList') {
           filterValue = values;
@@ -191,7 +195,7 @@ const FilterBtn = ({ className }: { className?: string }) => {
           return filter.name === group.name &&
             (Array.isArray(filter.value) && typeof filter.value[0] === 'string'
               ? filter.value.some(val => val === option.value)
-              : filter.value.some(val => (val as any).value === option.value));
+              : filter.value.some(val => readFilterValue(val) === option.value));
         })
       )
     })).filter(group =>
@@ -365,5 +369,9 @@ const FilterClear = ({ className }: { className?: string }) => {
     </Button>
   );
 };
+
+function readFilterValue(item: string | FilterOption): string {
+  return typeof item === 'string' ? item : item.value || '';
+}
 
 export { FilterProvider, FilterBtn, FilterBar, FilterClear };

--- a/packages/ui/src/core/components/shadcn/filters/filters.tsx
+++ b/packages/ui/src/core/components/shadcn/filters/filters.tsx
@@ -21,7 +21,7 @@ function generateComboboxOptions(
         case "date":
             return (
                 <DateCombobox
-                    filterValues={Array.isArray(filter.value) && typeof filter.value[0] === 'object' ? filter.value.map((v: any) => v.value || '') : []}
+                    filterValues={Array.isArray(filter.value) && typeof filter.value[0] === 'object' ? (filter.value as FilterOption[]).map((v) => v.value || '') : []}
                     isRange={filter.multiple}
                     setFilterValues={(filterValues) => {
                         setFilters((prev) =>
@@ -114,7 +114,7 @@ export default function Filters({
             {filters
                 .filter((filter) => filter.value?.length > 0)
                 .map((filter) => (
-                    <div className="flex gap-[1px] items-center text-sm" key={filter.name + '-' + (filter.type == 'date' ? 'date' : filter.type === 'stringList' && typeof filter.value[0] === 'string' ? (filter.value as string[]).join(',') : Array.isArray(filter.value) ? filter.value.map((v: any) => v.value).join(',') : '')}>
+                    <div className="flex gap-[1px] items-center text-sm" key={filter.name + '-' + (filter.type == 'date' ? 'date' : filter.type === 'stringList' && typeof filter.value[0] === 'string' ? (filter.value as string[]).join(',') : Array.isArray(filter.value) ? (filter.value as FilterOption[]).map((v) => v.value).join(',') : '')}>
                         <div className="flex gap-1.5 shrink-0 rounded-s bg-muted p-1.5 h-8 items-center">
                             {filter.placeholder || filter.name}
                         </div>

--- a/packages/ui/src/core/components/shadcn/input.tsx
+++ b/packages/ui/src/core/components/shadcn/input.tsx
@@ -52,11 +52,11 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, size = "md", variant = "default", clearable = true, onChange, value, invalid, ...props }, ref) => {
 
     const _onClear = () => {
-      onChange && onChange('');
+      onChange?.('');
     };
 
     const _onChange = (ev: ChangeEvent<HTMLInputElement>) => {
-      onChange && onChange(ev.target.value);
+      onChange?.(ev.target.value);
     };
 
     // Map `invalid` to aria-invalid unless the consumer already set it explicitly.

--- a/packages/ui/src/core/components/shadcn/modal/DeleteModal.tsx
+++ b/packages/ui/src/core/components/shadcn/modal/DeleteModal.tsx
@@ -8,7 +8,7 @@ interface DeleteModalProps {
     title: string;
     content: string | ReactNode;
     setIdToDelete: (id: string | undefined) => void;
-    deleteApi: (id: string) => Promise<any>;
+    deleteApi: (id: string) => Promise<unknown>;
 }
 export function DeleteModal({ idToDelete, title, content, setIdToDelete, deleteApi }: DeleteModalProps) {
     const { t } = useUITranslation();
@@ -25,10 +25,10 @@ export function DeleteModal({ idToDelete, title, content, setIdToDelete, deleteA
                     title: t('modal.delete.succeeded'),
                     status: 'success'
                 });
-            }).catch((err: any) => {
+            }).catch((err: unknown) => {
                 toast({
                     title: t('modal.delete.failed'),
-                    description: err.message ?? t('modal.delete.error'),
+                    description: err instanceof Error ? err.message : t('modal.delete.error'),
                     status: 'error'
                 });
             }).finally(() => {

--- a/packages/ui/src/core/components/shadcn/selectBox.tsx
+++ b/packages/ui/src/core/components/shadcn/selectBox.tsx
@@ -60,7 +60,7 @@ interface SelectBoxMultipleProps<T> extends SelectBoxBaseProps<T> {
 
 type SelectBoxProps<T> = SelectBoxSingleProps<T> | SelectBoxMultipleProps<T>;
 
-export function SelectBox<T = any>({
+export function SelectBox<T = unknown>({
     options,
     optionLabel,
     value,
@@ -102,7 +102,7 @@ export function SelectBox<T = any>({
         // Use the isOptionsEqual helper which respects the 'by' comparator
         return !options.some(opt => {
             if (typeof by === 'string') {
-                return (opt as any)[by] === (value as any)[by];
+                return getProperty(opt, by) === getProperty(value, by);
             } else if (typeof by === 'function') {
                 return by(opt, value as T);
             } else {
@@ -134,7 +134,7 @@ export function SelectBox<T = any>({
         };
     }, []);
 
-    const _onClick = (opt: any) => {
+    const _onClick = (opt: T) => {
         if (multiple) {
             const currentValues = Array.isArray(value) ? value : [];
             const isSelected = isOptionSelected(opt, currentValues);
@@ -169,7 +169,7 @@ export function SelectBox<T = any>({
         }
 
         if (typeof by === 'string') {
-            return (a as any)[by] === (b as any)[by];
+                return getProperty(a, by) === getProperty(b, by);
         } else if (typeof by === 'function') {
             return by(a, b);
         } else {
@@ -183,7 +183,7 @@ export function SelectBox<T = any>({
         if (!filterBy) {
             return (o: T) => String(o).toLowerCase();
         } else if (typeof filterBy === 'string') {
-            return (o: any) => String(o[filterBy]).toLowerCase();
+            return (o: T) => String(getProperty(o, filterBy)).toLowerCase();
         } else {
             return filterBy;
         }
@@ -402,7 +402,7 @@ export function SelectBox<T = any>({
                             if (multiple) {
                                 (onChange as (options: T[]) => void)([] as T[]);
                             } else {
-                                (onChange as (option: T) => void)(undefined as any);
+                                (onChange as (option: T) => void)(undefined as T);
                             }
                         }}
                         onKeyDown={(e) => {
@@ -430,4 +430,8 @@ export function SelectBox<T = any>({
             </PopoverContent>
         </Popover>
     );
+}
+
+function getProperty(value: unknown, key: string): unknown {
+    return typeof value === 'object' && value !== null ? (value as Record<string, unknown>)[key] : undefined;
 }

--- a/packages/ui/src/core/hooks/CompositeState.tsx
+++ b/packages/ui/src/core/hooks/CompositeState.tsx
@@ -3,7 +3,7 @@ import React, { ReactNode, useContext, useEffect, useState } from "react";
 //type KeysOfType<T, V> = { [K in keyof T]-?: T[K] extends V ? K : never }[keyof T];
 //type KeysNotOfType<T, V> = { [K in keyof T]-?: T[K] extends V ? never : K }[keyof T];
 
-export class Property<V = any> {
+export class Property<V = unknown> {
     private _value?: V;
     private watchers: ((value: V | undefined) => void)[] = [];
     /**
@@ -46,9 +46,9 @@ interface ContextContainer<T> {
     Context: React.Context<T>
 }
 
-type ConstructorOf<T = any> = new (...args: any[]) => T;
+type ConstructorOf<T = unknown> = new (...args: never[]) => T;
 export function createCompositeStateProvider<T>(StateClass: ConstructorOf<T>) {
-    const context = React.createContext<T>(undefined as any);
+    const context = React.createContext<T>(undefined as T);
     (StateClass as unknown as ContextContainer<T>).Context = context;
     return context.Provider;
 }
@@ -219,7 +219,7 @@ export function useDefineSlot(slot: Slot, value: ReactNode | undefined) {
  * @important Remember to call dispose() when the ComputedProperty is no longer needed
  * to prevent memory leaks by unsubscribing from all dependencies.
  */
-export class ComputedProperty<V = any> {
+export class ComputedProperty<V = unknown> {
     private _value?: V;
     private watchers: ((value: V | undefined) => void)[] = [];
     private unsubscribers: (() => void)[] = [];
@@ -236,7 +236,7 @@ export class ComputedProperty<V = any> {
      */
     constructor(
         private compute: () => V,
-        dependencies: Property<any>[],
+        dependencies: Property<unknown>[],
         name?: string
     ) {
         this.name = name;

--- a/packages/ui/src/core/hooks/CompositeState.tsx
+++ b/packages/ui/src/core/hooks/CompositeState.tsx
@@ -76,7 +76,7 @@ export class Slot {
 
     withConsumer(consume: ((content: ReactNode) => void) | undefined) {
         this.consume = consume;
-        consume && consume(this.current);
+        consume?.(this.current);
         return this;
     }
 }

--- a/packages/ui/src/core/hooks/SharedState.tsx
+++ b/packages/ui/src/core/hooks/SharedState.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-export class SharedState<V = any> {
+export class SharedState<V = unknown> {
     _value: V;
     watchers: ((value: V) => void)[] = [];
     constructor(value: V) {

--- a/packages/ui/src/core/hooks/useFetch.ts
+++ b/packages/ui/src/core/hooks/useFetch.ts
@@ -23,18 +23,18 @@ export function useFetch<T = unknown>(fetcher: () => Promise<T>, opts?: FetchOpt
     const [isLoading, setIsLoading] = useState(false);
     const [data, setData] = useState<T | undefined>(options.defaultValue);
     const fetch = () => {
-        options.start && options.start();
+        options.start?.();
         setIsLoading(true);
         return fetcher().then((result: T) => {
             setData(result);
-            options.onSuccess && options.onSuccess(result);
+            options.onSuccess?.(result);
         }).catch(error => {
             const err = toError(error);
             setError(err);
-            options.onError && options.onError(err);
+            options.onError?.(err);
         }).finally(() => {
             setIsLoading(false);
-            options.end && options.end();
+            options.end?.();
         });
     }
     useEffect(() => {

--- a/packages/ui/src/core/hooks/useFetch.ts
+++ b/packages/ui/src/core/hooks/useFetch.ts
@@ -4,18 +4,22 @@ export interface FetchOpts<T> {
     start?: () => void,
     end?: () => void,
     defaultValue?: T | (() => T),
-    deps?: any[] | undefined,
+    deps?: unknown[] | undefined,
     condition?: () => boolean,
     onSuccess?: (data: T) => void,
-    onError?: (err: any) => void,
+    onError?: (err: unknown) => void,
 }
 
-export function useFetch<T = any>(fetcher: () => Promise<T>, opts?: FetchOpts<T> | any[] | undefined | null) {
+function toError(error: unknown) {
+    return error instanceof Error ? error : new Error(String(error));
+}
+
+export function useFetch<T = unknown>(fetcher: () => Promise<T>, opts?: FetchOpts<T> | unknown[] | undefined | null) {
     if (Array.isArray(opts)) {
         opts = { deps: opts };
     }
     const options = (opts || {}) as FetchOpts<T>;
-    const [error, setError] = useState<any>(null);
+    const [error, setError] = useState<Error | undefined>(undefined);
     const [isLoading, setIsLoading] = useState(false);
     const [data, setData] = useState<T | undefined>(options.defaultValue);
     const fetch = () => {
@@ -25,8 +29,9 @@ export function useFetch<T = any>(fetcher: () => Promise<T>, opts?: FetchOpts<T>
             setData(result);
             options.onSuccess && options.onSuccess(result);
         }).catch(error => {
-            setError(error);
-            options.onError && options.onError(error);
+            const err = toError(error);
+            setError(err);
+            options.onError && options.onError(err);
         }).finally(() => {
             setIsLoading(false);
             options.end && options.end();
@@ -41,7 +46,7 @@ export function useFetch<T = any>(fetcher: () => Promise<T>, opts?: FetchOpts<T>
     return { data, isLoading, error, setData, refetch: fetch };
 }
 
-export function useFetchOnce<T>(fetcher: () => Promise<T>, opts?: FetchOpts<T> | any[] | undefined | null) {
+export function useFetchOnce<T>(fetcher: () => Promise<T>, opts?: FetchOpts<T> | unknown[] | undefined | null) {
     if (!opts || Array.isArray(opts)) {
         opts = { deps: [] };
     } else if (opts) {

--- a/packages/ui/src/core/hooks/useIntersectionObserver.tsx
+++ b/packages/ui/src/core/hooks/useIntersectionObserver.tsx
@@ -7,7 +7,7 @@ import { RefObject, useEffect } from "react";
  * @param cb
  * @param opts
  */
-export function useIntersectionObserver(target: RefObject<HTMLElement | null | undefined>, cb: (entry: IntersectionObserverEntry) => void, opts: { leave?: boolean, threshold?: number, deps?: any[] } = {}) {
+export function useIntersectionObserver(target: RefObject<HTMLElement | null | undefined>, cb: (entry: IntersectionObserverEntry) => void, opts: { leave?: boolean, threshold?: number, deps?: unknown[] } = {}) {
 
     useEffect(() => {
         const observer = new IntersectionObserver(

--- a/packages/ui/src/core/hooks/useScrollableSearch.tsx
+++ b/packages/ui/src/core/hooks/useScrollableSearch.tsx
@@ -91,7 +91,7 @@ interface ScrollableSearchResult<ResultT, PayloadT, PageT = number> {
 /**
  * A hook that provides paginated search functionality with infinite scrolling support.
  */
-export function useScrollableSearch<ResultT, PayloadT, PageT = number>(opts: ScrollableSearchOptions<ResultT, PayloadT, PageT>, dependencies: any[] = []): ScrollableSearchResult<ResultT, PayloadT, PageT> {
+export function useScrollableSearch<ResultT, PayloadT, PageT = number>(opts: ScrollableSearchOptions<ResultT, PayloadT, PageT>, dependencies: unknown[] = []): ScrollableSearchResult<ResultT, PayloadT, PageT> {
     const pageSize = opts.pageSize || 50;
     const [page, setPage] = useState<PageT | null>(null);
     const [lastPayload, setLastPayload] = useState<PayloadT>(opts.payload);
@@ -176,7 +176,7 @@ interface DefaultScrollableSearchOptions<ResultT, PayloadT> extends Omit<Scrolla
     search: DefaultSearchFn<PayloadT, ResultT>;
 }
 
-export function useDefaultScrollableSearch<ResultT, PayloadT>(opts: DefaultScrollableSearchOptions<ResultT, PayloadT>, dependencies: any[] = []): ScrollableSearchResult<ResultT, PayloadT, number> {
+export function useDefaultScrollableSearch<ResultT, PayloadT>(opts: DefaultScrollableSearchOptions<ResultT, PayloadT>, dependencies: unknown[] = []): ScrollableSearchResult<ResultT, PayloadT, number> {
     const actualOpts: ScrollableSearchOptions<ResultT, PayloadT, number> = {
         ...opts,
         async search(payload, page, pageSize) {

--- a/packages/ui/src/core/utils/a11y.ts
+++ b/packages/ui/src/core/utils/a11y.ts
@@ -1,0 +1,23 @@
+import type { KeyboardEvent } from "react";
+
+/**
+ * Returns an `onKeyDown` handler that fires the given callback when the user presses
+ * Enter or Space. Use on non-button elements that have an `onClick` handler to satisfy
+ * keyboard accessibility (pairs with `role="button"` and `tabIndex={0}`).
+ *
+ * @example
+ *   <div
+ *     role="button"
+ *     tabIndex={0}
+ *     onClick={handler}
+ *     onKeyDown={onActivateKey(handler)}
+ *   />
+ */
+export function onActivateKey<E extends Element>(callback: (event: KeyboardEvent<E>) => void) {
+    return (event: KeyboardEvent<E>) => {
+        if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            callback(event);
+        }
+    };
+}

--- a/packages/ui/src/core/utils/errorMessage.ts
+++ b/packages/ui/src/core/utils/errorMessage.ts
@@ -1,0 +1,20 @@
+interface ErrorLike {
+    message?: unknown;
+}
+
+function hasMessage(error: unknown): error is ErrorLike {
+    return typeof error === 'object' && error !== null && 'message' in error;
+}
+
+export function errorMessage(error: unknown, fallback = 'An error occurred'): string {
+    if (error instanceof Error) {
+        return error.message;
+    }
+    if (typeof error === 'string') {
+        return error;
+    }
+    if (hasMessage(error) && typeof error.message === 'string') {
+        return error.message;
+    }
+    return fallback;
+}

--- a/packages/ui/src/core/utils/index.ts
+++ b/packages/ui/src/core/utils/index.ts
@@ -1,1 +1,2 @@
 export * from "./cn.js";
+export * from "./errorMessage.js";

--- a/packages/ui/src/core/utils/index.ts
+++ b/packages/ui/src/core/utils/index.ts
@@ -1,2 +1,3 @@
+export * from "./a11y.js";
 export * from "./cn.js";
 export * from "./errorMessage.js";

--- a/packages/ui/src/env/index.ts
+++ b/packages/ui/src/env/index.ts
@@ -27,10 +27,10 @@ export interface EnvProps {
     datadogRum?: boolean,
     datadogLogs?: boolean,
     logger?: {
-        info: (msg: string, ...args: any) => void,
-        warn: (msg: string, ...args: any) => void,
-        error: (msg: string, ...args: any) => void,
-        debug: (msg: string, ...args: any) => void,
+        info: (msg: string, ...args: unknown[]) => void,
+        warn: (msg: string, ...args: unknown[]) => void,
+        error: (msg: string, ...args: unknown[]) => void,
+        debug: (msg: string, ...args: unknown[]) => void,
     }
     onLogin?: (token: AuthTokenPayload) => void,
     onLogout?: () => void,

--- a/packages/ui/src/features/agent/chat/ImageLightbox.tsx
+++ b/packages/ui/src/features/agent/chat/ImageLightbox.tsx
@@ -1,5 +1,5 @@
 import { useState, createContext, useContext, useCallback, ReactNode } from "react";
-import { Button } from "@vertesia/ui/core";
+import { Button, onActivateKey } from "@vertesia/ui/core";
 import { X, ExternalLink } from "lucide-react";
 import { useUITranslation } from '@vertesia/ui/i18n';
 
@@ -43,9 +43,14 @@ export function ImageLightboxProvider({ children }: ImageLightboxProviderProps) 
         <ImageLightboxContext.Provider value={{ openImage, closeImage }}>
             {children}
             {image && (
+                // biome-ignore lint/a11y/useSemanticElements: backdrop contains nested Button + <a> tags; button-in-button is invalid HTML so role="button" on a div is the pragmatic choice.
                 <div
+                    role="button"
+                    tabIndex={-1}
+                    aria-label={t('agent.close')}
                     className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 backdrop-blur-sm"
                     onClick={closeImage}
+                    onKeyDown={onActivateKey(closeImage)}
                 >
                     <div className="relative max-w-[90vw] max-h-[90vh]">
                         <img
@@ -91,15 +96,23 @@ interface LightboxImageProps {
 export function LightboxImage({ src, alt, className }: LightboxImageProps) {
     const { openImage } = useImageLightbox();
 
+    const open = () => openImage(src, alt);
+
     return (
-        <img
-            src={src}
-            alt={alt}
-            className={`cursor-pointer hover:opacity-90 transition-opacity ${className || ""}`}
+        <Button
+            variant="unstyled"
+            className="block p-0"
             onClick={(e) => {
                 e.stopPropagation();
-                openImage(src, alt);
+                open();
             }}
-        />
+            aria-label={alt || src}
+        >
+            <img
+                src={src}
+                alt={alt}
+                className={`cursor-pointer hover:opacity-90 transition-opacity ${className || ""}`}
+            />
+        </Button>
     );
 }

--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
@@ -515,6 +515,7 @@ function StartWorkflowView({
 
     return (
         <div className="flex flex-col h-full bg-background items-center">
+            {/* biome-ignore lint/a11y/noStaticElementInteractions: drag/drop target only; file selection is also exposed via the upload button. */}
             <div
                 className={cn(
                     "flex flex-col h-full w-full overflow-hidden border-0 relative",
@@ -1525,6 +1526,7 @@ const handleCloseRightPanel = useCallback(() => {
     const mainContent = (
         <ArtifactUrlCacheProvider>
         <ImageLightboxProvider>
+        {/* biome-ignore lint/a11y/noStaticElementInteractions: drag/drop target only; file selection is also exposed via the upload button. */}
         <div
             ref={conversationLayoutRef}
             className={cn("flex flex-col lg:flex-row gap-2 w-full h-full relative overflow-hidden", isDragOver && "ring-2 ring-blue-400 ring-inset", className)}

--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
@@ -469,7 +469,7 @@ function StartWorkflowView({
                     duration: 3000,
                 });
             }
-        } catch (err: any) {
+        } catch (err: unknown) {
             toast({
                 title: t('agent.errorStarting'),
                 status: "error",
@@ -1173,7 +1173,7 @@ const handleCloseRightPanel = useCallback(() => {
             })
             .catch((err) => {
                 removeOptimisticMessages((m) =>
-                    (m.details as any)?._messageId === messageId
+                    m.details?._messageId === messageId
                 );
                 toast({
                     status: "error",

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/BatchProgressPanel.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/BatchProgressPanel.tsx
@@ -1,5 +1,5 @@
 import { AgentMessage, BatchProgressDetails, BatchItemStatus } from "@vertesia/common";
-import { Button, cn, useToast } from "@vertesia/ui/core";
+import { Button, cn, onActivateKey, useToast } from "@vertesia/ui/core";
 import dayjs from "dayjs";
 import {
     CheckCircle,
@@ -119,9 +119,14 @@ function BatchProgressPanelComponent({
     return (
         <div className={cn("border-s-4 shadow-md overflow-hidden bg-white dark:bg-gray-900 mb-5", getBorderColor(), className)}>
             {/* Header */}
+            {/* biome-ignore lint/a11y/useSemanticElements: header contains nested Buttons (copy, etc.); button-in-button is invalid HTML so role="button" on a div is the pragmatic choice. */}
             <div
+                role="button"
+                tabIndex={0}
+                aria-expanded={isExpanded}
                 className={cn("flex items-center justify-between px-4 py-2 border-b border-gray-100/80 dark:border-gray-800/80 bg-blue-50/50 dark:bg-blue-900/10 cursor-pointer", headerClassName)}
                 onClick={() => setIsExpanded(!isExpanded)}
+                onKeyDown={onActivateKey(() => setIsExpanded(!isExpanded))}
             >
                 <div className="flex items-center gap-2">
                     {renderStatusIndicator()}

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageInput.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageInput.tsx
@@ -299,6 +299,7 @@ export default function MessageInput({
 
 
     return (
+        // biome-ignore lint/a11y/noStaticElementInteractions: drag/drop target only; file selection is also exposed via the upload button.
         <div
             className={cn("p-3 border-t border-muted flex-shrink-0 transition-all fixed lg:sticky bottom-0 start-0 end-0 lg:start-auto lg:end-auto w-full bg-background z-10", isDragOver && "bg-blue-50 dark:bg-blue-900/20 border-blue-400", className)}
             style={{ minHeight: "120px" }}

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageInput.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageInput.tsx
@@ -1,7 +1,7 @@
 import { Button, Spinner, Modal, ModalBody, ModalTitle, VTooltip, cn, Textarea } from "@vertesia/ui/core";
 import { Activity, FileTextIcon, HelpCircleIcon, PaperclipIcon, SendIcon, StopCircleIcon, UploadIcon, XIcon } from "lucide-react";
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { ConversationFile, FileProcessingStatus } from "@vertesia/common";
+import { ContentObjectItem, ConversationFile, FileProcessingStatus } from "@vertesia/common";
 import { SelectDocument } from "../../../store";
 import { useUITranslation } from '@vertesia/ui/i18n';
 
@@ -269,7 +269,7 @@ export default function MessageInput({
         adjustTextareaHeight();
     }, [value, adjustTextareaHeight]);
 
-    const handleObjectSelect = (object: any) => {
+    const handleObjectSelect = (object: ContentObjectItem) => {
         // Create a markdown link with the object title and ID
         const objectTitle = object.properties?.title || object.name || 'Object';
         const objectId = object.id;

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageItem.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageItem.tsx
@@ -333,13 +333,19 @@ function MessageItemComponent({
         },
         img: ({ node, ref, ...props }: { node?: unknown; ref?: unknown; src?: string; alt?: string }) => {
             return (
-                <img
-                    {...props}
-                    alt={props.alt ?? ""}
-                    className="max-w-full h-auto rounded-lg shadow-md my-3 cursor-pointer hover:shadow-lg transition-shadow"
-                    loading="lazy"
+                <Button
+                    variant="unstyled"
+                    className="block p-0"
                     onClick={() => props.src && openImage(props.src, props.alt)}
-                />
+                    aria-label={props.alt || props.src || 'image'}
+                >
+                    <img
+                        {...props}
+                        alt={props.alt ?? ""}
+                        className="max-w-full h-auto rounded-lg shadow-md my-3 cursor-pointer hover:shadow-lg transition-shadow"
+                        loading="lazy"
+                    />
+                </Button>
             );
         },
     }), [openImage, StoreLinkComponent, CollectionLinkComponent]);
@@ -558,10 +564,12 @@ function MessageItemComponent({
                                 {artifactLinks
                                     .filter(a => a.isImage)
                                     .map(({ displayName, artifactPath, url }) => (
-                                        <div
+                                        <Button
+                                            variant="unstyled"
                                             key={`${artifactPath}-preview`}
-                                            className="max-w-xs cursor-pointer"
+                                            className="max-w-xs cursor-pointer text-start p-0"
                                             onClick={() => openImage(url, displayName)}
+                                            aria-label={displayName}
                                         >
                                             <img
                                                 src={url}
@@ -571,7 +579,7 @@ function MessageItemComponent({
                                             <div className="mt-1 text-[11px] text-muted truncate">
                                                 {displayName}
                                             </div>
-                                        </div>
+                                        </Button>
                                     ))}
                             </div>
                         )}

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageItem.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageItem.tsx
@@ -293,7 +293,7 @@ function MessageItemComponent({
 
     // PERFORMANCE: Memoize markdown components to prevent MarkdownRenderer remounts
     const markdownComponents = useMemo(() => ({
-        a: ({ node, ref, ...props }: { node?: any; ref?: any; href?: string; children?: React.ReactNode }) => {
+        a: ({ node, ref, ...props }: { node?: unknown; ref?: unknown; href?: string; children?: React.ReactNode }) => {
             const href = props.href || "";
             if (href.includes("/store/objects")) {
                 if (StoreLinkComponent) {
@@ -331,7 +331,7 @@ function MessageItemComponent({
                 />
             );
         },
-        img: ({ node, ref, ...props }: { node?: any; ref?: any; src?: string; alt?: string }) => {
+        img: ({ node, ref, ...props }: { node?: unknown; ref?: unknown; src?: string; alt?: string }) => {
             return (
                 <img
                     {...props}
@@ -356,12 +356,12 @@ function MessageItemComponent({
         }
 
         // Handle string content with markdown - content is already processed
-        const runId = (message as any).workflow_run_id as string | undefined;
+        const runId = message.workflow_run_id;
 
         if (!runId && typeof content === 'string' && content.includes('artifact:')) {
             console.warn('[MessageItem] message contains artifact references but workflow_run_id is missing!', {
                 type: message.type,
-                workflow_run_id: (message as any).workflow_run_id,
+                workflow_run_id: message.workflow_run_id,
                 hasArtifact: content.includes('artifact:'),
             });
         }
@@ -386,10 +386,10 @@ function MessageItemComponent({
     >([]);
 
     // Create stable key from message for dependency tracking
-    const runId = (message as any).workflow_run_id as string | undefined;
-    const details = message.details as any;
+    const runId = message.workflow_run_id;
+    const details = message.details;
     // Check both outputFiles (from execute_shell) and files (from tool results like dashboard tools)
-    const outputFiles: unknown = details?.outputFiles ?? details?.files;
+    const outputFiles = details?.outputFiles ?? details?.files;
     const outputFilesKey = Array.isArray(outputFiles) ? outputFiles.join(",") : "";
 
     useEffect(() => {

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/SlideInPanel.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/SlideInPanel.tsx
@@ -38,10 +38,14 @@ export default function SlideInPanel({
     return (
         <>
             {/* Backdrop overlay */}
-            <div 
-                className={`fixed inset-0 bg-black/10 dark:bg-black/30 z-40 transition-opacity duration-300 ${
+            <Button
+                variant="unstyled"
+                size="none"
+                aria-label="Close panel"
+                tabIndex={-1}
+                className={`!fixed inset-0 bg-black/10 dark:bg-black/30 z-40 transition-opacity duration-300 ${
                     isOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'
-                }`} 
+                }`}
                 onClick={onClose}
             />
             

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/ToolCallGroup.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/ToolCallGroup.tsx
@@ -1,5 +1,5 @@
 import { AgentMessage, AgentMessageType } from "@vertesia/common";
-import { Button, cn, useToast } from "@vertesia/ui/core";
+import { Button, cn, onActivateKey, useToast } from "@vertesia/ui/core";
 import { useUserSession } from "@vertesia/ui/session";
 import { MarkdownRenderer } from "@vertesia/ui/widgets";
 import dayjs from "dayjs";
@@ -180,18 +180,20 @@ function FileDisplay({ files, className: fileClassName }: { files: string[]; cla
                 const fileName = file.split('/').pop()?.split('?')[0] || 'file';
                 if (isImageUrl(file)) {
                     return (
-                        <div
+                        <Button
+                            variant="unstyled"
                             key={idx}
-                            className="cursor-pointer"
+                            className="cursor-pointer p-0"
                             onClick={() => openImage(file, fileName)}
                             title={t('agent.clickToEnlarge')}
+                            aria-label={fileName}
                         >
                             <img
                                 src={file}
                                 alt={fileName}
                                 className="max-w-[300px] max-h-[200px] rounded border hover:opacity-80 transition-opacity hover:shadow-lg"
                             />
-                        </div>
+                        </Button>
                     );
                 }
                 return (
@@ -338,9 +340,13 @@ function ToolCallItem({ message, isExpanded, onToggle, artifactRunId, classNames
     return (
         <div className={cn("border-b border-gray-100 dark:border-gray-800 last:border-b-0", classNames.itemClassName)}>
             {/* Collapsed header - always visible */}
+            {/* biome-ignore lint/a11y/useSemanticElements: header contains nested Buttons (copy); button-in-button is invalid HTML so role="button" on a div is the pragmatic choice. */}
             <div
+                role="button"
+                tabIndex={0}
                 className={cn("flex items-start justify-between px-3 py-2 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors", classNames.itemHeaderClassName)}
                 onClick={onToggle}
+                onKeyDown={onActivateKey(onToggle)}
             >
                 <div className="flex items-start gap-2 flex-1 min-w-0">
                     <div className="flex-shrink-0 pt-0.5">
@@ -728,9 +734,14 @@ function ToolCallGroupComponent({
             className={cn("border-s-4 overflow-hidden bg-white dark:bg-gray-900 mb-4", getBorderColor(), rootClassName)}
         >
             {/* Compact header */}
+            {/* biome-ignore lint/a11y/useSemanticElements: header contains nested Buttons; button-in-button is invalid HTML so role="button" on a div is the pragmatic choice. */}
             <div
+                role="button"
+                tabIndex={0}
+                aria-expanded={!isCollapsed}
                 className={cn("flex items-center justify-between px-4 py-1.5 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors", headerClassName)}
                 onClick={() => setIsCollapsed(!isCollapsed)}
+                onKeyDown={onActivateKey(() => setIsCollapsed(!isCollapsed))}
             >
                 <div className="flex items-center gap-1 flex-1 min-w-0">
                     {renderStatusIndicator()}
@@ -807,9 +818,14 @@ function ToolCallGroupComponent({
                                 }}
                             >
                                 {/* Row header - clickable to expand */}
+                                {/* biome-ignore lint/a11y/useSemanticElements: header contains nested Buttons; button-in-button is invalid HTML so role="button" on a div is the pragmatic choice. */}
                                 <div
+                                    role="button"
+                                    tabIndex={0}
+                                    aria-expanded={isItemExpanded}
                                     className={cn("flex items-start gap-2 py-1.5 text-xs cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50", itemHeaderClassName)}
                                     onClick={() => toggleItem(idx)}
+                                    onKeyDown={onActivateKey(() => toggleItem(idx))}
                                     title={fullMessage}
                                 >
                                     <div className="flex-shrink-0 pt-0.5">

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/ToolCallGroup.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/ToolCallGroup.tsx
@@ -125,7 +125,7 @@ function mergeByToolRunId(messages: AgentMessage[]): AgentMessage[] {
         // message text from the running message (message_to_human) if the
         // completed message has no text or empty text.
         const base = msgs[msgs.length - 1];
-        const runningMsg = msgs.find(m => (m.details as any)?.tool_status === 'running');
+        const runningMsg = msgs.find(m => m.details?.tool_status === 'running');
 
         if (runningMsg && (!base.message || base.message.trim() === '') && runningMsg.message) {
             // Merge: use running message text with completed message details
@@ -425,7 +425,7 @@ function ToolCallItem({ message, isExpanded, onToggle, artifactRunId, classNames
 
                         {/* Show observation from details if available and different from header text */}
                         {(() => {
-                            const observation = (details as any)?.observation as string | undefined;
+                            const observation = typeof details?.observation === 'string' ? details.observation : undefined;
                             if (observation && observation !== messageContent) {
                                 return (
                                     <div className="vprose prose prose-slate dark:prose-invert prose-p:leading-relaxed prose-p:my-1.5 max-w-none text-sm">
@@ -626,8 +626,8 @@ function ToolCallGroupComponent({
     const toast = useToast();
 
     // Extract workflow_run_id from messages (any message in the group should have it)
-    const artifactRunId = messages.find(m => (m as any).workflow_run_id)?.workflow_run_id as string | undefined
-        ?? (messages[0] as any)?.workflow_run_id;
+    const artifactRunId = messages.find(m => m.workflow_run_id)?.workflow_run_id
+        ?? messages[0]?.workflow_run_id;
 
     // Render status indicator based on tool execution status
     const renderStatusIndicator = () => {
@@ -785,7 +785,7 @@ function ToolCallGroupComponent({
             {isCollapsed && (
                 <div className="px-3 py-0.5 space-y-0">
                     {messages.map((m, idx) => {
-                        const details = m.details as { tool?: string; files?: string[]; outputFiles?: string[] } | undefined;
+                        const details = m.details as { tool?: string; files?: string[]; outputFiles?: string[]; observation?: string } | undefined;
                         const toolName = getMessageActivityLabel(m);
                         const badgeClass = getMessageBadgeClass(m);
                         const fullMessage = typeof m.message === "string" ? m.message : "";
@@ -873,7 +873,7 @@ function ToolCallGroupComponent({
 
                                             {/* Show observation from details if different from header text */}
                                             {(() => {
-                                                const observation = (details as any)?.observation as string | undefined;
+                                                const observation = typeof details?.observation === 'string' ? details.observation : undefined;
                                                 if (observation && observation !== fullMessage) {
                                                     return (
                                                         <div className="vprose prose prose-slate dark:prose-invert prose-p:leading-relaxed prose-p:my-1.5 max-w-none text-sm">

--- a/packages/ui/src/features/agent/chat/VegaLiteChart.tsx
+++ b/packages/ui/src/features/agent/chat/VegaLiteChart.tsx
@@ -100,7 +100,7 @@ function FullscreenDialog({
 }
 
 // Calculate height based on spec complexity
-function calculateAutoHeight(spec: Record<string, any>, mode: 'chart' | 'dashboard'): number {
+function calculateAutoHeight(spec: VegaSpecObject, mode: 'chart' | 'dashboard'): number {
     if (mode === 'chart') {
         return DEFAULT_CHART_HEIGHT;
     }
@@ -152,6 +152,53 @@ type ArtifactReference = {
     artifactPath: string;  // The artifact path (without "artifact:" prefix)
 };
 
+type VegaData = Record<string, unknown> & {
+    url?: string;
+    values?: unknown[];
+};
+
+type VegaChannel = Record<string, unknown> & {
+    field?: string;
+};
+
+type VegaSelect = Record<string, unknown> & {
+    fields?: string[];
+    bind?: string;
+};
+
+type VegaParam = Record<string, unknown> & {
+    name?: string;
+    select?: VegaSelect;
+    value?: unknown;
+};
+
+type VegaSpecObject = Record<string, unknown> & {
+    title?: unknown;
+    data?: VegaData;
+    encoding?: Record<string, VegaChannel>;
+    params?: VegaParam[];
+    layer?: VegaSpecObject[];
+    vconcat?: VegaSpecObject[];
+    hconcat?: VegaSpecObject[];
+    concat?: VegaSpecObject[];
+    spec?: VegaSpecObject;
+    repeat?: VegaSpecObject;
+    facet?: VegaSpecObject | unknown;
+    columns?: number;
+    spacing?: number;
+    width?: number | string;
+    height?: number | string;
+    config?: Record<string, unknown>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isVegaSpecObject(value: unknown): value is VegaSpecObject {
+    return isRecord(value);
+}
+
 /**
  * Preprocess a Vega-Lite spec to fix duplicate signal names that occur
  * when params with selections are used in vconcat/hconcat layouts.
@@ -165,9 +212,9 @@ type ArtifactReference = {
  * (where selections typically originate). Cross-view references are preserved
  * so that clicking in one view filters other views.
  */
-function fixVegaLiteSelectionParams(spec: Record<string, any>): Record<string, any> {
+function fixVegaLiteSelectionParams(spec: VegaSpecObject): VegaSpecObject {
     // Deep clone the spec to avoid mutations
-    const result = JSON.parse(JSON.stringify(spec)) as Record<string, any>;
+    const result = JSON.parse(JSON.stringify(spec)) as VegaSpecObject;
 
     // Check if this is a concatenated spec with root-level selection params
     const concatKeys = ['vconcat', 'hconcat', 'concat'];
@@ -179,7 +226,7 @@ function fixVegaLiteSelectionParams(spec: Record<string, any>): Record<string, a
     }
 
     // Check for selection params at the root level
-    const rootSelectionParams: Array<{ name: string; param: Record<string, any> }> = [];
+    const rootSelectionParams: Array<{ name: string; param: VegaParam }> = [];
     if (Array.isArray(result.params)) {
         for (const param of result.params) {
             if (param && typeof param === 'object' && param.name && param.select) {
@@ -202,7 +249,7 @@ function fixVegaLiteSelectionParams(spec: Record<string, any>): Record<string, a
         const hasLegendBinding = param.select?.bind === 'legend';
 
         // Find the concat array
-        let concatArray: any[] | null = null;
+        let concatArray: VegaSpecObject[] | null = null;
         for (const key of concatKeys) {
             if (Array.isArray(result[key])) {
                 concatArray = result[key];
@@ -231,7 +278,8 @@ function fixVegaLiteSelectionParams(spec: Record<string, any>): Record<string, a
         targetView.params.push(param);
 
         // Remove the param from root level
-        result.params = result.params.filter((p: any) => p.name !== paramName);
+        const params = result.params ?? [];
+        result.params = params.filter((p) => p.name !== paramName);
 
         // Cross-view references are kept intact - Vega-Lite handles signal
         // propagation from the view where the selection is defined to other views
@@ -252,19 +300,19 @@ function fixVegaLiteSelectionParams(spec: Record<string, any>): Record<string, a
  * @exported for testing
  */
 export function applyParameterValues(
-    spec: Record<string, any>,
-    parameterValues: Record<string, any>
-): Record<string, any> {
+    spec: VegaSpecObject,
+    parameterValues: Record<string, unknown>
+): VegaSpecObject {
     if (!parameterValues || Object.keys(parameterValues).length === 0) {
         return spec;
     }
 
-    const result = JSON.parse(JSON.stringify(spec)) as Record<string, any>;
+    const result = JSON.parse(JSON.stringify(spec)) as VegaSpecObject;
 
     // Helper to update params in a view
-    const updateParams = (params: any[]) => {
+    const updateParams = (params: VegaParam[]) => {
         for (const param of params) {
-            if (param && typeof param === 'object' && param.name && param.name in parameterValues) {
+            if (param.name && param.name in parameterValues) {
                 param.value = parameterValues[param.name];
             }
         }
@@ -276,10 +324,10 @@ export function applyParameterValues(
     }
 
     // Update params in nested views (vconcat, hconcat, concat)
-    const updateNestedViews = (views: any[]) => {
+    const updateNestedViews = (views: VegaSpecObject[]) => {
         if (!Array.isArray(views)) return;
         for (const view of views) {
-            if (view && Array.isArray(view.params)) {
+            if (Array.isArray(view.params)) {
                 updateParams(view.params);
             }
             // Recursively handle nested concatenations
@@ -289,7 +337,7 @@ export function applyParameterValues(
             // Handle layers
             if (Array.isArray(view.layer)) {
                 for (const layer of view.layer) {
-                    if (layer && Array.isArray(layer.params)) {
+                    if (Array.isArray(layer.params)) {
                         updateParams(layer.params);
                     }
                 }
@@ -314,12 +362,12 @@ export function applyParameterValues(
 /**
  * Check if a view has encoding using any of the specified fields.
  */
-function viewHasField(view: Record<string, any>, fields: string[]): boolean {
+function viewHasField(view: VegaSpecObject, fields: string[]): boolean {
     if (!view || !view.encoding) return false;
 
     for (const field of fields) {
         for (const channel of Object.values(view.encoding)) {
-            if (channel && typeof channel === 'object' && (channel as any).field === field) {
+            if (channel.field === field) {
                 return true;
             }
         }
@@ -338,13 +386,13 @@ function viewHasField(view: Record<string, any>, fields: string[]): boolean {
 /**
  * Check if a view has color encoding using any of the specified fields.
  */
-function viewHasColorEncoding(view: Record<string, any>, fields: string[]): boolean {
+function viewHasColorEncoding(view: VegaSpecObject, fields: string[]): boolean {
     if (!view) return false;
 
-    const checkEncoding = (encoding: any): boolean => {
+    const checkEncoding = (encoding: Record<string, VegaChannel> | undefined): boolean => {
         if (!encoding) return false;
         const colorField = encoding.color?.field;
-        return colorField && fields.includes(colorField);
+        return !!colorField && fields.includes(colorField);
     };
 
     if (checkEncoding(view.encoding)) return true;
@@ -363,7 +411,7 @@ function viewHasColorEncoding(view: Record<string, any>, fields: string[]): bool
  * Walk the Vega-Lite spec and find all artifact: URL references in data.url fields.
  * Returns an array of references with their paths in the spec tree.
  */
-function findArtifactReferences(spec: Record<string, any>, currentPath: string[] = []): ArtifactReference[] {
+function findArtifactReferences(spec: VegaSpecObject, currentPath: string[] = []): ArtifactReference[] {
     const references: ArtifactReference[] = [];
 
     if (!spec || typeof spec !== 'object') {
@@ -388,9 +436,11 @@ function findArtifactReferences(spec: Record<string, any>, currentPath: string[]
             const value = spec[key];
             if (Array.isArray(value)) {
                 value.forEach((item, index) => {
-                    references.push(...findArtifactReferences(item, [...currentPath, key, String(index)]));
+                    if (isVegaSpecObject(item)) {
+                        references.push(...findArtifactReferences(item, [...currentPath, key, String(index)]));
+                    }
                 });
-            } else if (typeof value === 'object' && value !== null) {
+            } else if (isVegaSpecObject(value)) {
                 references.push(...findArtifactReferences(value, [...currentPath, key]));
             }
         }
@@ -403,28 +453,30 @@ function findArtifactReferences(spec: Record<string, any>, currentPath: string[]
  * Deep clone and update the spec by replacing artifact URLs with resolved data values.
  */
 function replaceArtifactData(
-    spec: Record<string, any>,
-    resolvedData: Map<string, any[]>
-): Record<string, any> {
-    const result = JSON.parse(JSON.stringify(spec)) as Record<string, any>;
+    spec: VegaSpecObject,
+    resolvedData: Map<string, unknown[]>
+): VegaSpecObject {
+    const result = JSON.parse(JSON.stringify(spec)) as VegaSpecObject;
 
     for (const [pathKey, data] of resolvedData) {
         const path = pathKey.split('.');
-        let current: any = result;
+        let current: Record<string, unknown> = result;
 
         // Navigate to the parent of the data object
         for (let i = 0; i < path.length - 1; i++) {
-            if (current[path[i]] === undefined) {
+            const next = current[path[i]];
+            if (!isRecord(next)) {
                 break;
             }
-            current = current[path[i]];
+            current = next;
         }
 
         // Replace data.url with data.values
         const lastKey = path[path.length - 1];
-        if (current[lastKey] && typeof current[lastKey] === 'object') {
-            delete current[lastKey].url;
-            current[lastKey].values = data;
+        const target = current[lastKey];
+        if (isRecord(target)) {
+            delete target.url;
+            target.values = data;
         }
     }
 
@@ -432,7 +484,7 @@ function replaceArtifactData(
 }
 
 // Get dark mode config for Vega with enhanced styling
-function getDarkModeConfig(isDark: boolean): Record<string, any> {
+function getDarkModeConfig(isDark: boolean): Record<string, unknown> {
     const baseConfig = {
         background: 'transparent',
         view: { stroke: 'transparent' },
@@ -545,7 +597,8 @@ function getDarkModeConfig(isDark: boolean): Record<string, any> {
 
 export const VegaLiteChart = memo(function VegaLiteChart({ spec, artifactRunId }: VegaLiteChartProps) {
     const { t } = useUITranslation();
-    const { title, description, spec: vegaSpec, options } = spec;
+    const { title, description, options } = spec;
+    const vegaSpec = spec.spec as VegaSpecObject;
     const [isExporting, setIsExporting] = useState(false);
     const [isCopied, setIsCopied] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -562,7 +615,7 @@ export const VegaLiteChart = memo(function VegaLiteChart({ spec, artifactRunId }
     clientRef.current = client;
     const urlCacheRef = useRef(urlCache);
     urlCacheRef.current = urlCache;
-    const [resolvedSpec, setResolvedSpec] = useState<Record<string, any> | null>(null);
+    const [resolvedSpec, setResolvedSpec] = useState<VegaSpecObject | null>(null);
     const [isLoadingArtifacts, setIsLoadingArtifacts] = useState(false);
     const [artifactError, setArtifactError] = useState<string | null>(null);
 
@@ -600,7 +653,7 @@ export const VegaLiteChart = memo(function VegaLiteChart({ spec, artifactRunId }
         setArtifactError(null);
 
         const resolveArtifacts = async () => {
-            const resolvedData = new Map<string, any[]>();
+            const resolvedData = new Map<string, unknown[]>();
             const currentClient = clientRef.current;
             const currentUrlCache = urlCacheRef.current;
 
@@ -644,7 +697,7 @@ export const VegaLiteChart = memo(function VegaLiteChart({ spec, artifactRunId }
 
                     // Detect CSV files by artifact path extension
                     const isCsv = ref.artifactPath.toLowerCase().endsWith('.csv');
-                    let data: any[];
+                    let data: unknown[];
 
                     if (isCsv) {
                         // Parse CSV to JSON array
@@ -654,7 +707,7 @@ export const VegaLiteChart = memo(function VegaLiteChart({ spec, artifactRunId }
                             skipEmptyLines: true,
                             dynamicTyping: true, // Auto-convert numbers and booleans
                         });
-                        data = parseResult.data as any[];
+                        data = parseResult.data as unknown[];
                     } else {
                         // Parse as JSON
                         const jsonData = await response.json();
@@ -756,7 +809,7 @@ export const VegaLiteChart = memo(function VegaLiteChart({ spec, artifactRunId }
     }, [resolvedSpec, vegaSpec, hasArtifactReferences, options?.parameterValues]);
 
     // Scale widths in concatenated views to fit container
-    const scaleSpecWidths = useCallback((spec: any, availableWidth: number): any => {
+    const scaleSpecWidths = useCallback((spec: VegaSpecObject, availableWidth: number): VegaSpecObject => {
         if (!spec || typeof spec !== 'object') return spec;
 
         // Handle hconcat - distribute width among children
@@ -768,7 +821,7 @@ export const VegaLiteChart = memo(function VegaLiteChart({ spec, artifactRunId }
 
             return {
                 ...spec,
-                hconcat: spec.hconcat.map((child: any) => scaleSpecWidths(child, widthPerChild)),
+                hconcat: spec.hconcat.map((child) => scaleSpecWidths(child, widthPerChild)),
             };
         }
 
@@ -776,7 +829,7 @@ export const VegaLiteChart = memo(function VegaLiteChart({ spec, artifactRunId }
         if (spec.vconcat && Array.isArray(spec.vconcat)) {
             return {
                 ...spec,
-                vconcat: spec.vconcat.map((child: any) => scaleSpecWidths(child, availableWidth)),
+                vconcat: spec.vconcat.map((child) => scaleSpecWidths(child, availableWidth)),
             };
         }
 
@@ -789,7 +842,7 @@ export const VegaLiteChart = memo(function VegaLiteChart({ spec, artifactRunId }
 
             return {
                 ...spec,
-                concat: spec.concat.map((child: any) => scaleSpecWidths(child, widthPerChild)),
+                concat: spec.concat.map((child) => scaleSpecWidths(child, widthPerChild)),
             };
         }
 
@@ -827,11 +880,11 @@ export const VegaLiteChart = memo(function VegaLiteChart({ spec, artifactRunId }
         }
 
         // Replace "container" width with our measured width - "container" relies on CSS which may not be ready
-        const specWidth = (scaledSpec as any).width;
+        const specWidth = scaledSpec.width;
         const width = isConcatenatedView ? undefined : (specWidth === 'container' ? calculatedWidth : (specWidth ?? calculatedWidth));
 
         // Destructure to remove width from spec so we can control it (only for non-concat views)
-        const { width: _specWidth, ...specWithoutWidth } = scaledSpec as any;
+        const { width: _specWidth, ...specWithoutWidth } = scaledSpec;
 
         return {
             $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
@@ -846,7 +899,7 @@ export const VegaLiteChart = memo(function VegaLiteChart({ spec, artifactRunId }
                 ...config,
                 ...processedSpec.config,
             },
-        };
+        } as VisualizationSpec;
     }, [processedSpec, title, isDarkMode, containerWidth, scaleSpecWidths]);
 
     const handleCopy = useCallback(async () => {
@@ -1021,8 +1074,8 @@ export const VegaLiteChart = memo(function VegaLiteChart({ spec, artifactRunId }
     if (typeof window !== 'undefined' && localStorage.getItem('DEBUG_VEGA_RENDERS')) {
         console.log('VegaLite rendering with spec:', {
             title,
-            hasData: !!(chartSpec as any).data?.values,
-            dataLength: (chartSpec as any).data?.values?.length,
+            hasData: !!(chartSpec as VegaSpecObject).data?.values,
+            dataLength: (chartSpec as VegaSpecObject).data?.values?.length,
         });
     }
 

--- a/packages/ui/src/features/agent/chat/applyParameterValues.test.ts
+++ b/packages/ui/src/features/agent/chat/applyParameterValues.test.ts
@@ -21,7 +21,7 @@ describe('applyParameterValues', () => {
 
         const result = applyParameterValues(spec, {});
 
-        expect(result.params[0].value).toBe(50);
+        expect(result.params?.[0].value).toBe(50);
     });
 
     it('should update root-level param value', () => {
@@ -35,9 +35,9 @@ describe('applyParameterValues', () => {
 
         const result = applyParameterValues(spec, { threshold: 75 });
 
-        expect(result.params[0].value).toBe(75);
-        expect(result.params[0].name).toBe('threshold');
-        expect(result.params[0].bind).toEqual({ input: 'range' });
+        expect(result.params?.[0].value).toBe(75);
+        expect(result.params?.[0].name).toBe('threshold');
+        expect(result.params?.[0].bind).toEqual({ input: 'range' });
     });
 
     it('should update multiple root-level params', () => {
@@ -55,9 +55,9 @@ describe('applyParameterValues', () => {
             colorScheme: 'tableau10'
         });
 
-        expect(result.params[0].value).toBe(100);
-        expect(result.params[1].value).toBe('tableau10');
-        expect(result.params[2].value).toBe(true); // unchanged
+        expect(result.params?.[0].value).toBe(100);
+        expect(result.params?.[1].value).toBe('tableau10');
+        expect(result.params?.[2].value).toBe(true); // unchanged
     });
 
     it('should not modify original spec (immutability)', () => {
@@ -102,8 +102,8 @@ describe('applyParameterValues', () => {
             filterY: 'category_a'
         });
 
-        expect(result.vconcat[0].params[0].value).toEqual([0, 100]);
-        expect(result.vconcat[1].params[0].value).toBe('category_a');
+        expect(result.vconcat?.[0].params?.[0].value).toEqual([0, 100]);
+        expect(result.vconcat?.[1].params?.[0].value).toBe('category_a');
     });
 
     it('should update params in hconcat views', () => {
@@ -125,8 +125,8 @@ describe('applyParameterValues', () => {
             rightParam: 20
         });
 
-        expect(result.hconcat[0].params[0].value).toBe(10);
-        expect(result.hconcat[1].params[0].value).toBe(20);
+        expect(result.hconcat?.[0].params?.[0].value).toBe(10);
+        expect(result.hconcat?.[1].params?.[0].value).toBe(20);
     });
 
     it('should update params in concat views', () => {
@@ -140,8 +140,8 @@ describe('applyParameterValues', () => {
 
         const result = applyParameterValues(spec, { p1: 'x', p2: 'y' });
 
-        expect(result.concat[0].params[0].value).toBe('x');
-        expect(result.concat[1].params[0].value).toBe('y');
+        expect(result.concat?.[0].params?.[0].value).toBe('x');
+        expect(result.concat?.[1].params?.[0].value).toBe('y');
     });
 
     it('should update params in nested layer views', () => {
@@ -159,7 +159,7 @@ describe('applyParameterValues', () => {
 
         const result = applyParameterValues(spec, { layerParam: 'updated' });
 
-        expect(result.layer[0].params[0].value).toBe('updated');
+        expect(result.layer?.[0].params?.[0].value).toBe('updated');
     });
 
     it('should update params in deeply nested vconcat > layer', () => {
@@ -178,7 +178,7 @@ describe('applyParameterValues', () => {
 
         const result = applyParameterValues(spec, { deepParam: 999 });
 
-        expect(result.vconcat[0].layer[0].params[0].value).toBe(999);
+        expect(result.vconcat?.[0].layer?.[0].params?.[0].value).toBe(999);
     });
 
     it('should handle both root and nested params', () => {
@@ -197,8 +197,8 @@ describe('applyParameterValues', () => {
             nestedParam: 'updated_nested'
         });
 
-        expect(result.params[0].value).toBe('updated_root');
-        expect(result.vconcat[0].params[0].value).toBe('updated_nested');
+        expect(result.params?.[0].value).toBe('updated_root');
+        expect(result.vconcat?.[0].params?.[0].value).toBe('updated_nested');
     });
 
     it('should apply only matching parameterValues (non-matching are ignored by applyParameterValues)', () => {
@@ -214,8 +214,8 @@ describe('applyParameterValues', () => {
             existing: 20
         });
 
-        expect(result.params[0].value).toBe(20);
-        expect(result.params.length).toBe(1);
+        expect(result.params?.[0].value).toBe(20);
+        expect(result.params?.length).toBe(1);
     });
 
     it('should handle selection params (point/interval)', () => {
@@ -234,7 +234,7 @@ describe('applyParameterValues', () => {
             brush: { x: [10, 50] }
         });
 
-        expect(result.params[0].value).toEqual({ x: [10, 50] });
+        expect(result.params?.[0].value).toEqual({ x: [10, 50] });
     });
 
     it('should handle recursive vconcat > vconcat', () => {
@@ -253,6 +253,6 @@ describe('applyParameterValues', () => {
 
         const result = applyParameterValues(spec, { deeplyNested: 'changed' });
 
-        expect(result.vconcat[0].vconcat[0].params[0].value).toBe('changed');
+        expect(result.vconcat?.[0].vconcat?.[0].params?.[0].value).toBe('changed');
     });
 });

--- a/packages/ui/src/features/errors/PanelErrorBoundary.tsx
+++ b/packages/ui/src/features/errors/PanelErrorBoundary.tsx
@@ -1,5 +1,5 @@
 import { MessageBox } from '@vertesia/ui/core';
-import { VertesiaErrorBoundary } from './VertesiaErrorBoundary';
+import { ErrorFallbackComponentProps, VertesiaErrorBoundary } from './VertesiaErrorBoundary';
 import { ReactNode } from 'react';
 import { useUITranslation } from '@vertesia/ui/i18n';
 
@@ -11,8 +11,9 @@ export function PanelErrorBoundary({ children }: { children: ReactNode }) {
     );
 }
 
-function PanelErrorFallback({ error }: { error?: Error }) {
+function PanelErrorFallback({ error }: ErrorFallbackComponentProps) {
     const { t } = useUITranslation();
+    const message = error instanceof Error ? error.message : undefined;
     return (
         <MessageBox status="error" title={t('errors.somethingWentWrong')}>
             <div className='mb-4'>
@@ -22,9 +23,9 @@ function PanelErrorFallback({ error }: { error?: Error }) {
                 <a className='text-info' href="mailto:support@vertesiahq.com">support@vertesiahq.com</a>.
             </div>
 
-            {error?.message &&
+            {message &&
                 <code className='w-full mt-4 text-sm text-muted break-words'>
-                    {error.message}
+                    {message}
                 </code>
             }
         </MessageBox>

--- a/packages/ui/src/features/errors/RowErrorBoundary.tsx
+++ b/packages/ui/src/features/errors/RowErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import { VertesiaErrorBoundary } from "./VertesiaErrorBoundary";
+import { ErrorFallbackComponentProps, VertesiaErrorBoundary } from "./VertesiaErrorBoundary";
 import { ReactNode } from "react";
 
 interface ErrorBoundaryProps {
@@ -15,13 +15,14 @@ export function RowErrorBoundary({ children }: ErrorBoundaryProps) {
     )
 }
 
-function RowErrorFallback({ error }: { error?: Error }) {
+function RowErrorFallback({ error }: ErrorFallbackComponentProps) {
+    const message = error instanceof Error ? error.message : undefined;
     return (
         <tr>
             <td colSpan={100}>
                 <span className="text-xs"> Cannot display row</span>
                 <br />
-                <span className="bg-gray-400">{error?.message}</span>
+                <span className="bg-gray-400">{message}</span>
             </td>
         </tr>
     )

--- a/packages/ui/src/features/errors/VertesiaErrorBoundary.tsx
+++ b/packages/ui/src/features/errors/VertesiaErrorBoundary.tsx
@@ -2,8 +2,8 @@ import { ReactNode, ComponentType } from "react"
 import { ErrorBoundary } from "react-error-boundary";
 
 export interface ErrorFallbackComponentProps {
-    error: any;
-    resetErrorBoundary: (...args: any[]) => void;
+    error: unknown;
+    resetErrorBoundary: (...args: unknown[]) => void;
 }
 export type ErrorBoundaryProps = {
     children: ReactNode;

--- a/packages/ui/src/features/errors/WidgetErrorBoundary.tsx
+++ b/packages/ui/src/features/errors/WidgetErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import { VertesiaErrorBoundary } from './VertesiaErrorBoundary';
+import { ErrorFallbackComponentProps, VertesiaErrorBoundary } from './VertesiaErrorBoundary';
 import { ReactNode } from 'react';
 
 export function WidgetErrorBoundary({ children }: { children: ReactNode }) {
@@ -10,16 +10,17 @@ export function WidgetErrorBoundary({ children }: { children: ReactNode }) {
     )
 }
 
-function WidgetErrorFallback({ error }: { error?: Error }) {
+function WidgetErrorFallback({ error }: ErrorFallbackComponentProps) {
+    const message = error instanceof Error ? error.message : undefined;
 
     console.log('WidgetError', error);
 
     return (
         <div className="text-sm">
             Sorry, this area cannot be loaded or rendered.
-            {error?.message &&
+            {message &&
                 <pre>
-                    {error.message}
+                    {message}
                 </pre>
             }
         </div>

--- a/packages/ui/src/features/facets/AgentRunnerFacetsNav.tsx
+++ b/packages/ui/src/features/facets/AgentRunnerFacetsNav.tsx
@@ -1,16 +1,18 @@
 import { Button, Filter as BaseFilter, FilterProvider, FilterBtn, FilterBar, FilterClear, FilterGroup } from '@vertesia/ui/core';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { VInteractionFacet } from './utils/VInteractionFacet';
+import type { EnrichedFacetBucket } from './utils/VInteractionFacet';
 import { VStringFacet } from './utils/VStringFacet';
 import { VUserFacet } from './utils/VUserFacet';
-import { SearchInterface } from './utils/SearchInterface';
+import { filterValueToQueryValue, SearchInterface, setSearchQueryValue } from './utils/SearchInterface';
 import { RefreshCw } from 'lucide-react';
+import type { FacetBucket } from '@vertesia/common';
 
 interface AgentRunnerFacetsNavProps {
     facets: {
-        statuses?: any[];
-        initiated_by?: any[];
-        interactions?: any[];
+        statuses?: FacetBucket[];
+        initiated_by?: FacetBucket[];
+        interactions?: EnrichedFacetBucket[];
     };
     search: SearchInterface;
     actions?: React.ReactNode[];
@@ -35,7 +37,6 @@ export function useAgentRunnerFilterGroups(facets: AgentRunnerFacetsNavProps['fa
     }));
 
     customFilterGroups.push(VStringFacet({
-        search: null as any, // This will be provided by the search context
         buckets: facets.statuses || [],
         name: 'status',
         placeholder: 'Status',
@@ -74,21 +75,8 @@ export function createAgentRunnerFilterHandler(search: SearchInterface) {
         newFilters.forEach(filter => {
             if (filter.value && filter.value.length > 0) {
                 const filterName = filter.name;
-                let filterValue;
-                if (filter.multiple) {
-                    filterValue = Array.isArray(filter.value)
-                        ? filter.value.map((v: any) => typeof v === 'object' && v.value ? v.value : v)
-                        : [typeof filter.value === 'object' && (filter.value as any).value ? (filter.value as any).value : filter.value];
-                } else {
-                    // Single value - don't wrap in array
-                    filterValue = Array.isArray(filter.value) && filter.value[0] && typeof filter.value[0] === 'object'
-                        ? (filter.value[0] as any).value
-                        : Array.isArray(filter.value) && filter.value[0]
-                            ? filter.value[0]
-                            : filter.value;
-                }
-
-                search.query[filterName] = filterValue;
+                const filterValue = filterValueToQueryValue(filter);
+                setSearchQueryValue(search, filterName, filterValue);
             }
         });
 

--- a/packages/ui/src/features/facets/CollectionsFacetsNav.tsx
+++ b/packages/ui/src/features/facets/CollectionsFacetsNav.tsx
@@ -1,12 +1,13 @@
 import { Filter as BaseFilter, FilterProvider, FilterBtn, FilterBar, FilterClear, FilterGroup } from '@vertesia/ui/core';
 import { useState } from 'react';
 import { useTypeRegistry } from '../store/types/TypeRegistryProvider.js';
-import { SearchInterface } from './utils/SearchInterface';
+import { filterValueToQueryValue, SearchInterface, setSearchQueryValue } from './utils/SearchInterface';
+import type { FacetBucket } from '@vertesia/common';
 
 interface CollectionsFacetsNavProps {
     facets: {
-        type?: any[];
-        dynamic?: any[];
+        type?: FacetBucket[];
+        dynamic?: FacetBucket[];
     };
     search: SearchInterface;
 }
@@ -67,23 +68,8 @@ export function useCollectionsFilterHandler(search: SearchInterface) {
         newFilters.forEach(filter => {
             if (filter.value && filter.value.length > 0) {
                 const filterName = filter.name;
-                let filterValue;
-                if (filter.type === 'stringList') {
-                    filterValue = filter.value.map(v => typeof v === 'string' ? v : v.value);
-                } else if (filter.multiple) {
-                    filterValue = Array.isArray(filter.value)
-                        ? filter.value.map((v: any) => typeof v === 'object' && v.value ? v.value : v)
-                        : [typeof filter.value === 'object' && (filter.value as any).value ? (filter.value as any).value : filter.value];
-                } else {
-                    // Single value - don't wrap in array
-                    filterValue = Array.isArray(filter.value) && filter.value[0] && typeof filter.value[0] === 'object'
-                        ? (filter.value[0] as any).value
-                        : Array.isArray(filter.value) && filter.value[0]
-                            ? filter.value[0]
-                            : filter.value;
-                }
-
-                search.query[filterName] = filterValue;
+                const filterValue = filterValueToQueryValue(filter);
+                setSearchQueryValue(search, filterName, filterValue);
             }
         });
 

--- a/packages/ui/src/features/facets/DocumentsFacetsNav.tsx
+++ b/packages/ui/src/features/facets/DocumentsFacetsNav.tsx
@@ -4,7 +4,7 @@ import { ComputedFacetResponse } from '@vertesia/common';
 import { useTypeRegistry } from '../store/types/TypeRegistryProvider.js';
 import { VStringFacet } from './utils/VStringFacet';
 import { VTypeFacet } from './utils/VTypeFacet';
-import { SearchInterface } from './utils/SearchInterface';
+import { filterValueToQueryValue, SearchInterface, setSearchQueryValue, unwrapFilterOptionValue } from './utils/SearchInterface';
 
 interface DocumentsFacetsNavProps {
     facets: ComputedFacetResponse;
@@ -46,7 +46,6 @@ export function useDocumentFilterGroups(facets: DocumentsFacetsNavProps['facets'
 
     if (facets.status) {
         const statusFilterGroup = VStringFacet({
-            search: null as any, // This will be provided by the search context
             buckets: getBuckets(facets.status),
             name: 'status',
             placeholder: 'Status',
@@ -101,49 +100,37 @@ export function useDocumentFilterHandler(search: SearchInterface) {
             if (filter.value && filter.value.length > 0) {
                 const filterName = filter.name;
 
-                let filterValue;
+                let filterValue: unknown;
                 if (filter.type === 'date' && filter.multiple) {
                     // Handle date range filters
                     if (Array.isArray(filter.value) && filter.value.length > 0) {
                         if (filter.value.length === 1) {
                             // Single date - use as both start and end
-                            const dateValue = typeof filter.value[0] === 'object' ? (filter.value[0] as any).value : filter.value[0];
+                            const dateValue = unwrapFilterOptionValue(filter.value[0]);
                             filterValue = {
                                 gte: dateValue,
                                 lte: dateValue
                             };
                         } else if (filter.value.length === 2) {
                             // Date range - start and end dates
-                            const startDate = typeof filter.value[0] === 'object' ? (filter.value[0] as any).value : filter.value[0];
-                            const endDate = typeof filter.value[1] === 'object' ? (filter.value[1] as any).value : filter.value[1];
+                            const startDate = unwrapFilterOptionValue(filter.value[0]);
+                            const endDate = unwrapFilterOptionValue(filter.value[1]);
                             filterValue = {
                                 gte: startDate,
                                 lte: endDate
                             };
                         }
                     }
-                } else if (filter.multiple) {
-                    if (Array.isArray(filter.value)) {
-                        filterValue = filter.value.map((v: any) => typeof v === 'object' && v.value ? v.value : v);
-                    } else {
-                        const singleValue = typeof filter.value === 'object' && (filter.value as any).value ? (filter.value as any).value : filter.value;
-                        filterValue = [singleValue];
-                    }
                 } else {
-                    // Single value - don't wrap in array
-                    filterValue = Array.isArray(filter.value) && filter.value[0] && typeof filter.value[0] === 'object'
-                        ? (filter.value[0] as any).value
-                        : Array.isArray(filter.value) && filter.value[0]
-                            ? filter.value[0]
-                            : filter.value;
+                    filterValue = filterValueToQueryValue(filter);
                 }
 
                 if (filterName === 'name') {
-                    search.query.name = filterValue;
+                    setSearchQueryValue(search, 'name', filterValue);
                 } else if (filterName === 'id') {
-                    search.query.id = filterValue;
+                    setSearchQueryValue(search, 'id', filterValue);
                 } else {
-                    search.query[filterName] = filterValue;
+                    setSearchQueryValue(search, filterName, filterValue);
                 }
             }
         });

--- a/packages/ui/src/features/facets/EnvironmentFacet.tsx
+++ b/packages/ui/src/features/facets/EnvironmentFacet.tsx
@@ -4,9 +4,10 @@ import { FacetBucket, FacetNameBucket } from '@vertesia/common';
 import { SelectBox } from '@vertesia/ui/core';
 import { useUserSession } from '@vertesia/ui/session';
 import { facetOptionNameLabel } from './utils/utils';
+import type { SearchInterface } from './utils/SearchInterface';
 
 interface EnvironmentFacetProps {
-    search: any;
+    search: SearchInterface;
     buckets: FacetBucket[];
     placeholder?: string;
     className?: string;
@@ -24,7 +25,7 @@ export function EnvironmentFacet({ search, buckets, placeholder = "All Environme
     useEffect(() => {
         if (client) {
             const options = buckets.map(async (bucket) => {
-                let name;
+                let name: string | undefined;
                 await client.environments.retrieve(bucket._id).then((environment) => {
                     name = environment.name;
                 }).catch(() => {

--- a/packages/ui/src/features/facets/InteractionsFacetsNav.tsx
+++ b/packages/ui/src/features/facets/InteractionsFacetsNav.tsx
@@ -1,7 +1,7 @@
 import { Filter as BaseFilter, FilterProvider, FilterBtn, FilterBar, FilterClear, FilterGroup } from '@vertesia/ui/core';
 import type { ComputedFacetResponse } from '@vertesia/common';
 import { useState } from 'react';
-import { SearchInterface } from './utils/SearchInterface';
+import { filterValueToQueryValue, SearchInterface, setSearchQueryValue } from './utils/SearchInterface';
 
 interface InteractionsFacetsNavProps {
     facets: ComputedFacetResponse;
@@ -68,23 +68,8 @@ export function useInteractionsFilterHandler(search: SearchInterface) {
         newFilters.forEach(filter => {
             if (filter.value && filter.value.length > 0) {
                 const filterName = filter.name;
-                let filterValue;
-                if (filter.type === 'stringList') {
-                    filterValue = filter.value.map(v => typeof v === 'string' ? v : v.value);
-                } else if (filter.multiple) {
-                    filterValue = Array.isArray(filter.value)
-                        ? filter.value.map((v: any) => typeof v === 'object' && v.value ? v.value : v)
-                        : [typeof filter.value === 'object' && (filter.value as any).value ? (filter.value as any).value : filter.value];
-                } else {
-                    // Single value - don't wrap in array
-                    filterValue = Array.isArray(filter.value) && filter.value[0] && typeof filter.value[0] === 'object'
-                        ? (filter.value[0] as any).value
-                        : Array.isArray(filter.value) && filter.value[0]
-                            ? filter.value[0]
-                            : filter.value;
-                }
-
-                search.query[filterName] = filterValue;
+                const filterValue = filterValueToQueryValue(filter);
+                setSearchQueryValue(search, filterName, filterValue);
             }
         });
 

--- a/packages/ui/src/features/facets/PromptsFacetsNav.tsx
+++ b/packages/ui/src/features/facets/PromptsFacetsNav.tsx
@@ -1,12 +1,13 @@
 import { Filter as BaseFilter, FilterProvider, FilterBtn, FilterBar, FilterClear, FilterGroup } from '@vertesia/ui/core';
 import { useState } from 'react';
-import { SearchInterface } from './utils/SearchInterface';
+import { filterValueToQueryValue, SearchInterface, setSearchQueryValue } from './utils/SearchInterface';
+import type { FacetBucket } from '@vertesia/common';
 
 interface PromptsFacetsNavProps {
     facets: {
-        role?: any[];
-        status?: any[];
-        tags?: any[];
+        role?: FacetBucket[];
+        status?: FacetBucket[];
+        tags?: FacetBucket[];
     };
     search: SearchInterface;
 }
@@ -31,7 +32,7 @@ export function usePromptsFilterGroups(facets: PromptsFacetsNavProps['facets']):
             name: 'role',
             placeholder: 'Role',
             type: 'select' as const,
-            options: facets.role.map((facet: { _id: string; count: number }) => ({
+            options: facets.role.map((facet) => ({
                 label: facet._id,
                 value: facet._id,
                 count: facet.count
@@ -58,23 +59,8 @@ export function usePromptsFilterHandler(search: SearchInterface) {
         newFilters.forEach(filter => {
             if (filter.value && filter.value.length > 0) {
                 const filterName = filter.name;
-                let filterValue;
-                if (filter.type === 'stringList') {
-                    filterValue = filter.value.map(v => typeof v === 'string' ? v : v.value);
-                } else if (filter.multiple) {
-                    filterValue = Array.isArray(filter.value)
-                        ? filter.value.map((v: any) => typeof v === 'object' && v.value ? v.value : v)
-                        : [typeof filter.value === 'object' && (filter.value as any).value ? (filter.value as any).value : filter.value];
-                } else {
-                    // Single value - don't wrap in array
-                    filterValue = Array.isArray(filter.value) && filter.value[0] && typeof filter.value[0] === 'object'
-                        ? (filter.value[0] as any).value
-                        : Array.isArray(filter.value) && filter.value[0]
-                            ? filter.value[0]
-                            : filter.value;
-                }
-
-                search.query[filterName] = filterValue;
+                const filterValue = filterValueToQueryValue(filter);
+                setSearchQueryValue(search, filterName, filterValue);
             }
         });
 

--- a/packages/ui/src/features/facets/RunsFacetsNav.tsx
+++ b/packages/ui/src/features/facets/RunsFacetsNav.tsx
@@ -2,21 +2,23 @@ import { Button, Filter as BaseFilter, FilterProvider, FilterBtn, FilterBar, Fil
 import { useState } from 'react';
 import { VEnvironmentFacet } from './utils/VEnvironmentFacet';
 import { VInteractionFacet } from './utils/VInteractionFacet';
+import type { EnrichedFacetBucket } from './utils/VInteractionFacet';
 import { VStringFacet } from './utils/VStringFacet';
 import { VUserFacet } from './utils/VUserFacet';
-import { SearchInterface } from './utils/SearchInterface';
+import { filterValueToQueryValue, SearchInterface, setSearchQueryValue } from './utils/SearchInterface';
 import { RefreshCw } from 'lucide-react';
+import type { FacetBucket } from '@vertesia/common';
 
 interface RunsFacetsNavProps {
     facets: {
-        type?: any[];
-        interactions?: any[];
-        environments?: any[];
-        models?: any[];
-        statuses?: any[];
-        tags?: any[];
-        finish_reason?: any[];
-        created_by?: any[];
+        type?: FacetBucket[];
+        interactions?: EnrichedFacetBucket[];
+        environments?: FacetBucket[];
+        models?: FacetBucket[];
+        statuses?: FacetBucket[];
+        tags?: FacetBucket[];
+        finish_reason?: FacetBucket[];
+        created_by?: FacetBucket[];
     };
     search: SearchInterface;
     actions?: React.ReactNode[];
@@ -63,7 +65,6 @@ export function useRunsFilterGroups(facets: RunsFacetsNavProps['facets']): Filte
 
     if (facets.models) {
         const modelFilterGroup = VStringFacet({
-            search: null as any, // This will be provided by the search context
             buckets: facets.models || [],
             name: 'model'
         });
@@ -72,7 +73,6 @@ export function useRunsFilterGroups(facets: RunsFacetsNavProps['facets']): Filte
 
     if (facets.statuses) {
         const statusFilterGroup = VStringFacet({
-            search: null as any, // This will be provided by the search context
             buckets: facets.statuses || [],
             name: 'status'
         });
@@ -80,13 +80,12 @@ export function useRunsFilterGroups(facets: RunsFacetsNavProps['facets']): Filte
     }
 
     if (facets.finish_reason) {
-        const processedFinishReason = facets.finish_reason.map((bucket: any) => ({
+        const processedFinishReason = facets.finish_reason.map((bucket) => ({
             ...bucket,
             _id: bucket._id === null ? 'none' : bucket._id
         }));
 
         const finishReasonFilterGroup = VStringFacet({
-            search: null as any, // This will be provided by the search context
             buckets: processedFinishReason,
             name: 'finish_reason',
             placeholder: 'Finish Reason'
@@ -153,28 +152,14 @@ export function useRunsFilterHandler(search: SearchInterface) {
         newFilters.forEach(filter => {
             if (filter.value && filter.value.length > 0) {
                 const filterName = filter.name;
-                let filterValue;
-                if (filter.type === 'stringList') {
-                    filterValue = filter.value.map(v => typeof v === 'string' ? v : v.value);
-                } else if (filter.multiple) {
-                    filterValue = Array.isArray(filter.value)
-                        ? filter.value.map((v: any) => typeof v === 'object' && v.value ? v.value : v)
-                        : [typeof filter.value === 'object' && (filter.value as any).value ? (filter.value as any).value : filter.value];
-                } else {
-                    // Single value - don't wrap in array
-                    filterValue = Array.isArray(filter.value) && filter.value[0] && typeof filter.value[0] === 'object'
-                        ? (filter.value[0] as any).value
-                        : Array.isArray(filter.value) && filter.value[0]
-                            ? filter.value[0]
-                            : filter.value;
-                }
+                let filterValue = filterValueToQueryValue(filter);
 
                 // Force array format for backend fields that expect arrays
                 if ((filterName === 'run_ids' || filterName === 'workflow_run_ids' || filterName === 'workflow_ids') && !Array.isArray(filterValue)) {
                     filterValue = [filterValue];
                 }
 
-                search.query[filterName] = filterValue;
+                setSearchQueryValue(search, filterName, filterValue);
             }
         });
 

--- a/packages/ui/src/features/facets/WorkflowExecutionsFacetsNav.tsx
+++ b/packages/ui/src/features/facets/WorkflowExecutionsFacetsNav.tsx
@@ -2,12 +2,13 @@ import { Filter as BaseFilter, FilterProvider, FilterBtn, FilterBar, FilterClear
 import { useState } from 'react';
 import { VStringFacet } from './utils/VStringFacet';
 import { VUserFacet } from './utils/VUserFacet';
-import { SearchInterface } from './utils/SearchInterface';
+import { filterValueToQueryValue, SearchInterface, setSearchQueryValue } from './utils/SearchInterface';
+import type { FacetBucket } from '@vertesia/common';
 
 interface WorkflowExecutionsFacetsNavProps {
     facets: {
-        status?: any[];
-        initiated_by?: any[];
+        status?: FacetBucket[];
+        initiated_by?: FacetBucket[];
     };
     search: SearchInterface;
 }
@@ -25,7 +26,6 @@ export function useWorkflowExecutionsFilterGroups(facets: WorkflowExecutionsFace
 
     if (facets.status) {
         const statusFilterGroup = VStringFacet({
-            search: null as any, // This will be provided by the search context
             buckets: facets.status || [],
             name: 'status',
             placeholder: 'Status'
@@ -86,34 +86,20 @@ export function useWorkflowExecutionsFilterHandler(search: SearchInterface) {
         newFilters.forEach(filter => {
             if (filter.value && filter.value.length > 0) {
                 const filterName = filter.name;
-                let filterValue;
-                if (filter.type === 'stringList') {
-                    filterValue = filter.value.map(v => typeof v === 'string' ? v : v.value);
-                } else if (filter.multiple) {
-                    filterValue = Array.isArray(filter.value)
-                        ? filter.value.map((v: any) => typeof v === 'object' && v.value ? v.value : v)
-                        : [typeof filter.value === 'object' && (filter.value as any).value ? (filter.value as any).value : filter.value];
-                } else {
-                    // Single value - don't wrap in array
-                    filterValue = Array.isArray(filter.value) && filter.value[0] && typeof filter.value[0] === 'object'
-                        ? (filter.value[0] as any).value
-                        : Array.isArray(filter.value) && filter.value[0]
-                            ? filter.value[0]
-                            : filter.value;
-                }
+                const filterValue = filterValueToQueryValue(filter);
 
                 if (filterName === 'name') {
-                    search.query.search_term = filterValue;
-                    search.query.name = filterValue;
+                    setSearchQueryValue(search, 'search_term', filterValue);
+                    setSearchQueryValue(search, 'name', filterValue);
                 } else if (filterName === 'has_reported_errors') {
                     // Convert string "true"/"false" to boolean
                     const stringValue = Array.isArray(filterValue) ? filterValue[0] : filterValue;
                     // Only set the filter if we have a valid value
                     if (stringValue === 'true' || stringValue === 'false') {
-                        search.query[filterName] = stringValue === 'true';
+                        setSearchQueryValue(search, filterName, stringValue === 'true');
                     }
                 } else {
-                    search.query[filterName] = filterValue;
+                    setSearchQueryValue(search, filterName, filterValue);
                 }
             }
         });

--- a/packages/ui/src/features/facets/utils/SearchInterface.tsx
+++ b/packages/ui/src/features/facets/utils/SearchInterface.tsx
@@ -1,14 +1,43 @@
+import type { Filter as BaseFilter } from '@vertesia/ui/core';
+
 interface defaultKeys {
     [key: string]: string;
 }
 export interface SearchInterface {
-    getFilterValue(name: string): any;
-    setFilterValue(name: string, value: any): void;
+    getFilterValue(name: string): unknown;
+    setFilterValue(name: string, value: unknown): void;
     clearFilters(autoSearch?: boolean, applyDefaults?: boolean): void;
     search(applyDefaults?: boolean): Promise<boolean | undefined>;
     setDefaultKeys(keys: defaultKeys[]): void;
     readonly isRunning: boolean;
     readonly initialized?: boolean;
     readonly totalCount?: number;
-    query: Record<string, any>;
+    query: object;
+}
+
+interface FilterOptionValue {
+    value?: unknown;
+}
+
+function isFilterOptionValue(value: unknown): value is FilterOptionValue {
+    return typeof value === 'object' && value !== null && 'value' in value;
+}
+
+export function unwrapFilterOptionValue(value: unknown): unknown {
+    return isFilterOptionValue(value) ? value.value : value;
+}
+
+export function filterValueToQueryValue(filter: BaseFilter): unknown {
+    if (filter.type === 'stringList') {
+        return filter.value.map(value => typeof value === 'string' ? value : unwrapFilterOptionValue(value));
+    }
+    if (filter.multiple) {
+        return filter.value.map(unwrapFilterOptionValue);
+    }
+    const firstValue = filter.value[0];
+    return firstValue === undefined ? undefined : unwrapFilterOptionValue(firstValue);
+}
+
+export function setSearchQueryValue(search: SearchInterface, name: string, value: unknown): void {
+    (search.query as Record<string, unknown>)[name] = value;
 }

--- a/packages/ui/src/features/facets/utils/StringFacet.tsx
+++ b/packages/ui/src/features/facets/utils/StringFacet.tsx
@@ -1,9 +1,10 @@
 import { FacetBucket } from '@vertesia/common';
 import { SelectBox } from '@vertesia/ui/core';
+import type { SearchInterface } from './SearchInterface';
 import { facetOptionLabel } from './utils';
 
 interface StringFacetProps {
-    search: any;
+    search: SearchInterface;
     buckets: FacetBucket[];
     name: string;
     placeholder?: string;

--- a/packages/ui/src/features/facets/utils/StringListFacet.tsx
+++ b/packages/ui/src/features/facets/utils/StringListFacet.tsx
@@ -1,9 +1,10 @@
 import { FacetBucket } from '@vertesia/common';
 import { InputList } from '@vertesia/ui/core';
 import { useEffect, useState } from 'react';
+import type { SearchInterface } from './SearchInterface';
 
 interface StringListFacetProps {
-    search: any;
+    search: SearchInterface;
     buckets: FacetBucket[];
     name: string;
     placeholder?: string;

--- a/packages/ui/src/features/facets/utils/TypeFacet.tsx
+++ b/packages/ui/src/features/facets/utils/TypeFacet.tsx
@@ -2,6 +2,7 @@ import { FacetBucket } from "@vertesia/common";
 import { SelectBox } from "@vertesia/ui/core";
 import { useEffect, useState } from "react";
 import { useTypeRegistry } from "../../store/types/TypeRegistryProvider.js";
+import type { SearchInterface } from "./SearchInterface";
 
 interface TypeFacetBucket {
     name: string;
@@ -14,7 +15,7 @@ export function facetOptionLabel(bucket: TypeFacetBucket) {
 }
 
 interface TypeFacetProps {
-    search: any;
+    search: SearchInterface;
     buckets: FacetBucket[];
     placeholder?: string;
     className?: string;
@@ -30,7 +31,7 @@ export function TypeFacet({ search, buckets, placeholder = "Filter by Type", cla
     useEffect(() => {
         if (typeRegistry) {
             const options = buckets.map((bucket) => {
-                let name;
+                let name: string | undefined;
                 if (bucket._id == null) {
                     bucket._id = "Document";
                     name = "Document"

--- a/packages/ui/src/features/facets/utils/VInteractionFacet.tsx
+++ b/packages/ui/src/features/facets/utils/VInteractionFacet.tsx
@@ -1,7 +1,7 @@
 import { FacetBucket, InteractionStatus } from '@vertesia/common';
 import { Badge, FilterGroup } from '@vertesia/ui/core';
 
-interface EnrichedFacetBucket extends FacetBucket {
+export interface EnrichedFacetBucket extends FacetBucket {
     name?: string;
     status?: string;
     version?: number;

--- a/packages/ui/src/features/facets/utils/VStringFacet.tsx
+++ b/packages/ui/src/features/facets/utils/VStringFacet.tsx
@@ -29,7 +29,6 @@ export function createStringFilterGroup({ buckets, name, placeholder, type = 'se
 }
 
 export function VStringFacet({ buckets, name, placeholder, type, multiple }: {
-    search: any;
     buckets: FacetBucket[];
     name: string;
     placeholder?: string;

--- a/packages/ui/src/features/facets/utils/VTypeFacet.tsx
+++ b/packages/ui/src/features/facets/utils/VTypeFacet.tsx
@@ -16,7 +16,7 @@ export function VTypeFacet({ buckets, typeRegistry, type = 'select', multiple = 
         console.warn("Type names cannot be resolved");
     }
     buckets.forEach((bucket) => {
-        let name;
+        let name: string | undefined;
         let typeId = bucket._id;
 
         if (bucket._id == null) {

--- a/packages/ui/src/features/layout/GenericPageNavHeader.tsx
+++ b/packages/ui/src/features/layout/GenericPageNavHeader.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { JSX, ReactNode } from 'react';
+import { JSX, ReactElement, ReactNode } from 'react';
 
 import { ChevronRight, Info } from 'lucide-react';
 import { VTooltip, Breadcrumbs } from '@vertesia/ui/core';
@@ -10,11 +10,22 @@ interface GenericPageNavHeaderProps {
     title?: string | JSX.Element;
     description?: string | JSX.Element;
     actions?: ReactNode | ReactNode[];
-    breadcrumbs?: JSX.Element[]
+    breadcrumbs?: ReactElement<BreadcrumbElementProps>[]
     isCompact?: boolean
     children?: ReactNode
     className?: string
     useDynamicBreadcrumbs?: boolean;
+}
+
+interface BreadcrumbElementProps {
+    href?: string;
+    clearBreadcrumbs?: boolean;
+    children?: ReactNode;
+}
+
+interface BreadcrumbHistoryEntry {
+    title?: string;
+    href: string;
 }
 
 // Matches MongoDB ObjectId (24 hex), UUID (36 chars with dashes), or any segment containing digits mixed with letters
@@ -35,7 +46,7 @@ export function GenericPageNavHeader({ className, children, title, description, 
             .join(' ');
     }
 
-    const buildBreadcrumbLabel = (entry: any): string => {
+    const buildBreadcrumbLabel = (entry: BreadcrumbHistoryEntry): string => {
         if (entry?.title) {
             return entry.title;
         }
@@ -58,11 +69,12 @@ export function GenericPageNavHeader({ className, children, title, description, 
         const items: Array<{ label: string | ReactNode, href?: string, onClick?: () => void, clearHistory?: boolean }> = [];
 
         if (useDynamicBreadcrumbs && typeof window !== 'undefined') {
-            const historyChain = window.history.state?.historyChain;
+            const historyState = window.history.state as { historyChain?: BreadcrumbHistoryEntry[] } | null;
+            const historyChain = historyState?.historyChain;
 
-            if (historyChain) {
+            if (Array.isArray(historyChain)) {
                 // Use existing history chain
-                historyChain.forEach((entry: any, index: number) => {
+                historyChain.forEach((entry, index) => {
                     const stepsBack = historyChain.length - index;
                     items.push({
                         label: buildBreadcrumbLabel(entry),
@@ -88,14 +100,15 @@ export function GenericPageNavHeader({ className, children, title, description, 
 
         // Add current page breadcrumbs
         if (breadcrumbs && breadcrumbs.length > 0) {
-            breadcrumbs.forEach((breadcrumb: any) => {
+            breadcrumbs.forEach((breadcrumb) => {
                 // Preserve the entire React element as label
                 const label = breadcrumb.props?.children || breadcrumb;
+                const href = breadcrumb.props?.href;
 
-                items.push((breadcrumb?.props?.href) ? {
-                    href: breadcrumb?.props?.href,
+                items.push(href ? {
+                    href,
                     label: label,
-                    onClick: () => navigate(breadcrumb.props.href, { replace: breadcrumb.props.clearBreadcrumbs }),
+                    onClick: () => navigate(href, { replace: breadcrumb.props.clearBreadcrumbs }),
                 } : {
                     label: label
                 });

--- a/packages/ui/src/features/magic-pdf/AnnotatedImageSlider.tsx
+++ b/packages/ui/src/features/magic-pdf/AnnotatedImageSlider.tsx
@@ -419,9 +419,13 @@ function PageThumbnail({ pageNumber, currentPage, aspectRatio, zoom, url, onSele
             data-page={pageNumber}
             style={{ width: `${widthPercent}%` }}
         >
-            <div
+            <Button
+                variant="unstyled"
+                size="none"
+                aria-pressed={isSelected}
+                aria-label={`Page ${pageNumber}`}
                 className={clsx(
-                    'relative border-[2px] cursor-pointer overflow-hidden flex items-center justify-center bg-muted/50 w-full',
+                    'relative border-[2px] cursor-pointer overflow-hidden !flex items-center justify-center bg-muted/50 w-full',
                     isSelected ? "border-primary" : "border-border"
                 )}
                 style={{ aspectRatio: `1 / ${aspectRatio}` }}
@@ -432,7 +436,7 @@ function PageThumbnail({ pageNumber, currentPage, aspectRatio, zoom, url, onSele
                 ) : (
                     <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
                 )}
-            </div>
+            </Button>
             <Center className="text-sm text-muted-foreground pt-1 font-semibold">{pageNumber}</Center>
         </div>
     );

--- a/packages/ui/src/features/magic-pdf/MagicPdfProvider.tsx
+++ b/packages/ui/src/features/magic-pdf/MagicPdfProvider.tsx
@@ -160,7 +160,7 @@ function extractMarkdownPages(content: string, totalPages: number): string[] {
 
     // Find all page markers and their positions
     const markers: { page: number; index: number }[] = [];
-    let match;
+    let match: RegExpExecArray | null;
     while ((match = pageDelimiterRegex.exec(content)) !== null) {
         markers.push({
             page: parseInt(match[1], 10),

--- a/packages/ui/src/features/magic-pdf/MagicPdfView.tsx
+++ b/packages/ui/src/features/magic-pdf/MagicPdfView.tsx
@@ -1,5 +1,5 @@
 import { ContentObject, DocumentMetadata } from "@vertesia/common";
-import { Button, ErrorBox, ResizableHandle, ResizablePanel, ResizablePanelGroup, useFetch } from "@vertesia/ui/core";
+import { Button, ErrorBox, ResizableHandle, ResizablePanel, ResizablePanelGroup, errorMessage, useFetch } from "@vertesia/ui/core";
 import { useUserSession } from "@vertesia/ui/session";
 import { X } from "lucide-react";
 import { Component, ErrorInfo, ReactNode, useState } from "react";
@@ -69,7 +69,7 @@ export function MagicPdfView({ objectId, onClose }: MagicPdfViewProps) {
         return (
             <div className="fixed inset-0 bg-background z-50 flex items-center justify-center">
                 <div className="flex flex-col items-center gap-4 p-8 max-w-md">
-                    <ErrorBox title={t('pdf.fetchingDocumentFailed')}>{error.message}</ErrorBox>
+                    <ErrorBox title={t('pdf.fetchingDocumentFailed')}>{errorMessage(error)}</ErrorBox>
                     {onClose && (
                         <Button variant="outline" onClick={onClose}>
                             Close

--- a/packages/ui/src/features/media-viewer/AudioPanel.tsx
+++ b/packages/ui/src/features/media-viewer/AudioPanel.tsx
@@ -56,7 +56,7 @@ export function AudioPanel({ url, source, object, className }: AudioPanelProps) 
                 if (!object) return;
                 if (object.metadata?.type !== ContentNature.Audio) return;
 
-                let downloadUrl;
+                let downloadUrl: Awaited<ReturnType<typeof client.files.getDownloadUrl>> | undefined;
                 if (audioRendition?.content?.source) {
                     downloadUrl = await client.files.getDownloadUrl(audioRendition.content.source);
                 } else if (isOriginalWebSupported && object.content?.source) {

--- a/packages/ui/src/features/media-viewer/VideoPanel.tsx
+++ b/packages/ui/src/features/media-viewer/VideoPanel.tsx
@@ -60,7 +60,7 @@ export function VideoPanel({ url, source, object, className }: VideoPanelProps) 
                 if (!object) return;
                 if (object.metadata?.type !== ContentNature.Video) return;
 
-                let downloadUrl;
+                let downloadUrl: Awaited<ReturnType<typeof client.files.getDownloadUrl>> | undefined;
                 if (webRendition?.content?.source) {
                     downloadUrl = await client.files.getDownloadUrl(webRendition.content.source);
                 } else if (isOriginalWebSupported && object.content?.source) {

--- a/packages/ui/src/features/pdf-viewer/PdfPageSlider.tsx
+++ b/packages/ui/src/features/pdf-viewer/PdfPageSlider.tsx
@@ -340,12 +340,16 @@ export function PdfPageSlider({
                     calculateItemHeight={calculateItemHeight}
                     renderThumbnail={({ pageNumber, isSelected, pageElement, onSelect }) => (
                         <div key={pageNumber} className={clsx("hover:bg-muted rounded-md w-full", compact ? "p-1" : "p-2")}>
-                            <div
+                            <Button
+                                variant="unstyled"
+                                size="none"
+                                aria-pressed={isSelected}
+                                aria-label={`Page ${pageNumber}`}
                                 className={clsx('relative border-[2px] cursor-pointer overflow-hidden', isSelected ? "border-primary" : "border-border")}
                                 onClick={onSelect}
                             >
                                 {pageElement}
-                            </div>
+                            </Button>
                             <Center className={clsx("text-muted-foreground font-semibold", compact ? "text-xs pt-0.5" : "text-sm pt-1")}>{pageNumber}</Center>
                         </div>
                     )}

--- a/packages/ui/src/features/permissions/UserPermissionsProvider.tsx
+++ b/packages/ui/src/features/permissions/UserPermissionsProvider.tsx
@@ -1,5 +1,5 @@
 import { Permission, ProjectRoles } from "@vertesia/common"
-import { ErrorBox, useFetch } from "@vertesia/ui/core"
+import { ErrorBox, errorMessage, useFetch } from "@vertesia/ui/core"
 import { UserSession, useUserSession } from "@vertesia/ui/session"
 import { createContext, useContext, useMemo } from "react"
 import { useUITranslation } from '@vertesia/ui/i18n';
@@ -96,7 +96,7 @@ export function UserPermissionProvider({ children }: UserPermissionProviderProps
     }, [session, data, isLoading]);
 
     if (error) {
-        return <ErrorBox title={t('store.failedToFetchRoleMappings')}>{error.message}</ErrorBox>
+        return <ErrorBox title={t('store.failedToFetchRoleMappings')}>{errorMessage(error)}</ErrorBox>
     }
 
     return perms && (

--- a/packages/ui/src/features/permissions/helpers.ts
+++ b/packages/ui/src/features/permissions/helpers.ts
@@ -1,9 +1,12 @@
 import { Permission } from "@vertesia/common";
 
+type PermissionSet = Permission[] & {
+    __AnyOf__?: boolean;
+};
 
 export function AnyOf(...permissions: Permission[]): Permission[] {
-    const p = Array.from(permissions);
-    (p as any).__AnyOf__ = true;
+    const p: PermissionSet = Array.from(permissions);
+    p.__AnyOf__ = true;
     return p;
 }
 
@@ -12,5 +15,5 @@ export function AllOf(...permissions: Permission[]): Permission[] {
 }
 
 export function isAnyOf(permissions: Permission[]) {
-    return (permissions as any).__AnyOf__ === true;
+    return (permissions as PermissionSet).__AnyOf__ === true;
 }

--- a/packages/ui/src/features/store/collections/CollectionsTable.tsx
+++ b/packages/ui/src/features/store/collections/CollectionsTable.tsx
@@ -1,7 +1,7 @@
 import { NavLink } from "@vertesia/ui/router";
 import { useUserSession } from "@vertesia/ui/session";
 import { FolderClosed, Search, Trash2 } from "lucide-react";
-import { Button, ConfirmModal, ErrorBox, Table, TBody, TR, useToast, VTooltip, useFetch, EmptyCollection } from "@vertesia/ui/core";
+import { Button, ConfirmModal, ErrorBox, Table, TBody, TR, useToast, VTooltip, useFetch, EmptyCollection, errorMessage } from "@vertesia/ui/core";
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { useState, useEffect } from "react";
@@ -30,7 +30,7 @@ export function CollectionsTable({ }: CollectionsTableProps) {
     }, [collections, error]);
 
     if (error) {
-        return <ErrorBox title={t('store.collectionFetchFailed')}>{error.message}</ErrorBox>
+        return <ErrorBox title={t('store.collectionFetchFailed')}>{errorMessage(error)}</ErrorBox>
     }
 
     const deleteCollection = async () => {
@@ -44,11 +44,11 @@ export function CollectionsTable({ }: CollectionsTableProps) {
                 duration: 3000
             });
             refetch();
-        } catch (err: any) {
+        } catch (err: unknown) {
             console.error('Failed to delete collection:', err);
             toast({
                 title: t('store.failedToDeleteCollection'),
-                description: err.message || 'An error occurred',
+                description: errorMessage(err),
                 status: 'error',
                 duration: 5000
             });

--- a/packages/ui/src/features/store/collections/CreateCollection.tsx
+++ b/packages/ui/src/features/store/collections/CreateCollection.tsx
@@ -23,7 +23,7 @@ export function CreateCollectionForm({ onClose, redirect = true, onAddToCollecti
         description: "",
     });
 
-    function setPayloadProp(name: string, value: any) {
+    function setPayloadProp(name: string, value: unknown) {
         setPayload({
             ...payload,
             [name]: value,

--- a/packages/ui/src/features/store/collections/EditCollectionView.tsx
+++ b/packages/ui/src/features/store/collections/EditCollectionView.tsx
@@ -1,5 +1,5 @@
 import { Collection, CreateCollectionPayload, getContentTypeRefId, JSONSchemaObject, SecurityLevelLabels } from "@vertesia/common";
-import { Badge, Button, ErrorBox, FormItem, Input, Panel, SelectBox, Styles, Textarea, useFetch, useToast, useTheme } from "@vertesia/ui/core";
+import { Badge, Button, ErrorBox, FormItem, Input, Panel, SelectBox, Styles, Textarea, errorMessage, useFetch, useToast, useTheme } from "@vertesia/ui/core";
 import { SharedPropsEditor, SyncMemberHeadsToggle, UserInfo } from "@vertesia/ui/features";
 import { useUserSession } from "@vertesia/ui/session";
 import { MonacoEditor, EditorApi, GeneratedForm, ManagedObject, Node } from "@vertesia/ui/widgets";
@@ -24,6 +24,11 @@ interface EditCollectionViewProps {
     collection: Collection;
     refetch: () => void;
 }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 export function EditCollectionView({ refetch, collection }: EditCollectionViewProps) {
     const { t } = useUITranslation();
     const typeId = collection.type ? getContentTypeRefId(collection.type) : undefined;
@@ -50,13 +55,17 @@ export function EditCollectionView({ refetch, collection }: EditCollectionViewPr
     }, [collection.table_layout]);
 
     const onSubmit = () => {
-        let query: any;
+        let query: Record<string, unknown> | undefined;
         try {
-            query = metadata.query ? JSON.parse(metadata.query) : undefined;
-        } catch (err: any) {
+            const parsedQuery = metadata.query ? JSON.parse(metadata.query) : undefined;
+            if (parsedQuery !== undefined && !isRecord(parsedQuery)) {
+                throw new Error(t('store.invalidQueryJson'));
+            }
+            query = parsedQuery;
+        } catch (err: unknown) {
             toast({
                 title: t('store.invalidQueryJson'),
-                description: err.message,
+                description: errorMessage(err),
                 status: "error",
                 duration: 5000,
             });
@@ -78,7 +87,7 @@ export function EditCollectionView({ refetch, collection }: EditCollectionViewPr
             error = t('type.nameRequired');
         }
         if (!payload.type) {
-            (payload as any).type = null;
+            payload.type = null;
         }
         if (error) {
             toast({
@@ -94,10 +103,10 @@ export function EditCollectionView({ refetch, collection }: EditCollectionViewPr
             if (layout) {
                 try {
                     payload.table_layout = JSON.parse(layout);
-                } catch (err: any) {
+                } catch (err: unknown) {
                     toast({
                         title: t('store.invalidTableLayout'),
-                        description: err.message,
+                        description: errorMessage(err),
                         status: "error",
                         duration: 5000,
                     });
@@ -127,7 +136,7 @@ export function EditCollectionView({ refetch, collection }: EditCollectionViewPr
             .catch((err) => {
                 toast({
                     title: t('store.failedToUpdateCollection'),
-                    description: err.message,
+                    description: errorMessage(err),
                     status: "error",
                     duration: 5000,
                 });
@@ -137,7 +146,7 @@ export function EditCollectionView({ refetch, collection }: EditCollectionViewPr
             });
     };
 
-    const setField = (name: string, value: any) => {
+    const setField = (name: string, value: unknown) => {
         setMetadata({
             ...metadata,
             [name]: value,
@@ -301,10 +310,10 @@ function PropertiesEditor({ typeId, collection }: PropertiesEditorProps) {
 
     const { data: type, error } = useFetch(() => client.store.types.catalog.resolve(typeId), [typeId]);
     const schema = type?.object_schema || {};
-    const object = useMemo(() => new ManagedObject(schema, collection.properties || {}), [schema, collection.properties]);
+    const object = useMemo(() => new ManagedObject(schema, (collection.properties as JSONSchemaObject | undefined) || {}), [schema, collection.properties]);
 
     if (error) {
-        return <ErrorBox title={t('store.failedToLoadType')}>{error.message}</ErrorBox>;
+        return <ErrorBox title={t('store.failedToLoadType')}>{errorMessage(error)}</ErrorBox>;
     }
 
     if (!type) {
@@ -331,7 +340,7 @@ function PropertiesEditor({ typeId, collection }: PropertiesEditorProps) {
             .catch((err) => {
                 toast({
                     title: t('store.failedToUpdateCollectionProperties'),
-                    description: err.message,
+                    description: errorMessage(err),
                     status: "error",
                     duration: 5000,
                 });

--- a/packages/ui/src/features/store/collections/SelectCollection.tsx
+++ b/packages/ui/src/features/store/collections/SelectCollection.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo, useState } from "react";
 
 import { CollectionItem } from "@vertesia/common";
 import {
-    Button, cn, ErrorBox, useDebounce, useFetch,
+    Button, cn, ErrorBox, errorMessage, useDebounce, useFetch,
     Popover, PopoverContent, PopoverTrigger,
     Command, CommandEmpty, CommandGroup, CommandItem, CommandInput
 } from "@vertesia/ui/core";
@@ -157,7 +157,7 @@ export function SelectCollection({ onChange, value, disabled = false, placeholde
     if (error) {
         return (
             <ErrorBox title={t('store.collectionFetchFailed')}>
-                {error.message}
+                {errorMessage(error)}
             </ErrorBox>
         );
     }

--- a/packages/ui/src/features/store/objects/DocumentSearchResults.tsx
+++ b/packages/ui/src/features/store/objects/DocumentSearchResults.tsx
@@ -171,7 +171,7 @@ export function DocumentSearchResults({ layout, onUpload, allowFilter = true, al
                     {
                         name: "Search Score",
                         field: "score",
-                        render: (item) => (item as any).score?.toFixed(4) || "0.0000"
+                        render: (item) => typeof item.score === 'number' ? item.score.toFixed(4) : "0.0000"
                     } satisfies ExtendedColumnLayout,
                 ];
                 setActualLayout(layout);
@@ -374,8 +374,9 @@ function OverviewDrawer({ object, onClose }: OverviewDrawerProps) {
     const { downloadFromContentSource } = useDownloadFile({ client: store, toast });
 
     const contentSource = object?.content?.source;
+    const title = typeof object?.properties?.title === 'string' ? object.properties.title : object?.name;
     return object ? (
-        <SidePanel title={object.properties?.title || object.name} isOpen={true} onClose={onClose}>
+        <SidePanel title={title} isOpen={true} onClose={onClose}>
             <div className="flex items-center gap-x-2">
                 <Button variant="ghost" size="sm" title="Open Object" onClick={() => navigate(`/objects/${object.id}`)}>
                     <ExternalLink className="size-4" />

--- a/packages/ui/src/features/store/objects/DocumentSelectionProvider.tsx
+++ b/packages/ui/src/features/store/objects/DocumentSelectionProvider.tsx
@@ -68,7 +68,7 @@ export class DocumentSelection {
     }
 }
 
-const DocumentSelectionContext = createContext<DocumentSelection>(undefined as any);
+const DocumentSelectionContext = createContext<DocumentSelection | undefined>(undefined);
 
 export function useDocumentSelection() {
     const selection = useContext(DocumentSelectionContext);

--- a/packages/ui/src/features/store/objects/DocumentTable.tsx
+++ b/packages/ui/src/features/store/objects/DocumentTable.tsx
@@ -359,7 +359,7 @@ function DocumentTableImpl({
                     }
                 }
             }
-            onSelectionChange && onSelectionChange(selection);
+            onSelectionChange?.(selection);
         }
     };
 

--- a/packages/ui/src/features/store/objects/DocumentTable.tsx
+++ b/packages/ui/src/features/store/objects/DocumentTable.tsx
@@ -178,6 +178,7 @@ function ObjectTableWithDropZone({
     };
 
     return (
+        // biome-ignore lint/a11y/noStaticElementInteractions: drag/drop target for file upload; selection is exposed via the upload UI.
         <div
             className="min-h-[400px] relative"
             onDragOver={handleDragOver}

--- a/packages/ui/src/features/store/objects/DocumentTable.tsx
+++ b/packages/ui/src/features/store/objects/DocumentTable.tsx
@@ -47,6 +47,11 @@ interface ObjectTableWithDropZoneProps extends DocumentTableProps {
     collectionId?: string;
     skipTypeModal?: boolean;
 }
+
+type UploadPromiseWithProcessedFiles = Promise<unknown> & {
+    processedFiles?: FileWithMetadata[] | null;
+};
+
 function ObjectTableWithDropZone({
     isGridView,
     onUpload,
@@ -118,7 +123,7 @@ function ObjectTableWithDropZone({
 
                 // Attach the processed files to the promise for parent components to use
                 if (uploadPromise && typeof uploadPromise === "object") {
-                    (uploadPromise as any).processedFiles = processedFiles;
+                    (uploadPromise as UploadPromiseWithProcessedFiles).processedFiles = processedFiles;
                 }
             } else {
                 // Otherwise, open our type selection modal
@@ -326,7 +331,7 @@ function DocumentTableImpl({
 
     const _onSelectionChange = (object: ContentObjectItem, ev: ChangeEvent<HTMLInputElement>) => {
         if (selection) {
-            const isShift = (ev.nativeEvent as any).shiftKey;
+            const isShift = ev.nativeEvent instanceof MouseEvent && ev.nativeEvent.shiftKey;
             const checked = ev.target.checked;
             if (!checked) {
                 selection.remove(object.id);

--- a/packages/ui/src/features/store/objects/components/DocumentIcon.tsx
+++ b/packages/ui/src/features/store/objects/components/DocumentIcon.tsx
@@ -11,7 +11,7 @@ import { CheckIcon, Eye } from 'lucide-react'
 interface DocumentIconProps {
     document: ContentObjectItem
     onSelectionChange: ((object: ContentObjectItem, ev: ChangeEvent<HTMLInputElement>) => void);
-    selection: DocumentSelection;
+    selection?: DocumentSelection;
     onRowClick?: (object: ContentObjectItem) => void;
     highlightRow?: (item: ContentObjectItem) => boolean;
     previewObject?: (objectId: string) => void;
@@ -53,6 +53,7 @@ export function DocumentIcon({ selection, document, onSelectionChange, onRowClic
     const [renditionUrl, setRenditionUrl] = useState<string | undefined>(undefined)
     const [renditionAlt, setRenditionAlt] = useState<string | undefined>(undefined)
     const [renditionStatus, setRenditionStatus] = useState<string | undefined>(undefined)
+    const title = typeof document.properties?.title === 'string' ? document.properties.title : document.name;
 
 
     const handleSelect = (ev: React.ChangeEvent<HTMLInputElement>) => {
@@ -118,8 +119,8 @@ export function DocumentIcon({ selection, document, onSelectionChange, onRowClic
                 <div className="flex flex-col overflow-hidden">
                     <VTooltip
                         placement='top'
-                        description={document.properties?.title ?? document.name}>
-                        <h3 className="text-start font-medium leading-none truncate">{document.properties?.title ?? document.name}</h3>
+                        description={title}>
+                        <h3 className="text-start font-medium leading-none truncate">{title}</h3>
                     </VTooltip>
                     {
                         document?.type?.name ? (

--- a/packages/ui/src/features/store/objects/components/DocumentInput.tsx
+++ b/packages/ui/src/features/store/objects/components/DocumentInput.tsx
@@ -54,7 +54,7 @@ export function DocumentInput({ object }: DocumentInputProps) {
             return;
         }
 
-        client.objects.get(match[1]).then((doc) => {
+        client.objects.retrieve(match[1]).then((doc) => {
             setDoc(doc);
         }).catch(() => {
             clearValue();
@@ -81,7 +81,7 @@ export function DocumentInput({ object }: DocumentInputProps) {
             </div>
             {doc &&
                 <div className="p-1 semibold text-sm text-gray-600 dark:text-slate-300">
-                    {doc.properties?.title || doc.name}
+                    {typeof doc.properties?.title === 'string' ? doc.properties.title : doc.name}
                 </div>
             }
         </div>

--- a/packages/ui/src/features/store/objects/components/PropertiesEditorModal.tsx
+++ b/packages/ui/src/features/store/objects/components/PropertiesEditorModal.tsx
@@ -7,10 +7,11 @@ import {
     ModalBody,
     ModalFooter,
     ModalTitle,
+    errorMessage,
     useToast,
     useTheme
 } from '@vertesia/ui/core';
-import { ContentObject } from '@vertesia/common';
+import { ContentObject, JSONSchema } from '@vertesia/common';
 import { useNavigate } from "@vertesia/ui/router";
 
 // Import Monaco Editor wrapper
@@ -35,9 +36,9 @@ export function PropertiesEditorModal({ isOpen, onClose, object, refetch }: Prop
     const [isLoading, setIsLoading] = useState(false);
     const [propertiesJson, setPropertiesJson] = useState('');
     const [showConfirmation, setShowConfirmation] = useState(false);
-    const [parsedProperties, setParsedProperties] = useState<any>(null);
+    const [parsedProperties, setParsedProperties] = useState<unknown>(null);
     const editorRef = useRef<IEditorApi | undefined>(undefined);
-    const [jsonSchema, setJsonSchema] = useState<any>(null);
+    const [jsonSchema, setJsonSchema] = useState<JSONSchema | null>(null);
     //TODO  state not used
     const [_newVersionId, setNewVersionId] = useState<string | null>(null);
 
@@ -91,7 +92,7 @@ export function PropertiesEditorModal({ isOpen, onClose, object, refetch }: Prop
             const properties = JSON.parse(editorValue);
             setParsedProperties(properties);
             setShowConfirmation(true);
-        } catch (err) {
+        } catch {
             toast({
                 status: 'error',
                 title: t('store.invalidJson'),
@@ -171,11 +172,11 @@ export function PropertiesEditorModal({ isOpen, onClose, object, refetch }: Prop
                 setShowConfirmation(false);
                 onClose();
             }
-        } catch (error: any) {
+        } catch (error: unknown) {
             toast({
                 status: 'error',
                 title: t('store.errorUpdatingProperties'),
-                description: error.message || t('store.errorUpdatingPropertiesDefault'),
+                description: errorMessage(error, t('store.errorUpdatingPropertiesDefault')),
                 duration: 5000
             });
             setIsLoading(false);
@@ -203,7 +204,7 @@ export function PropertiesEditorModal({ isOpen, onClose, object, refetch }: Prop
                         ) : (
                             <span>{t('store.editingGenericDocument')}</span>
                         )}
-                        {jsonSchema && (
+                        {jsonSchema !== null && (
                             <span className="ms-2 text-green-600">(JSON schema validation enabled)</span>
                         )}
                     </div>

--- a/packages/ui/src/features/store/objects/components/TextEditorPanel.tsx
+++ b/packages/ui/src/features/store/objects/components/TextEditorPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback } from 'react';
 import { ContentObject } from '@vertesia/common';
-import { Button, useToast, useTheme } from '@vertesia/ui/core';
+import { Button, errorMessage, useToast, useTheme } from '@vertesia/ui/core';
 import { useUserSession } from '@vertesia/ui/session';
 import { useNavigate } from '@vertesia/ui/router';
 import { MonacoEditor, IEditorApi } from '@vertesia/ui/widgets';
@@ -66,7 +66,7 @@ export function TextEditorPanel({ object, text, onClose, onSaved }: TextEditorPa
             const file = new File([blob], fileName, { type: contentType });
 
             const response = await store.objects.update(object.id, {
-                content: file as any,
+                content: file,
             }, {
                 createRevision: createVersion,
                 revisionLabel: versionLabel,
@@ -89,14 +89,16 @@ export function TextEditorPanel({ object, text, onClose, onSaved }: TextEditorPa
             } else {
                 onSaved();
             }
-        } catch (error: any) {
-            const is412 = error?.status === 412 || error?.message?.includes('412');
+        } catch (error: unknown) {
+            const message = errorMessage(error, t('store.errorSavingTextDefault'));
+            const status = typeof error === 'object' && error !== null && 'status' in error ? error.status : undefined;
+            const is412 = status === 412 || message.includes('412');
             toast({
                 status: 'error',
                 title: t('store.errorSavingText'),
                 description: is412
                     ? t('store.textConflict')
-                    : (error.message || t('store.errorSavingTextDefault')),
+                    : message,
                 duration: 5000,
             });
         } finally {

--- a/packages/ui/src/features/store/objects/components/VectorSearchWidget.tsx
+++ b/packages/ui/src/features/store/objects/components/VectorSearchWidget.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { ComplexSearchQuery, ProjectConfiguration, SearchTypes, SupportedEmbeddingTypes } from '@vertesia/common';
-import { Button, Checkbox, Input, Modal, ModalBody, ModalFooter, ModalTitle, NumberInput, useToast } from '@vertesia/ui/core';
+import { Button, Checkbox, Input, Label, Modal, ModalBody, ModalFooter, ModalTitle, NumberInput, useToast } from '@vertesia/ui/core';
 import { useUserSession } from '@vertesia/ui/session';
 import { Settings } from 'lucide-react';
 
@@ -113,22 +113,24 @@ export function VectorSearchWidget({ onChange, isLoading, refresh, searchTypes }
                 <ModalTitle>{t('store.searchTypes')}</ModalTitle>
                 <ModalBody>
                     <div className="flex flex-col gap-2">
-                        <label className="flex items-center gap-2">
+                        <div className="flex items-center gap-2">
                             <Checkbox
+                                id="search-type-full_text"
                                 checked={selectedTypes.includes(SearchTypes.full_text)}
                                 onCheckedChange={handleCheckboxChange(SearchTypes.full_text)}
                             />
-                            <span>{t('store.fullText')}</span>
-                        </label>
+                            <Label htmlFor="search-type-full_text">{t('store.fullText')}</Label>
+                        </div>
                         <div className="font-semibold mt-2 mb-1">{t('store.embeddings')}</div>
                         {embeddingTypes.map(type => (
-                            <label key={type} className="flex items-center gap-2">
+                            <div key={type} className="flex items-center gap-2">
                                 <Checkbox
+                                    id={`search-type-${type}`}
                                     checked={selectedTypes.includes(type)}
                                     onCheckedChange={handleCheckboxChange(type)}
                                 />
-                                <span>{type.charAt(0).toUpperCase() + type.slice(1)}</span>
-                            </label>
+                                <Label htmlFor={`search-type-${type}`}>{type.charAt(0).toUpperCase() + type.slice(1)}</Label>
+                            </div>
                         ))}
                         <div className="mt-3">
                             <span className="me-2">{t('store.limit')}</span>

--- a/packages/ui/src/features/store/objects/layout/DocumentTableColumn.tsx
+++ b/packages/ui/src/features/store/objects/layout/DocumentTableColumn.tsx
@@ -6,16 +6,26 @@ import renderers from './renderers';
 
 const defaultRenderer = renderers.string();
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
 function resolveField(object: ContentObjectItem, path: string[]) {
-    let p = object as any;
+    let p = object as unknown;
     if (!p) return undefined;
     if (!path.length) return p;
     const last = path.length - 1;
     for (let i = 0; i < last; i++) {
+        if (!isRecord(p)) {
+            return undefined;
+        }
         p = p[path[i]];
         if (!p) {
             return undefined;
         }
+    }
+    if (!isRecord(p)) {
+        return undefined;
     }
     return p[path[last]];
 }
@@ -34,7 +44,7 @@ export interface ExtendedColumnLayout extends Omit<ColumnLayout, 'field'> {
 }
 
 export class DocumentTableColumn {
-    renderer: (value: any, index: number) => React.ReactNode = defaultRenderer;
+    renderer: (value: unknown, index: number) => React.ReactNode = defaultRenderer;
     path: string[];
     fallbackPath?: string[];
     previewObject?: (objectId: string) => void;
@@ -45,7 +55,7 @@ export class DocumentTableColumn {
 
         // If there's a custom render function, use it
         if (layout.render) {
-            this.renderer = (_value: any, _index: number) => null; // Placeholder, we'll use render directly
+            this.renderer = (_value: unknown, _index: number) => null; // Placeholder, we'll use render directly
         } else {
             // Otherwise use the type-based renderer
             const type = layout.type || 'string';

--- a/packages/ui/src/features/store/objects/layout/documentLayout.tsx
+++ b/packages/ui/src/features/store/objects/layout/documentLayout.tsx
@@ -40,7 +40,7 @@ export function DocumentTableView({ objects, selection, isLoading, columns, onRo
                         return (
                             // biome-ignore lint/a11y/useKeyWithClickEvents: clickable table row; <tr> doesn't accept role="button" semantically — keyboard nav handled at table level via arrow keys.
                             <tr key={obj.id} className={`cursor-pointer hover:bg-muted group ${selectedObject?.id === obj.id ? 'bg-muted' : ''} ${isHighlighted ? 'bg-blue-50 dark:bg-blue-900/20' : ''}`} onClick={() => {
-                                onRowClick && onRowClick(obj)
+                                onRowClick?.(obj)
                             }}>
                                 {selection &&
                                     // biome-ignore lint/a11y/useKeyWithClickEvents: stop-propagation wrapper to prevent inner checkbox clicks from triggering row activation; not a user-facing interaction.

--- a/packages/ui/src/features/store/objects/layout/documentLayout.tsx
+++ b/packages/ui/src/features/store/objects/layout/documentLayout.tsx
@@ -38,10 +38,12 @@ export function DocumentTableView({ objects, selection, isLoading, columns, onRo
                     objects?.map((obj: ContentObjectItem) => {
                         const isHighlighted = highlightRow?.(obj);
                         return (
+                            // biome-ignore lint/a11y/useKeyWithClickEvents: clickable table row; <tr> doesn't accept role="button" semantically — keyboard nav handled at table level via arrow keys.
                             <tr key={obj.id} className={`cursor-pointer hover:bg-muted group ${selectedObject?.id === obj.id ? 'bg-muted' : ''} ${isHighlighted ? 'bg-blue-50 dark:bg-blue-900/20' : ''}`} onClick={() => {
                                 onRowClick && onRowClick(obj)
                             }}>
                                 {selection &&
+                                    // biome-ignore lint/a11y/useKeyWithClickEvents: stop-propagation wrapper to prevent inner checkbox clicks from triggering row activation; not a user-facing interaction.
                                     <td onClick={ev => ev.stopPropagation()}>
                                         <input checked={selection.isSelected(obj.id)} type="checkbox" className={`${!selection.isSelected(obj.id) ? 'hidden group-hover:block' : ''}`}
                                             onChange={(ev: ChangeEvent<HTMLInputElement>) => onSelectionChange(obj, ev)} />

--- a/packages/ui/src/features/store/objects/layout/documentLayout.tsx
+++ b/packages/ui/src/features/store/objects/layout/documentLayout.tsx
@@ -16,7 +16,7 @@ interface ViewProps {
     previewObject?: (objectId: string) => void;
     selectedObject?: ContentObjectItem | null;
     onSelectionChange: ((object: ContentObjectItem, ev: ChangeEvent<HTMLInputElement>) => void);
-    selection: DocumentSelection;
+    selection?: DocumentSelection;
     toggleAll?: (ev: ChangeEvent<HTMLInputElement>) => void;
     columns: DocumentTableColumn[];
 }

--- a/packages/ui/src/features/store/objects/layout/renderers.tsx
+++ b/packages/ui/src/features/store/objects/layout/renderers.tsx
@@ -7,7 +7,29 @@ import { Button } from "@vertesia/ui/core";
 dayjs.extend(RelativeTime);
 dayjs.extend(LocalizedFormat);
 
-const renderers: Record<string, (params?: URLSearchParams, onClick?: (id: string) => void) => (value: any, index: number) => React.ReactNode> = {
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
+}
+
+function getStringProperty(value: unknown, property: string): string | undefined {
+    if (!isRecord(value)) return undefined;
+    const propertyValue = value[property];
+    return typeof propertyValue === "string" ? propertyValue : undefined;
+}
+
+function getObjectId(value: unknown): string {
+    if (typeof value === "string") return value;
+    return getStringProperty(value, "id") || "";
+}
+
+function renderableValue(value: unknown): React.ReactNode {
+    if (value == null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+        return value;
+    }
+    return String(value);
+}
+
+const renderers: Record<string, (params?: URLSearchParams, onClick?: (id: string) => void) => (value: unknown, index: number) => React.ReactNode> = {
     string(params?: URLSearchParams, _onClick?: (id: string) => void) {
         let transforms: ((value: string) => string)[] = [];
         if (params) {
@@ -32,7 +54,7 @@ const renderers: Record<string, (params?: URLSearchParams, onClick?: (id: string
                 transforms.push((value: string) => value + "...");
             }
         }
-        return (value: any, index: number) => {
+        return (value: unknown, index: number) => {
             let v: string;
             if (value) {
                 v = String(value);
@@ -50,7 +72,7 @@ const renderers: Record<string, (params?: URLSearchParams, onClick?: (id: string
     },
 
     fileSize(_params?: URLSearchParams, _onClick?: (id: string) => void) {
-        return (value: any, index: number) => {
+        return (value: unknown, index: number) => {
             let fileSize = "";
             if (value) {
                 const bytes = Number(value);
@@ -80,12 +102,13 @@ const renderers: Record<string, (params?: URLSearchParams, onClick?: (id: string
 
         const digits = decimals ? parseInt(decimals) : 2;
 
-        return (value: any, index: number) => {
+        return (value: unknown, index: number) => {
+            const numberValue = Number(value);
             let v = new Intl.NumberFormat("en-US", {
                 style: currency ? "currency" : "decimal",
                 currency,
                 maximumFractionDigits: digits,
-            }).format(value);
+            }).format(Number.isFinite(numberValue) ? numberValue : 0);
             return <td key={index}>{v}</td>;
         };
     },
@@ -99,18 +122,19 @@ const renderers: Record<string, (params?: URLSearchParams, onClick?: (id: string
                 transforms.push((value) => value.slice(parseInt(slice)));
             }
         }
-        return (value: any, index: number) => {
-            const displayValue = transforms.reduce((v, t) => t(v), value.id);
+        return (value: unknown, index: number) => {
+            const objectId = getObjectId(value);
+            const displayValue = transforms.reduce((v, t) => t(v), objectId);
             return (
                 <td key={index} className="flex justify-between items-center gap-2">
                     {hasSlice ? '~' : ''}{displayValue}
                     <Button
                         variant="ghost"
                         alt="Preview Object"
-                        onClick={(e) => {
-                            e.stopPropagation();
-                            onClick?.(value.id);
-                        }}
+	                        onClick={(e) => {
+	                            e.stopPropagation();
+	                            onClick?.(objectId);
+	                        }}
                     >
                         <Eye className="size-4" />
                     </Button>
@@ -123,10 +147,15 @@ const renderers: Record<string, (params?: URLSearchParams, onClick?: (id: string
         if (params) {
             title = params.get("title") || "title";
         }
-        return (value: any, index: number) => {
+        return (value: unknown, index: number) => {
+            const properties = isRecord(value) && isRecord(value.properties) ? value.properties : undefined;
+            const titleValue = properties?.[title];
+            const titleText = renderableValue(titleValue);
+            const name = getStringProperty(value, "name");
+            const id = getStringProperty(value, "id");
             return (
                 <td key={index}>
-                    {value.properties?.[title] || value.name || shortId(value.id)}
+                    {titleText || name || (id ? shortId(id) : "")}
                 </td>
             );
         };
@@ -137,18 +166,19 @@ const renderers: Record<string, (params?: URLSearchParams, onClick?: (id: string
         const hasSlice = true;
         transforms.push((value) => value.slice(-7));
 
-        return (value: any, index: number) => {
-            const displayValue = transforms.reduce((v, t) => t(v), value.id);
+        return (value: unknown, index: number) => {
+            const objectId = getObjectId(value);
+            const displayValue = transforms.reduce((v, t) => t(v), objectId);
             return (
                 <td key={index} className="flex justify-between items-center gap-2 max-w-48">
                     {hasSlice ? "~" : ""}{displayValue}
                     <Button
                         variant="ghost"
                         alt="Preview Object"
-                        onClick={(e) => {
-                            e.stopPropagation();
-                            onClick?.(value.id);
-                        }}
+	                        onClick={(e) => {
+	                            e.stopPropagation();
+	                            onClick?.(objectId);
+	                        }}
                     >
                         <Eye className="size-4" />
                     </Button>
@@ -157,31 +187,33 @@ const renderers: Record<string, (params?: URLSearchParams, onClick?: (id: string
         };
     },
     typeLink(_params?: URLSearchParams, _onClick?: (id: string) => void) {
-        return (value: any, index: number) => {
-            return <td key={index}>{value?.name || "n/a"}</td>;
+        return (value: unknown, index: number) => {
+            return <td key={index}>{getStringProperty(value, "name") || "n/a"}</td>;
         };
     },
     revision(_params?: URLSearchParams, _onClick?: (id: string) => void) {
-        return (value: any, index: number) => {
-            const rev = value?.revision;
+        return (value: unknown, index: number) => {
+            const rev = isRecord(value) && isRecord(value.revision) ? value.revision : undefined;
             if (!rev) return <td key={index} />;
+            const root = getStringProperty(rev, "root");
+            const label = getStringProperty(rev, "label");
             return (
                 <td key={index}>
                     <div className="flex flex-col gap-0.5">
-                        {rev.root &&
+                        {root &&
                             <div className="flex items-center gap-1">
                                 <span className="text-xs text-muted font-mono">
-                                    root: ~{rev.root.slice(-7)}
+                                    root: ~{root.slice(-7)}
                                 </span>
                                 <a
-                                    href={`/store/objects/${rev.root}`}
+                                    href={`/store/objects/${root}`}
                                     onClick={(e) => e.stopPropagation()}
                                 >
                                     <ExternalLink className="size-3 text-muted" />
                                 </a>
                             </div>
                         }
-                        {rev.label && <span className="text-xs text-muted">label: {rev.label}</span>}
+                        {label && <span className="text-xs text-muted">label: {label}</span>}
                     </div>
                 </td>
             );
@@ -202,8 +234,11 @@ const renderers: Record<string, (params?: URLSearchParams, onClick?: (id: string
                 }
             }
         }
-        return (value: any, index: number) => {
-            return <td key={index}>{(dayjs(value) as any)[method](arg)}</td>;
+        return (value: unknown, index: number) => {
+            const dateValue = typeof value === "string" || typeof value === "number" || value instanceof Date ? value : undefined;
+            const date = dayjs(dateValue);
+            const text = method === "fromNow" ? date.fromNow() : method === "toNow" ? date.toNow() : date.format(arg);
+            return <td key={index}>{text}</td>;
         };
     },
 };

--- a/packages/ui/src/features/store/objects/search/DocumentSearchContext.ts
+++ b/packages/ui/src/features/store/objects/search/DocumentSearchContext.ts
@@ -46,16 +46,16 @@ export class DocumentSearch implements SearchInterface {
     }
 
     getFilterValue(name: string) {
-        return (this.query as any)[name];
+        return (this.query as Record<string, unknown>)[name];
     }
 
-    setFilterValue(name: string, value: any) {
-        (this.query as any)[name] = value;
+    setFilterValue(name: string, value: unknown) {
+        (this.query as Record<string, unknown>)[name] = value;
         // search now
         this.search();
     }
 
-    setDefaultKeys(keys: any[]) {
+    setDefaultKeys(keys: unknown[]) {
         void keys;
     }
 

--- a/packages/ui/src/features/store/objects/selection/ObjectsActionContext.tsx
+++ b/packages/ui/src/features/store/objects/selection/ObjectsActionContext.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, useMemo } from 'react';
 
 import { ContentObjectTypeItem } from '@vertesia/common';
-import { ErrorBox, useFetch, useToast } from '@vertesia/ui/core';
+import { ErrorBox, errorMessage, useFetch, useToast } from '@vertesia/ui/core';
 import { useUserSession } from '@vertesia/ui/session';
 import { useUITranslation } from '@vertesia/ui/i18n';
 
@@ -63,7 +63,7 @@ export function ObjectsActionContextProvider({ children, type }: ObjectsActionCo
     }, [selection, rules, type]);
 
     if (error) {
-        return <ErrorBox title={t('store.failedToFetchWorkflows')}>{error.message}</ErrorBox>
+        return <ErrorBox title={t('store.failedToFetchWorkflows')}>{errorMessage(error)}</ErrorBox>
     }
 
     return (

--- a/packages/ui/src/features/store/objects/selection/ObjectsActionHooks.ts
+++ b/packages/ui/src/features/store/objects/selection/ObjectsActionHooks.ts
@@ -3,7 +3,7 @@ import { ObjectsActionContext, type ObjectsActionCallback } from './ObjectsActio
 
 export { type ObjectsActionCallback };
 
-export const ObjectsActionContextReact = createContext<ObjectsActionContext>(undefined as any);
+export const ObjectsActionContextReact = createContext<ObjectsActionContext | undefined>(undefined);
 
 export function useObjectsActionContext() {
     const ctx = useContext(ObjectsActionContextReact);

--- a/packages/ui/src/features/store/objects/selection/actions/AddToCollectionAction.tsx
+++ b/packages/ui/src/features/store/objects/selection/actions/AddToCollectionAction.tsx
@@ -90,7 +90,7 @@ function AddToCollectionForm({ onClose, objectIds }: AddToCollectionFormProps) {
         });
     }
 
-    const onCollectionChange = (collectionId: string | string[] | undefined, _collection?: any) => {
+    const onCollectionChange = (collectionId: string | string[] | undefined, _collection?: unknown) => {
         if (typeof collectionId === "string" || typeof collectionId === "undefined") {
             setSelectedCollectionId(collectionId);
         } else if (Array.isArray(collectionId) && collectionId.length > 0) {

--- a/packages/ui/src/features/store/objects/selection/actions/ExportPropertiesAction.tsx
+++ b/packages/ui/src/features/store/objects/selection/actions/ExportPropertiesAction.tsx
@@ -70,7 +70,7 @@ export function ExportPropertiesComponent({ action, objectIds }: ActionComponent
                     const data = new Blob([response.data], { type: response.type });
 
                     const url = window.URL.createObjectURL(data);
-                    const a: any = document.createElement('a');
+                    const a = document.createElement('a');
                     a.download = response.name;
                     a.href = url;
                     a.click();

--- a/packages/ui/src/features/store/objects/selection/actions/RemoveFromCollectionAction.tsx
+++ b/packages/ui/src/features/store/objects/selection/actions/RemoveFromCollectionAction.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 
-import { useToast } from '@vertesia/ui/core';
+import { errorMessage, useToast } from '@vertesia/ui/core';
 import { useUserSession } from '@vertesia/ui/session';
 
 import { useUITranslation } from '@vertesia/ui/i18n';
@@ -52,11 +52,11 @@ export function RemoveFromCollectionActionComponent({ action, objectIds, collect
                 ctx.params?.selection?.removeAll();
                 search.search();
             }
-        }).catch((err: any) => {
+        }).catch((err: unknown) => {
             toast({
                 status: 'error',
                 title: t('store.actions.errorRemovingObjects'),
-                description: err.message,
+                description: errorMessage(err),
                 duration: 5000
             });
         });

--- a/packages/ui/src/features/store/objects/upload/DocumentUploadModal.tsx
+++ b/packages/ui/src/features/store/objects/upload/DocumentUploadModal.tsx
@@ -1,5 +1,5 @@
 import { Collection, ContentObjectTypeItem, DynamicCollection } from "@vertesia/common";
-import { Button, MessageBox, Modal, ModalBody, ModalFooter, ModalTitle, SelectBox, Spinner, useToast, VTooltip } from "@vertesia/ui/core";
+import { Button, MessageBox, Modal, ModalBody, ModalFooter, ModalTitle, SelectBox, Spinner, errorMessage, useToast, VTooltip } from "@vertesia/ui/core";
 import { useUserSession } from "@vertesia/ui/session";
 import { useTypeRegistry } from "../../types/TypeRegistryProvider.js";
 import { DropZone, UploadSummary } from '@vertesia/ui/widgets';
@@ -426,7 +426,7 @@ export function DocumentUploadModal({
                                     location: fileInfo.location,
                                 });
                             }
-                        } catch (error: any) {
+                        } catch (error: unknown) {
                             console.error(`Failed to process file ${fileInfo.name}:`, error);
 
                             // Update status to error
@@ -437,7 +437,7 @@ export function DocumentUploadModal({
                                             ...status,
                                             status: "error",
                                             progress: 100,
-                                            message: error.message || "Unknown error",
+                                            message: errorMessage(error, "Unknown error"),
                                         }
                                         : status,
                                 ),
@@ -446,7 +446,7 @@ export function DocumentUploadModal({
                             // Add to failed result
                             result.failedFiles.push({
                                 name: fileInfo.name,
-                                error: error.message || "Unknown error",
+                                error: errorMessage(error, "Unknown error"),
                                 status: "failed",
                                 location: fileInfo.location,
                                 type: typeId,

--- a/packages/ui/src/features/store/objects/upload/DocumentUploadModal.tsx
+++ b/packages/ui/src/features/store/objects/upload/DocumentUploadModal.tsx
@@ -563,7 +563,7 @@ export function DocumentUploadModal({
     const typeSelection = () => {
         return (
             <div className="mb-4">
-                <label className="block text-sm font-medium mb-2">
+                <div className="block text-sm font-medium mb-2">
                     {t('store.contentType')} <span className="text-muted font-normal">{t('store.optional')}</span>
                     <VTooltip
                         description={t('upload.contentTypeTooltip')}
@@ -571,7 +571,7 @@ export function DocumentUploadModal({
                     >
                         <Info className="size-3 ms-2" />
                     </VTooltip>
-                </label>
+                </div>
                 <SelectBox
                     options={types}
                     value={selectedType}

--- a/packages/ui/src/features/store/objects/upload/useSmartFileUploadProcessing.ts
+++ b/packages/ui/src/features/store/objects/upload/useSmartFileUploadProcessing.ts
@@ -1,5 +1,5 @@
 import { ComplexSearchPayload, ContentObjectItem, FindPayload } from "@vertesia/common";
-import { useToast } from "@vertesia/ui/core";
+import { errorMessage, useToast } from "@vertesia/ui/core";
 import { useUserSession } from "@vertesia/ui/session";
 import { Md5 } from "ts-md5";
 import { i18nInstance, NAMESPACE } from '@vertesia/ui/i18n';
@@ -27,7 +27,7 @@ export interface FileWithMetadata {
     // Action to take with this file
     action?: FileUploadAction;
     // Any additional metadata needed
-    metadata?: Record<string, any>;
+    metadata?: Record<string, unknown>;
 }
 
 /**
@@ -69,9 +69,9 @@ async function prepareFilesWithMetadata(files: File[], selectedFolder?: string |
                 let location = selectedFolder || "/";
 
                 // If file has relative path, use it to determine location
-                const hasRelativePath = !!(file as any).webkitRelativePath;
+                const hasRelativePath = !!file.webkitRelativePath;
                 if (hasRelativePath) {
-                    const relativePath = (file as any).webkitRelativePath;
+                    const relativePath = file.webkitRelativePath;
                     const pathParts = relativePath.split("/");
 
                     if (pathParts.length > 1) {
@@ -175,7 +175,7 @@ export function useSmartFileUploadProcessing() {
                     const namesInLocation = unskippedFiles
                         .filter((file) => file.location === location)
                         .map((file) => file.name);
-                    const query: Record<string, any> = {
+                    const query: Record<string, unknown> = {
                         "content.name": { $in: namesInLocation },
                         location: location || "/"
                     };
@@ -236,14 +236,14 @@ export function useSmartFileUploadProcessing() {
             });
 
             return filesWithMetadata;
-        } catch (error: any) {
+        } catch (error: unknown) {
             toast({
                 title: t('store.errorInUploadProcessingCheck'),
                 status: "error",
-                description: error.message,
+                description: errorMessage(error),
             });
             console.log("Error in file upload processing check", error);
-            throw new Error("Error in file upload processing check: " + error.message, { cause: error });
+            throw new Error("Error in file upload processing check: " + errorMessage(error), { cause: error });
         }
     };
 

--- a/packages/ui/src/features/store/objects/upload/useUploadHandler.ts
+++ b/packages/ui/src/features/store/objects/upload/useUploadHandler.ts
@@ -1,4 +1,4 @@
-import { useToast } from "@vertesia/ui/core";
+import { errorMessage, useToast } from "@vertesia/ui/core";
 import { useUserSession } from "@vertesia/ui/session";
 import { i18nInstance, NAMESPACE } from '@vertesia/ui/i18n';
 import { useDocumentSearch } from "../search/DocumentSearchContext";
@@ -234,13 +234,13 @@ export function useDocumentUploadHandler(options: UploadHandlerOptions | ((objec
                                     location: fileInfo.location,
                                 });
                             }
-                        } catch (error: any) {
+                        } catch (error: unknown) {
                             console.error(`Failed to process file ${fileInfo.name}:`, error);
 
                             // Track failed upload
                             failedFilesInfo.push({
                                 name: fileInfo.name,
-                                error: error.message || "Unknown error",
+                                error: errorMessage(error, "Unknown error"),
                                 status: "failed",
                                 location: fileInfo.location,
                                 type,
@@ -249,7 +249,7 @@ export function useDocumentUploadHandler(options: UploadHandlerOptions | ((objec
                             toast({
                                 status: "error",
                                 title: t('store.processingFailedFor', { name: fileInfo.name }),
-                                description: error.message,
+                                description: errorMessage(error),
                                 duration: 4000,
                             });
                         }

--- a/packages/ui/src/features/store/types/ContentObjectTypesSearch.tsx
+++ b/packages/ui/src/features/store/types/ContentObjectTypesSearch.tsx
@@ -44,8 +44,8 @@ export function ContentObjectTypesSearch({ isDirty = false }: ContentObjectTypes
             .then(() => setIsReady(true));
     }, [debounceValue]);
 
-    const [chunkable, setChunkable] = useState(undefined);
-    const onChunkableChange = (data: any) => {
+    const [chunkable, setChunkable] = useState<string | undefined>(undefined);
+    const onChunkableChange = (data: string | undefined) => {
         setChunkable(data);
     };
 

--- a/packages/ui/src/features/store/types/ContentObjectTypesSearch.tsx
+++ b/packages/ui/src/features/store/types/ContentObjectTypesSearch.tsx
@@ -30,7 +30,7 @@ export function ContentObjectTypesSearch({ isDirty = false }: ContentObjectTypes
 
     const loadMoreRef = useRef<HTMLDivElement>(null);
     useIntersectionObserver(loadMoreRef, () => {
-        isReady && search.loadMore();
+        if (isReady) search.loadMore();
     }, { deps: [isReady] });
 
     useEffect(() => {

--- a/packages/ui/src/features/store/types/ContentObjectTypesTable.tsx
+++ b/packages/ui/src/features/store/types/ContentObjectTypesTable.tsx
@@ -28,7 +28,7 @@ export function ContentObjectTypesTable({ objects, isLoading }: ContentObjectTyp
             </THead>
             <TBody isLoading={isLoading && (!objects || objects.length === 0)} columns={4}>
                 {
-                    objects?.map((obj: any) => (
+                    objects?.map((obj) => (
                         <tr key={obj.id} onClick={() => navigate(`/types/${obj.id}`)} className='cursor-pointer hover:bg-muted'>
                             <td>{obj.name}</td>
                             <td>{obj.strict_mode ? 'Yes' : 'No'}</td>

--- a/packages/ui/src/features/store/types/CreateOrUpdateTypeModal.tsx
+++ b/packages/ui/src/features/store/types/CreateOrUpdateTypeModal.tsx
@@ -42,11 +42,11 @@ export function CreateOrUpdateTypeModal({ title, isOpen, onClose, okLabel, initi
             <ModalBody className="pt-0">
                 <div className='h-full flex flex-col gap-4 content-between'>
                     <div>
-                        <label className="block text-sm font-medium text-muted">{t('type.name')}</label>
+                        <div className="block text-sm font-medium text-muted">{t('type.name')}</div>
                         <Input value={name} onChange={setName} />
                     </div>
                     <div>
-                        <label className="block text-sm font-medium text-muted">{t('type.description')}</label>
+                        <div className="block text-sm font-medium text-muted">{t('type.description')}</div>
                         <Textarea value={description} onChange={e => setDescription(e.target.value)} minLines={5}/>
                     </div>
                 </div>

--- a/packages/ui/src/features/store/types/ObjectSchemaEditor.tsx
+++ b/packages/ui/src/features/store/types/ObjectSchemaEditor.tsx
@@ -3,13 +3,13 @@ import { useMemo, useRef, useState } from 'react';
 import { useUITranslation } from '@vertesia/ui/i18n';
 import { useUserSession } from '@vertesia/ui/session';
 import { MonacoEditor, EditorApi, SchemaEditor, useSchema } from '@vertesia/ui/widgets';
-import { Button, useToast, useTheme, Panel } from '@vertesia/ui/core';
+import { Button, errorMessage, useToast, useTheme, Panel } from '@vertesia/ui/core';
 import { ContentObjectType } from '@vertesia/common';
 import { Ajv } from "ajv";
 
 interface ObjectSchemaEditorProps {
     objectType: ContentObjectType;
-    onSchemaUpdate: (jsonSchema: any) => void;
+    onSchemaUpdate: (jsonSchema: unknown) => void;
     readonly?: boolean;
 }
 export function ObjectSchemaEditor({ objectType, onSchemaUpdate, readonly = false }: ObjectSchemaEditorProps) {
@@ -72,11 +72,11 @@ export function ObjectSchemaEditor({ objectType, onSchemaUpdate, readonly = fals
                 const newSchema = contentToJson(value);
                 validateSchema(newSchema);
                 schema.replaceSchema(newSchema);
-            } catch (err: any) {
+            } catch (err: unknown) {
                 toast({
                     status: 'error',
                     title: t('store.invalidJsonSchema'),
-                    description: err.message,
+                    description: errorMessage(err),
                     duration: 5000
                 })
                 return false;
@@ -118,7 +118,7 @@ export function ObjectSchemaEditor({ objectType, onSchemaUpdate, readonly = fals
     );
 }
 
-function jsonToContent(json: any | undefined | null) {
+function jsonToContent(json: unknown | undefined | null) {
     if (!json) {
         return ''
     }
@@ -134,7 +134,7 @@ function contentToJson(content: string | undefined | null) {
     return JSON.parse(content.trim());
 }
 
-const validateSchema = (schema: Record<string, any>) => {
+const validateSchema = (schema: Record<string, unknown>) => {
     try {
         const ajv = new Ajv({
             strict: false, // Enable strict mode to ensure all properties are validated
@@ -142,7 +142,7 @@ const validateSchema = (schema: Record<string, any>) => {
         // Compile the schema. This implicitly validates the schema definition
         // against the JSON Schema draft that ajv supports by default.
         ajv.compile(schema);
-    } catch (error: any) {
-        throw new Error(`Invalid JSON Schema definition: ${error.message}`, { cause: error });
+    } catch (error: unknown) {
+        throw new Error(`Invalid JSON Schema definition: ${errorMessage(error)}`, { cause: error });
     }
 };

--- a/packages/ui/src/features/store/types/SelectContentType.tsx
+++ b/packages/ui/src/features/store/types/SelectContentType.tsx
@@ -66,7 +66,7 @@ export function SelectContentType({ className, defaultValue, onChange, isClearab
                     optionLabel={optionLabel}
                     className={className || "text-sm bg-background"}
                     filterBy="name"
-                    isClearable={isClearable || false as any}
+                    isClearable={isClearable || false}
                     multiple
                 />
             </div>
@@ -83,7 +83,7 @@ export function SelectContentType({ className, defaultValue, onChange, isClearab
                 optionLabel={optionLabel}
                 className={className || "text-sm bg-background"}
                 filterBy="name"
-                isClearable={isClearable || false as any}
+                isClearable={isClearable || false}
             />
         </div>
     );

--- a/packages/ui/src/features/store/types/SelectContentTypeModal.tsx
+++ b/packages/ui/src/features/store/types/SelectContentTypeModal.tsx
@@ -81,9 +81,9 @@ export function SelectContentTypeModal({
 
                 {/* Type selection */}
                 <div className="mb-4 mt-4">
-                    <label className="block text-sm font-medium mb-2">
+                    <div className="block text-sm font-medium mb-2">
                         {t('store.contentType')} {allowNone && <span className="text-gray-500 font-normal">{t('store.optional')}</span>}
-                    </label>
+                    </div>
                     {allowNone ? (
                         <SelectBox
                             options={types}

--- a/packages/ui/src/features/store/types/TableLayoutEditor.tsx
+++ b/packages/ui/src/features/store/types/TableLayoutEditor.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useRef, useState } from 'react';
 import { ColumnLayout, ContentObjectType } from '@vertesia/common';
-import { Button, useToast, useTheme, Panel } from '@vertesia/ui/core';
+import { Button, errorMessage, useToast, useTheme, Panel } from '@vertesia/ui/core';
 import { useUserSession } from '@vertesia/ui/session';
 import { MonacoEditor, EditorApi } from '@vertesia/ui/widgets';
 import { useUITranslation } from '@vertesia/ui/i18n';
@@ -44,8 +44,8 @@ export function TableLayoutEditor({ objectType, onLayoutUpdate, readonly = false
         } else {
             try {
                 table_layout = JSON.parse(value);
-            } catch (err: any) {
-                return validationError('Invalid JSON', err.message);
+            } catch (err: unknown) {
+                return validationError('Invalid JSON', errorMessage(err));
             }
         }
 
@@ -98,7 +98,7 @@ export function TableLayoutEditor({ objectType, onLayoutUpdate, readonly = false
 }
 
 
-export function stringifyTableLayout(obj: any) {
+export function stringifyTableLayout(obj: unknown) {
     if (!obj) {
         return '[\n\n]';
     }

--- a/packages/ui/src/features/store/types/search/ObjectTypeSearchContext.tsx
+++ b/packages/ui/src/features/store/types/search/ObjectTypeSearchContext.tsx
@@ -30,11 +30,11 @@ export class ObjectTypeSearch {
     }
 
     getFilterValue(name: string) {
-        return (this.query as any)[name];
+        return (this.query as Record<string, unknown>)[name];
     }
 
-    setFilterValue(name: string, value: any) {
-        (this.query as any)[name] = value;
+    setFilterValue(name: string, value: unknown) {
+        (this.query as Record<string, unknown>)[name] = value;
         this.search();
     }
 

--- a/packages/ui/src/features/user/UserInfo.tsx
+++ b/packages/ui/src/features/user/UserInfo.tsx
@@ -1,5 +1,5 @@
 import { ApiKey, PrincipalType, User, UserGroup } from "@vertesia/common";
-import { Avatar, Popover, PopoverContent, PopoverTrigger, Table, useFetch } from "@vertesia/ui/core";
+import { Avatar, Popover, PopoverContent, PopoverTrigger, Table, errorMessage, useFetch } from "@vertesia/ui/core";
 import { useUserSession } from "@vertesia/ui/session";
 import { Users, Users2 } from "lucide-react";
 import { ReactNode } from "react";
@@ -243,11 +243,11 @@ function AgentAvatar({ agentId, onBehalfOfType, onBehalfOfId, showTitle = false,
 
 interface ErrorInfoProps extends InfoProps {
     title?: string;
-    error: Error | string;
+    error: unknown;
 }
 function ErrorAvatar({ title = "Error", error, showTitle = false, size = "md" }: ErrorInfoProps) {
     return (
-        <UnknownAvatar title={title} message={typeof error === 'string' ? error : error.message} color="bg-red-500" showTitle={showTitle} size={size} />
+        <UnknownAvatar title={title} message={errorMessage(error)} color="bg-red-500" showTitle={showTitle} size={size} />
     );
 }
 

--- a/packages/ui/src/router/FixLinks.tsx
+++ b/packages/ui/src/router/FixLinks.tsx
@@ -13,7 +13,7 @@ export function FixLinks({ basePath, children }: FixLinksProps) {
             const listener = (ev: MouseEvent) => {
                 const elem = ev.target as HTMLElement;
                 if (elem.tagName.toLowerCase() === 'a') {
-                    (ev as any)[BASE_PATH] = basePath;
+                    (ev as MouseEvent & Record<typeof BASE_PATH, string>)[BASE_PATH] = basePath;
                 }
             }
             divElem.addEventListener('click', listener);

--- a/packages/ui/src/router/HistoryNavigator.ts
+++ b/packages/ui/src/router/HistoryNavigator.ts
@@ -240,7 +240,7 @@ export class HistoryNavigator {
     }
 
     stop() {
-        this._popStateListener && window.removeEventListener('popstate', this._popStateListener);
-        this._linkNavListener && document.body.removeEventListener('click', this._linkNavListener);
+        if (this._popStateListener) window.removeEventListener('popstate', this._popStateListener);
+        if (this._linkNavListener) document.body.removeEventListener('click', this._linkNavListener);
     }
 }

--- a/packages/ui/src/router/HistoryNavigator.ts
+++ b/packages/ui/src/router/HistoryNavigator.ts
@@ -12,7 +12,7 @@ export class LocationChangeEvent {
         public name: LocationChangeEventName,
         public type: LocationChangeType,
         public location: URL,
-        public state?: any) {
+        public state?: unknown) {
     }
 
     get isPageLoad() {
@@ -45,19 +45,19 @@ export class LocationChangeEvent {
 }
 
 export class BeforeLocationChangeEvent extends LocationChangeEvent {
-    constructor(type: LocationChangeType, location: URL, state?: any) {
+    constructor(type: LocationChangeType, location: URL, state?: unknown) {
         super('beforeChange', type, location, state);
     }
 }
 export class AfterLocationChangeEvent extends LocationChangeEvent {
-    constructor(type: LocationChangeType, location: URL, state?: any) {
+    constructor(type: LocationChangeType, location: URL, state?: unknown) {
         super('afterChange', type, location, state);
     }
 }
 
 export interface NavigateOptions {
     replace?: boolean;
-    state?: any;
+    state?: unknown;
     /**
      * if defined prepend the basePath to the `to` argument
      */
@@ -203,7 +203,7 @@ export class HistoryNavigator {
         const _popStateListener = (ev: PopStateEvent) => {
             let type: LocationChangeType;
             const to = new URL(window.location.href);
-            let state: any = undefined;
+            let state: unknown = undefined;
             if (ev.state) {
                 type = 'popState';
                 state = ev.state.data;
@@ -225,7 +225,8 @@ export class HistoryNavigator {
             if (url && url.origin === window.location.origin) {
                 ev.preventDefault();
                 const to = new URL(this.addStickyParams(url.href));
-                const basePath = (ev as any)[BASE_PATH] || (ev.target as any)[BASE_PATH];
+                const basePath = (ev as MouseEvent & Partial<Record<typeof BASE_PATH, string>>)[BASE_PATH]
+                    || (ev.target as HTMLElement & Partial<Record<typeof BASE_PATH, string>>)[BASE_PATH];
                 if (basePath) {
                     to.pathname = joinPath(basePath, to.pathname);
                 }

--- a/packages/ui/src/router/Nav.tsx
+++ b/packages/ui/src/router/Nav.tsx
@@ -36,6 +36,8 @@ export function Nav({ children, to, onClick, replace = true }: NavProps) {
         }
     }
     return (
+        // biome-ignore lint/a11y/noStaticElementInteractions: span intercepts clicks on inner <a>; keyboard a11y comes from the anchor (Enter triggers click natively).
+        // biome-ignore lint/a11y/useKeyWithClickEvents: same — the inner <a> provides keyboard activation natively.
         <span onClick={_onClick}>{children}</span>
     )
 }

--- a/packages/ui/src/router/NestedNavigationContext.tsx
+++ b/packages/ui/src/router/NestedNavigationContext.tsx
@@ -15,8 +15,8 @@ export function NestedNavigationContext({ basePath, fixLinks = false, children }
     const ctx = useRouterContext();
 
     const wrapWithFixLinks = fixLinks ?
-        (elem: any) => <FixLinks basePath={ctx.matchedRoutePath}>{elem}</FixLinks>
-        : (elem: any) => elem;
+        (elem: React.ReactNode) => <FixLinks basePath={ctx.matchedRoutePath}>{elem}</FixLinks>
+        : (elem: React.ReactNode) => elem;
 
     return (
         <ReactRouterContext.Provider value={{

--- a/packages/ui/src/router/NestedRouterProvider.tsx
+++ b/packages/ui/src/router/NestedRouterProvider.tsx
@@ -42,8 +42,8 @@ export function NestedRouterProvider({ routes, index, children, fixLinks = false
 
 
     const wrapWithFixLinks = fixLinks ?
-        (elem: any) => <FixLinks basePath={ctx.matchedRoutePath}>{elem}</FixLinks>
-        : (elem: any) => elem;
+        (elem: React.ReactNode) => <FixLinks basePath={ctx.matchedRoutePath}>{elem}</FixLinks>
+        : (elem: React.ReactNode) => elem;
 
     return nestedRouteMatch && (
         <ReactRouterContext.Provider value={{

--- a/packages/ui/src/router/PathMatcher.ts
+++ b/packages/ui/src/router/PathMatcher.ts
@@ -159,7 +159,7 @@ class WildcardSegmentNode<T = unknown> implements SegmentNode<T> {
         if (!params._) {
             params._ = segment ? [segment] : [];
         } else {
-            segment && params._.push(segment);
+            if (segment) params._.push(segment);
         }
         return this;
     }

--- a/packages/ui/src/router/PathMatcher.ts
+++ b/packages/ui/src/router/PathMatcher.ts
@@ -1,6 +1,6 @@
 import { PathMatchParams, getPathSegments, toSegments } from "./path";
 
-export interface PathMatch<T = any> {
+export interface PathMatch<T = unknown> {
     params: PathMatchParams;
     matchedSegments: string[];
     remainingSegments?: string[];
@@ -11,9 +11,9 @@ export interface PathMatch<T = any> {
  * Path matcher which support :param and *wildcard segments.
  * The wildcard segment is only supported as the last segment
  */
-export class PathMatcher<T = any> {
+export class PathMatcher<T = unknown> {
 
-    tree: RootSegmentNode = new RootSegmentNode();
+    tree: RootSegmentNode<T> = new RootSegmentNode<T>();
 
     loadMapping(mapping: Record<string, T>) {
         for (const [key, value] of Object.entries(mapping)) {
@@ -30,12 +30,12 @@ export class PathMatcher<T = any> {
             if (segment[0] === ':') {
                 let childNode = node.wildcard;
                 if (!childNode) {
-                    childNode = new VariableSegmentNode(segment);
+                    childNode = new VariableSegmentNode<T>(segment);
                     node.wildcard = childNode;
                 } else if (!(childNode instanceof VariableSegmentNode)) {
                     throw new Error(`Failed to index path segments: ${segments.join('/')}. A wildcard ":" segment will overwrite an existing wildcard segment at path: ${'/' + segments.slice(0, i).join("/")}`);
                 }
-                node = childNode as VariableSegmentNode;
+                node = childNode as VariableSegmentNode<T>;
             } else if (segment === '*') {
                 if (node.wildcard) {
                     throw new Error(`Failed to index path segments: ${segments.join('/')}. A wildcard "*" segment already exists at path: ${'/' + segments.slice(0, i).join("/")}`);
@@ -48,10 +48,10 @@ export class PathMatcher<T = any> {
             } else {
                 let childNode = node.children[segment];
                 if (!childNode) {
-                    childNode = new LiteralSegmentNode(segment);
+                    childNode = new LiteralSegmentNode<T>(segment);
                     node.children[segment] = childNode;
                 } // else // a literal segment already exists
-                node = childNode as LiteralSegmentNode;
+                node = childNode as LiteralSegmentNode<T>;
             }
         }
         if (node.value !== undefined) {
@@ -99,12 +99,12 @@ export class PathMatcher<T = any> {
 
 }
 
-interface SegmentNode<T = any> {
+interface SegmentNode<T = unknown> {
     name: string;
     value?: T | undefined;
     match(segment: string, params: PathMatchParams): SegmentNode<T> | null;
 }
-class ParentSegmentNode<T = any> implements SegmentNode<T> {
+class ParentSegmentNode<T = unknown> implements SegmentNode<T> {
     children: Record<string, SegmentNode<T>> = {};
     wildcard?: SegmentNode<T>;
 
@@ -131,19 +131,19 @@ class ParentSegmentNode<T = any> implements SegmentNode<T> {
 
 }
 
-class RootSegmentNode<T = any> extends ParentSegmentNode<T> {
+class RootSegmentNode<T = unknown> extends ParentSegmentNode<T> {
     constructor() {
         super("#root");
     }
 }
 
-class LiteralSegmentNode<T = any> extends ParentSegmentNode<T> {
+class LiteralSegmentNode<T = unknown> extends ParentSegmentNode<T> {
     constructor(name: string, value?: T | undefined) {
         super(name, value);
     }
 }
 
-class VariableSegmentNode<T = any> extends ParentSegmentNode<T> {
+class VariableSegmentNode<T = unknown> extends ParentSegmentNode<T> {
     paramName: string;
     constructor(name: string, value?: T | undefined) {
         super(name, value)
@@ -151,7 +151,7 @@ class VariableSegmentNode<T = any> extends ParentSegmentNode<T> {
     }
 }
 
-class WildcardSegmentNode<T = any> implements SegmentNode<T> {
+class WildcardSegmentNode<T = unknown> implements SegmentNode<T> {
     constructor(public name: string, public value?: T | undefined) {
     }
 

--- a/packages/ui/src/router/RouteComponent.tsx
+++ b/packages/ui/src/router/RouteComponent.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { ComponentRoute, LazyComponentRoute, useRouterContext } from "./Router";
+import { ComponentRoute, LazyComponentRoute, LazyRouteModule, useRouterContext } from "./Router";
 
 interface RouteComponentProps {
     spinner?: React.ReactNode;
@@ -23,7 +23,7 @@ interface LazyRouteComponentProps {
     spinner?: React.ReactNode;
 }
 function LazyRouteComponent({ route, spinner }: LazyRouteComponentProps) {
-    const [Component, setComponent] = useState<React.ComponentType<any> | null>(null);
+    const [Component, setComponent] = useState<LazyRouteModule["default"] | null>(null);
     useEffect(() => {
         route.LazyComponent().then(module => {
             if (!module.default) {

--- a/packages/ui/src/router/Router.tsx
+++ b/packages/ui/src/router/Router.tsx
@@ -1,12 +1,14 @@
 import { createContext, useContext, useEffect } from "react";
 import { HistoryNavigator, LocationChangeEvent, NavigateOptions } from "./HistoryNavigator";
 import { PathMatch, PathMatcher } from "./PathMatcher";
-import { isRootPath, joinPath } from "./path";
+import { isRootPath, joinPath, PathMatchParams } from "./path";
 
-export type LazyImportFn = () => Promise<any>;
+export type RouteComponentProps = PathMatchParams;
+export type LazyRouteModule = { default: React.ComponentType<Record<string, never>> };
+export type LazyImportFn = () => Promise<LazyRouteModule>;
 export interface ComponentRoute {
     path: string;
-    Component: React.ComponentType<any>;
+    Component: React.ComponentType<RouteComponentProps>;
 }
 export interface LazyComponentRoute {
     path: string;
@@ -15,7 +17,7 @@ export interface LazyComponentRoute {
 export type Route = ComponentRoute | LazyComponentRoute;
 
 export interface RouteMatch extends PathMatch<Route> {
-    state: any;
+    state: unknown;
 }
 
 export interface NavigationPrompt {
@@ -151,7 +153,7 @@ export interface RouterContext {
     route: Route;
     router: BaseRouter;
     params: Record<string, string>;
-    state: any;
+    state: unknown;
     /**
      * The path that matched the route. For wildcard `/*` paths this does not include the wildcard part.
      * You can get the wildcard path from `remainingPath`.
@@ -220,7 +222,7 @@ export function useNavigationPrompt(prompt: NavigationPrompt) {
             const listener = function (ev: Event) {
                 if (doBlock) {
                     ev.preventDefault();
-                    (ev as any).returnValue = "";
+                    (ev as BeforeUnloadEvent).returnValue = "";
                 }
             };
             window.addEventListener("beforeunload", listener);

--- a/packages/ui/src/router/RouterProvider.tsx
+++ b/packages/ui/src/router/RouterProvider.tsx
@@ -41,9 +41,9 @@ export function RouterProvider({ routes, index, onChange, children }: RouterProv
         return router;
     }, []);
     useSafeLayoutEffect(() => {
-        router && router.start();
+        router?.start();
         return () => {
-            router && router.stop();
+            router?.stop();
         }
     }, []);
 

--- a/packages/ui/src/session/UserSession.ts
+++ b/packages/ui/src/session/UserSession.ts
@@ -250,7 +250,7 @@ class UserSession {
     }
 }
 
-const UserSessionContext = createContext<UserSession>(undefined as any);
+const UserSessionContext = createContext<UserSession | undefined>(undefined);
 
 export function useUserSession() {
     const session = useContext(UserSessionContext);

--- a/packages/ui/src/session/auth/composable.ts
+++ b/packages/ui/src/session/auth/composable.ts
@@ -101,7 +101,7 @@ export async function fetchComposableToken(getIdToken: () => Promise<string | nu
                         project_id: projectId,
                     }
                 });
-                const idTokenDecoded = jwtDecode(idToken) as any;
+                const idTokenDecoded = jwtDecode<{ email?: string }>(idToken);
                 if (!idTokenDecoded?.email) {
                     Env.logger.error('No email found in id token');
                     throw new Error('No email found in id token');
@@ -141,7 +141,7 @@ export async function fetchComposableToken(getIdToken: () => Promise<string | nu
                     status: stsRes?.status
                 },
             });
-            const idTokenDecoded = jwtDecode(idToken) as any;
+            const idTokenDecoded = jwtDecode<{ email?: string }>(idToken);
             if (!idTokenDecoded?.email) {
                 Env.logger.error('No email found in id token');
                 throw new Error('No email found in id token');

--- a/packages/ui/src/session/auth/domainRouting.test.ts
+++ b/packages/ui/src/session/auth/domainRouting.test.ts
@@ -3,23 +3,23 @@ import { shouldRedirectToCentralAuth, shouldUseFirebaseAuth } from "./domainRout
 
 describe("domainRouting", () => {
     afterEach(() => {
-        delete (globalThis as any).window;
+        delete (globalThis as { window?: unknown }).window;
     });
 
     it("uses Firebase auth when AUTH_MODE is 'firebase'", () => {
-        (globalThis as any).window = { AUTH_MODE: "firebase" };
+        (globalThis as { window?: unknown }).window = { AUTH_MODE: "firebase" };
         expect(shouldUseFirebaseAuth()).toBe(true);
         expect(shouldRedirectToCentralAuth()).toBe(false);
     });
 
     it("uses central auth when AUTH_MODE is 'central'", () => {
-        (globalThis as any).window = { AUTH_MODE: "central" };
+        (globalThis as { window?: unknown }).window = { AUTH_MODE: "central" };
         expect(shouldUseFirebaseAuth()).toBe(false);
         expect(shouldRedirectToCentralAuth()).toBe(true);
     });
 
     it("defaults to central auth when AUTH_MODE is not set", () => {
-        (globalThis as any).window = {};
+        (globalThis as { window?: unknown }).window = {};
         expect(shouldUseFirebaseAuth()).toBe(false);
         expect(shouldRedirectToCentralAuth()).toBe(true);
     });

--- a/packages/ui/src/session/auth/firebase.ts
+++ b/packages/ui/src/session/auth/firebase.ts
@@ -84,7 +84,7 @@ export async function setFirebaseTenant(tenantEmail?: string) {
                     try {
                         const errorData = await response.json();
                         console.error("Failed to resolve tenant ID:", errorData.error);
-                    } catch (parseError) {
+                    } catch {
                         console.error(`Failed to resolve tenant ID: HTTP ${response.status}`);
                     }
 

--- a/packages/ui/src/session/useUXTracking.tsx
+++ b/packages/ui/src/session/useUXTracking.tsx
@@ -19,7 +19,7 @@ export function useUXTracking() {
     }
 
     //send event to analytics and UX systems
-    const trackEvent = (eventName: string, eventProperties?: any) => {
+    const trackEvent = (eventName: string, eventProperties?: Record<string, unknown>) => {
 
         if (!Env.isProd) {
             console.debug('track event', eventName, eventProperties);

--- a/packages/ui/src/shell/apps/AppProjectSelector.tsx
+++ b/packages/ui/src/shell/apps/AppProjectSelector.tsx
@@ -1,5 +1,5 @@
 import { ProjectRef, RequireAtLeastOne } from "@vertesia/common";
-import { SelectBox, useFetch } from "@vertesia/ui/core";
+import { SelectBox, errorMessage, useFetch } from "@vertesia/ui/core";
 import { LastSelectedAccountId_KEY, LastSelectedProjectId_KEY, useUserSession } from "@vertesia/ui/session";
 import { useState } from "react";
 
@@ -28,7 +28,7 @@ export function AppProjectSelector({ app, onChange, placeholder }: AppProjectSel
     }
 
     if (error) {
-        return <span className='text-red-600'>Error: failed to fetch projects: {error.message}</span>
+        return <span className='text-red-600'>Error: failed to fetch projects: {errorMessage(error)}</span>
     }
     return <SelectProject placeholder={placeholder} initialValue={project?.id} projects={projects || []} onChange={_onChange} />
 }

--- a/packages/ui/src/shell/login/SigninScreen.tsx
+++ b/packages/ui/src/shell/login/SigninScreen.tsx
@@ -22,7 +22,7 @@ interface SigninScreenProps {
 export function SigninScreen({ allowedPrefix, isNested = false, lightLogo, darkLogo, preservePath }: SigninScreenProps) {
     const [allow, setAllow] = useState(false);
     useSafeLayoutEffect(() => {
-        allowedPrefix && setAllow(window.location.pathname.startsWith(allowedPrefix));
+        if (allowedPrefix) setAllow(window.location.pathname.startsWith(allowedPrefix));
     }, [allowedPrefix]);
     return allow ? null : <SigninScreenImpl isNested={isNested} lightLogo={lightLogo} darkLogo={darkLogo} preservePath={preservePath} />;
 }

--- a/packages/ui/src/shell/login/TerminalLogin.tsx
+++ b/packages/ui/src/shell/login/TerminalLogin.tsx
@@ -1,5 +1,5 @@
 import { AccountRef, ProjectRef } from '@vertesia/common'
-import { Button, Center, ErrorBox, Input, SelectBox, Spinner, useFetch, useToast } from '@vertesia/ui/core'
+import { Button, Center, ErrorBox, Input, SelectBox, Spinner, errorMessage, useFetch, useToast } from '@vertesia/ui/core'
 import { Env } from "@vertesia/ui/env"
 import { useLocation } from "@vertesia/ui/router"
 import { fetchComposableTokenFromFirebaseToken, fetchComposableTokenFromVertesiaToken, getCurrentVertesiaToken, useUserSession } from '@vertesia/ui/session'
@@ -143,14 +143,14 @@ export function TerminalLogin() {
                     duration: 5000
                 })
             }
-        } catch (err: any) {
+        } catch (err: unknown) {
             if (payload) {
-                setError(err)
+                setError(err instanceof Error ? err : new Error(errorMessage(err)))
                 setPayload(payload)
             } else {
                 toast({
                     title: t('login.terminal.errorAuthorizingClient'),
-                    description: err.message,
+                    description: errorMessage(err),
                     status: 'error',
                     duration: 5000
                 })
@@ -185,7 +185,7 @@ function AuthAcceptScreen({ onAccept, clientInfo }: Readonly<AuthAcceptScreenPro
     const { t } = useUITranslation()
 
     if (error) {
-        return <ErrorBox title={t('login.terminal.errorLoadingProjects')}>{error.message}</ErrorBox>
+        return <ErrorBox title={t('login.terminal.errorLoadingProjects')}>{errorMessage(error)}</ErrorBox>
     }
 
     const getEnvironmentName = () => {

--- a/packages/ui/src/widgets/SvgIcon.tsx
+++ b/packages/ui/src/widgets/SvgIcon.tsx
@@ -21,7 +21,7 @@ export function SvgIcon({ content, ...props }: SvgIconProps) {
         }
 
         // Apply all passed props to the SVG element
-        props && Object.entries(props).forEach(([key, value]) => {
+        Object.entries(props).forEach(([key, value]) => {
             if (value == null) return;
 
             const attrName = key === 'className' ? 'class' : key;

--- a/packages/ui/src/widgets/form/Form.tsx
+++ b/packages/ui/src/widgets/form/Form.tsx
@@ -20,7 +20,7 @@ export function Form({ object, components, onSubmit, children, onChange, disable
     const _onSubmit = (evt: SyntheticEvent) => {
         evt.stopPropagation();
         evt.preventDefault();
-        onSubmit && onSubmit(object.value);
+        onSubmit?.(object.value);
     }
     object.observer = onChange;
     return (

--- a/packages/ui/src/widgets/form/Form.tsx
+++ b/packages/ui/src/widgets/form/Form.tsx
@@ -4,7 +4,7 @@ import { Button, FormItem } from "@vertesia/ui/core";
 import clsx from "clsx";
 import { Plus, Trash2 } from "lucide-react";
 import { ComponentType, ReactNode, SyntheticEvent, useState } from "react";
-import { FormContext, FormContextProvider, InputComponentProps, useForm } from "./FormContext.js";
+import { FormContext, FormContextProvider, InputChangeEvent, InputComponentProps, useForm } from "./FormContext.js";
 import { ManagedListProperty, ManagedObject, ManagedObjectBase, ManagedProperty, Node } from "./ManagedObject.js";
 import { Input } from "./inputs.js";
 
@@ -88,10 +88,10 @@ export function ScalarField({ object, editor, inline = false }: ScalarFieldProps
         inline = true;
     }
 
-    const handleOnChange = (event: any) => {
+    const handleOnChange = (event: InputChangeEvent) => {
         if (disabled) return;
         if (object.schema.isBoolean) {
-            object.value = event.target.checked;
+            object.value = event.target instanceof HTMLInputElement ? event.target.checked : false;
         } else if (object.schema.isNumber) {
             object.value = parseFloat(event.target.value);
         } else {
@@ -130,7 +130,7 @@ interface ListFieldProps {
     object: ManagedListProperty;
 }
 function ListField({ object }: ListFieldProps) {
-    const [value, setValue] = useState<any[]>(object.value || []);
+    const [value, setValue] = useState<unknown[]>(object.value || []);
     const { disabled } = useForm();
 
     const addItem = () => {
@@ -150,7 +150,7 @@ function ListField({ object }: ListFieldProps) {
             {!object.isListItem && <div className='text-gray-900 dark:text-gray-200 font-semibold'>{object.title}</div>}
             {
                 object.items.map((item, index) => {
-                    return <ListItem key={`${index}-${value[index] ?? ''}`} object={item} list={object} onDelete={() => deleteItem(index)} disabled={disabled} />;
+                    return <ListItem key={`${index}-${String(value[index] ?? '')}`} object={item} list={object} onDelete={() => deleteItem(index)} disabled={disabled} />;
                 })
             }
             <div>
@@ -167,11 +167,12 @@ interface ListItemProps {
     disabled?: boolean;
 }
 function ListItem({ list, object, onDelete, disabled }: ListItemProps) {
+    const editor = typeof list.schema.arraySchema.editor === 'string' ? list.schema.arraySchema.editor : undefined;
     return (
         <div className='flex gap-2 w-full'>
             <div className="flex-1">
                 {
-                    renderItemProperty(object, list.schema.arraySchema.editor)
+                    renderItemProperty(object, editor)
                 }
             </div>
             <Button variant='ghost' onClick={onDelete} disabled={disabled} alt="Delete"><Trash2 className='size-4 text-destructive' /></Button>

--- a/packages/ui/src/widgets/form/FormContext.ts
+++ b/packages/ui/src/widgets/form/FormContext.ts
@@ -1,4 +1,4 @@
-import { ComponentType, createContext, useContext } from "react";
+import { ChangeEvent, ComponentType, createContext, useContext } from "react";
 import { ManagedObject, ManagedObjectBase, Node } from "./ManagedObject.js";
 
 const FieldSetContext = createContext<ManagedObjectBase | undefined>(undefined);
@@ -12,10 +12,12 @@ export function useFieldSet() {
     return ctx;
 }
 
+export type InputChangeEvent = ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>;
+
 export interface InputComponentProps {
     object: Node;
     type: string; // the editor/input type
-    onChange?: (event: any) => void;
+    onChange?: (event: InputChangeEvent) => void;
     disabled?: boolean;
 }
 export class FormContext {

--- a/packages/ui/src/widgets/form/ManagedObject.ts
+++ b/packages/ui/src/widgets/form/ManagedObject.ts
@@ -75,7 +75,7 @@ export abstract class Node<SchemaT extends Schema = Schema, ValueT = JSONSchemaT
                 return;
             };
         }
-        this.parent && this.parent.onChange(node);
+        this.parent?.onChange(node);
     }
 
 }

--- a/packages/ui/src/widgets/form/inputs.tsx
+++ b/packages/ui/src/widgets/form/inputs.tsx
@@ -25,7 +25,7 @@ const Input = React.forwardRef<HTMLInputElement | HTMLTextAreaElement, InputProp
         } else {
             object.value = ev.target.value;
         }
-        onChange && onChange(ev);
+        onChange?.(ev);
     }
     if (type === 'textarea') {
         return (

--- a/packages/ui/src/widgets/form/schema.ts
+++ b/packages/ui/src/widgets/form/schema.ts
@@ -44,7 +44,10 @@ export class Schema {
     }
 
     get title() {
-        return this.schema.title || this.schema.name;
+        const title = this.schema.title;
+        if (typeof title === 'string') return title;
+        const name = this.schema.name;
+        return typeof name === 'string' ? name : undefined;
     }
 
     get description() {
@@ -66,7 +69,7 @@ export class Schema {
         return this.schema.type as JSONSchemaTypeName;
     }
 
-    validate(value: any): ErrorObject<string, Record<string, any>, unknown>[] | null {
+    validate(value: unknown): ErrorObject<string, Record<string, unknown>, unknown>[] | null {
         if (!this.validator(value)) {
             return this.validator.errors || [];
         } else {
@@ -105,7 +108,7 @@ export class Schema {
     }
 
     get editor() {
-        return this.schema.editor;
+        return typeof this.schema.editor === 'string' ? this.schema.editor : undefined;
     }
 }
 
@@ -133,7 +136,7 @@ export class PropertySchema extends Schema {
     }
 
     get defaultValue() {
-        return this.schema.default;
+        return this.schema.default as JSONSchemaType | undefined;
     }
 
     set defaultValue(value: JSONSchemaType | undefined) {
@@ -141,7 +144,7 @@ export class PropertySchema extends Schema {
     }
 
     get enum() {
-        return this.schema.enum;
+        return this.schema.enum as JSONSchemaType[] | undefined;
     }
 
     set enum(values: JSONSchemaType[] | undefined) {

--- a/packages/ui/src/widgets/json-view/JSONCode.tsx
+++ b/packages/ui/src/widgets/json-view/JSONCode.tsx
@@ -3,7 +3,7 @@ import { useTheme } from '@vertesia/ui/core';
 import { MonacoEditor } from '../monacoEditor/MonacoEditor';
 import { useMemo } from 'react';
 
-export function JSONCode({ data, className }: { data: any; className?: string }) {
+export function JSONCode({ data, className }: { data: unknown; className?: string }) {
     const { theme } = useTheme();
 
     // Convert data to formatted JSON string

--- a/packages/ui/src/widgets/json-view/JSONDisplay.tsx
+++ b/packages/ui/src/widgets/json-view/JSONDisplay.tsx
@@ -1,4 +1,4 @@
-import type { JSONObject } from "@vertesia/json";
+import type { JSONValue } from "@vertesia/json";
 import { useUITranslation } from "@vertesia/ui/i18n";
 
 import { JSONCode } from './JSONCode.js';
@@ -6,7 +6,7 @@ import { JSONView } from './JSONView.js';
 
 
 interface JSONDisplayProps {
-    value: JSONObject;
+    value: unknown;
     viewCode?: boolean;
 }
 export function JSONDisplay({ value, viewCode = false }: JSONDisplayProps) {
@@ -20,10 +20,26 @@ export function JSONDisplay({ value, viewCode = false }: JSONDisplayProps) {
 
     return (
         <div className='relative w-full h-full flex flex-col'>
-            {viewCode
+            {viewCode || !isJSONValue(value)
                 ? <JSONCode data={value} />
                 : <div className="flex-1 min-h-0 overflow-auto"><JSONView value={value} /></div>
             }
         </div>
     )
+}
+
+function isJSONValue(value: unknown): value is JSONValue {
+    if (value == null) {
+        return true;
+    }
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+        return true;
+    }
+    if (Array.isArray(value)) {
+        return value.every(isJSONValue);
+    }
+    if (typeof value === 'object') {
+        return Object.values(value).every(isJSONValue);
+    }
+    return false;
 }

--- a/packages/ui/src/widgets/json-view/JSONEditor.tsx
+++ b/packages/ui/src/widgets/json-view/JSONEditor.tsx
@@ -4,11 +4,11 @@ import { MonacoEditor, IEditorApi } from '../monacoEditor/MonacoEditor';
 
 export interface JSONEditorProps {
     /** The JSON value to edit */
-    value: Record<string, any> | undefined | null;
+    value: Record<string, unknown> | undefined | null;
     /** Called when the user saves (value is the parsed JSON) */
-    onChange?: (value: Record<string, any>) => void;
+    onChange?: (value: Record<string, unknown>) => void;
     /** Called on every valid edit (for controlled mode) */
-    onValidChange?: (value: Record<string, any>) => void;
+    onValidChange?: (value: Record<string, unknown>) => void;
     /** If true, the editor is read-only */
     readonly?: boolean;
     /** Editor height (default: '200px') */
@@ -79,7 +79,7 @@ export function JSONEditor({
  * Get the current parsed value from a JSONEditor ref.
  * Returns the parsed object or null if invalid.
  */
-export function getJSONEditorValue(editorRef: React.RefObject<IEditorApi | undefined>): Record<string, any> | null {
+export function getJSONEditorValue(editorRef: React.RefObject<IEditorApi | undefined>): Record<string, unknown> | null {
     if (!editorRef.current) return null;
     try {
         return JSON.parse(editorRef.current.getValue());

--- a/packages/ui/src/widgets/json-view/JSONView.tsx
+++ b/packages/ui/src/widgets/json-view/JSONView.tsx
@@ -6,9 +6,19 @@ import { computeTitleFromName } from "../form/ManagedObject.js";
 
 
 interface JSONViewProps {
-    value: JSONObject;
+    value: JSONValue;
 }
 export function JSONView({ value }: JSONViewProps) {
+    if (Array.isArray(value)) {
+        return <div className="flex flex-col gap-4 px-2 h-full overflow-auto">
+            <ArrayProperty value={value} />
+        </div>
+    }
+    if (typeof value !== 'object' || value == null) {
+        return <div className="flex flex-col gap-4 px-2 h-full overflow-auto">
+            <PropertyElement name="value" value={value} />
+        </div>
+    }
     return <div className="flex flex-col gap-4 px-2 h-full overflow-auto">
         {
             Object.entries(value).map(([key, value]) =>
@@ -111,7 +121,7 @@ interface ItemPropertyProps {
 function ItemProperty({ index, value, useBullet }: ItemPropertyProps) {
     const bullet = useBullet ? <span className='text-xl'>&bull;</span> : <span>{index + 1}.</span>
     const info = getValueInfo(value);
-    let content;
+    let content: React.ReactNode;
     switch (info.type) {
         case ValueType.Object:
             content = <BlockElement>
@@ -143,7 +153,12 @@ enum ValueType {
     Array,
     Object
 }
-function getValueInfo(value: JSONValue): { value: any, type: ValueType } {
+type ValueInfo =
+    | { value: string; type: ValueType.Inline | ValueType.Paragraph | ValueType.Prose }
+    | { value: JSONArray; type: ValueType.Array }
+    | { value: JSONObject; type: ValueType.Object };
+
+function getValueInfo(value: JSONValue): ValueInfo {
     if (value == null) {
         return {
             value: '-',
@@ -156,27 +171,27 @@ function getValueInfo(value: JSONValue): { value: any, type: ValueType } {
             type: ValueType.Array
         }
     }
-    const type = typeof value;
-    if (type === 'string') {
-        const len = (value as string).length;
-        let type;
+    if (typeof value === 'string') {
+        const len = value.length;
+        let valueType: ValueType.Inline | ValueType.Paragraph | ValueType.Prose;
+        let displayValue = value;
         if (len < 80) {
-            type = ValueType.Inline;
+            valueType = ValueType.Inline;
         } else if (len > 400) {
-            type = ValueType.Prose;
+            valueType = ValueType.Prose;
         } else {
-            type = ValueType.Paragraph;
-            value = (value as string).replace(/(?:\n\n)+/g, '\n\n')
+            valueType = ValueType.Paragraph;
+            displayValue = value.replace(/(?:\n\n)+/g, '\n\n')
         }
-        return { type, value };
-    } else if (type === 'number' || type === 'boolean') {
+        return { type: valueType, value: displayValue };
+    } else if (typeof value === 'number' || typeof value === 'boolean') {
         return {
             value: String(value),
             type: ValueType.Inline
         }
     } else {
         return {
-            value,
+            value: value as JSONObject,
             type: ValueType.Object
         }
     }

--- a/packages/ui/src/widgets/markdown/CodeBlockRendering.tsx
+++ b/packages/ui/src/widgets/markdown/CodeBlockRendering.tsx
@@ -5,7 +5,7 @@ export interface CodeBlockRendererProps {
     language?: string;
 }
 export class CodeBlockRendererRegistry {
-    components: Record<string, React.FunctionComponent<any>> = {};
+    components: Record<string, React.FunctionComponent<CodeBlockRendererProps>> = {};
 
     registerComponent(language: string, component: React.FunctionComponent<CodeBlockRendererProps>) {
         this.components[language] = component;

--- a/packages/ui/src/widgets/markdown/MarkdownImage.tsx
+++ b/packages/ui/src/widgets/markdown/MarkdownImage.tsx
@@ -3,13 +3,13 @@ import { useResolvedUrl, parseUrlScheme } from './useResolvedUrl';
 import { CodeBlockPlaceholder } from './CodeBlockPlaceholder';
 
 export interface MarkdownImageProps {
-    node?: any;
+    node?: unknown;
     src?: string;
     alt?: string;
     className?: string;
     artifactRunId?: string;
     /** Existing image component to delegate to for standard URLs */
-    ExistingImg?: React.ComponentType<any>;
+    ExistingImg?: React.ComponentType<MarkdownImageProps>;
 }
 
 /**

--- a/packages/ui/src/widgets/markdown/MarkdownLink.tsx
+++ b/packages/ui/src/widgets/markdown/MarkdownLink.tsx
@@ -10,7 +10,7 @@ export interface MarkdownLinkProps {
     className?: string;
     artifactRunId?: string;
     /** Existing link component to delegate to for standard URLs */
-    ExistingLink?: React.ComponentType<any>;
+    ExistingLink?: React.ComponentType<MarkdownLinkProps>;
 }
 
 /**

--- a/packages/ui/src/widgets/markdown/MarkdownRenderer.tsx
+++ b/packages/ui/src/widgets/markdown/MarkdownRenderer.tsx
@@ -1,6 +1,6 @@
 import type { Element } from 'hast';
 import React from 'react';
-import Markdown, { defaultUrlTransform } from 'react-markdown';
+import Markdown, { defaultUrlTransform, type Components } from 'react-markdown';
 import rehypeKatex from 'rehype-katex';
 import { defListHastHandlers, remarkDefinitionList } from 'remark-definition-list';
 import remarkDirective from 'remark-directive';
@@ -18,11 +18,16 @@ import {
 import { useCodeBlockRendererRegistry } from './CodeBlockRendering';
 import { preprocessMathDelimiters } from './preprocessMathDelimiters';
 import { MarkdownFigure } from './MarkdownFigure';
-import { MarkdownImage } from './MarkdownImage';
-import { MarkdownLink } from './MarkdownLink';
+import { MarkdownImage, MarkdownImageProps } from './MarkdownImage';
+import { MarkdownLink, MarkdownLinkProps } from './MarkdownLink';
 import { normalizeCustomSchemeLinks } from './normalizeCustomSchemeLinks';
 import { normalizeDirectives } from './normalizeDirectives';
 import { remarkDirectiveHandler } from './remarkDirectiveHandler';
+
+type MarkdownTree = Parameters<typeof visit>[0];
+type MarkdownNode = { value?: unknown };
+type MarkdownParent = { children?: unknown[] };
+type RemarkPluginList = NonNullable<React.ComponentProps<typeof Markdown>["remarkPlugins"]>;
 
 // Custom URL schemes that we handle in our components
 const ALLOWED_CUSTOM_SCHEMES = [
@@ -49,11 +54,13 @@ function customUrlTransform(url: string): string {
  * Remark plugin to remove HTML comments from markdown
  */
 function remarkRemoveComments() {
-    return (tree: any) => {
-        visit(tree, 'html', (node: any, index: number | undefined, parent: any) => {
-            if (node.value && /<!--[\s\S]*?-->/.test(node.value)) {
-                if (parent && typeof index === 'number' && parent.children) {
-                    parent.children.splice(index, 1);
+    return (tree: MarkdownTree) => {
+        visit(tree, 'html', (node, index: number | undefined, parent) => {
+            const literal = node as MarkdownNode;
+            const parentNode = parent as MarkdownParent | undefined;
+            if (typeof literal.value === 'string' && /<!--[\s\S]*?-->/.test(literal.value)) {
+                if (parentNode?.children && typeof index === 'number') {
+                    parentNode.children.splice(index, 1);
                     return [SKIP, index];
                 }
             }
@@ -63,8 +70,8 @@ function remarkRemoveComments() {
 
 export interface MarkdownRendererProps {
     children: string;
-    components?: any;
-    remarkPlugins?: any[];
+    components?: Components;
+    remarkPlugins?: RemarkPluginList;
     removeComments?: boolean;
     /**
      * Optional workflow run id used to resolve shorthand artifact paths (e.g. artifact:out/result.csv)
@@ -113,7 +120,7 @@ export function MarkdownRenderer({
     // Order matters: GFM first, then directive (must precede handler),
     // then definition-list/supersub, then math, then user plugins.
     const remarkPluginsArray = React.useMemo(() => {
-        const result: any[] = [
+        const result: RemarkPluginList = [
             remarkGfm,
             remarkDirective,
             remarkDirectiveHandler,
@@ -216,14 +223,14 @@ export function MarkdownRenderer({
             href?: string;
             children?: React.ReactNode;
         }) => {
-            const { node, href, children: linkChildren, ...rest } = props as any;
+            const { node, href, children: linkChildren, ...rest } = props;
             return (
                 <MarkdownLink
                     node={node}
                     href={href}
                     className={linkClassName}
                     artifactRunId={artifactRunId}
-                    ExistingLink={ExistingLink}
+                    ExistingLink={typeof ExistingLink === 'function' ? ExistingLink as React.ComponentType<MarkdownLinkProps> : undefined}
                     {...rest}
                 >
                     {linkChildren}
@@ -231,8 +238,8 @@ export function MarkdownRenderer({
             );
         };
 
-        const ImageComponent = (props: { node?: any; src?: string; alt?: string; title?: string }) => {
-            const { node, src, alt, title, ...rest } = props as any;
+        const ImageComponent = (props: { node?: unknown; src?: string; alt?: string; title?: string }) => {
+            const { node, src, alt, title, ...rest } = props;
 
             // If image has a title, render as figure with caption
             if (title) {
@@ -254,7 +261,7 @@ export function MarkdownRenderer({
                     alt={alt}
                     className={imageClassName}
                     artifactRunId={artifactRunId}
-                    ExistingImg={ExistingImg}
+                    ExistingImg={typeof ExistingImg === 'function' ? ExistingImg as React.ComponentType<MarkdownImageProps> : undefined}
                     {...rest}
                 />
             );

--- a/packages/ui/src/widgets/markdown/codeBlockHandlers.test.tsx
+++ b/packages/ui/src/widgets/markdown/codeBlockHandlers.test.tsx
@@ -123,7 +123,7 @@ describe('Proposal JSON parsing', () => {
                 question: spec.question || spec.title || '',
                 description: spec.description,
                 options: Array.isArray(spec.options)
-                    ? spec.options.map((opt: any) => ({
+                    ? spec.options.map((opt: { id?: string; value?: string; label?: string; description?: string }) => ({
                         id: opt.id || opt.value || '',
                         label: opt.label || '',
                         description: opt.description,

--- a/packages/ui/src/widgets/markdown/codeBlockHandlers.tsx
+++ b/packages/ui/src/widgets/markdown/codeBlockHandlers.tsx
@@ -255,7 +255,7 @@ export function ProposalCodeBlockHandler({ code }: CodeBlockRendererProps) {
 
         try {
             const raw = code.trim();
-            const spec = JSON.parse(raw);
+            const spec = JSON.parse(raw) as ProposalSpec;
 
             if (!spec.options || (!spec.question && !spec.title)) {
                 return null;
@@ -265,7 +265,7 @@ export function ProposalCodeBlockHandler({ code }: CodeBlockRendererProps) {
                 question: spec.question || spec.title || '',
                 description: spec.description,
                 options: Array.isArray(spec.options)
-                    ? spec.options.map((opt: any) => ({
+                    ? spec.options.map((opt) => ({
                         id: opt.id || opt.value || '',
                         label: opt.label || '',
                         description: opt.description,
@@ -311,6 +311,23 @@ export function ProposalCodeBlockHandler({ code }: CodeBlockRendererProps) {
             <AskUserWidget {...widgetProps} />
         </CodeBlockErrorBoundary>
     );
+}
+
+interface ProposalOption {
+    id?: string;
+    value?: string;
+    label?: string;
+    description?: string;
+}
+
+interface ProposalSpec {
+    question?: string;
+    title?: string;
+    description?: string;
+    options?: ProposalOption[];
+    allowFreeResponse?: boolean;
+    multiple?: boolean;
+    variant?: AskUserWidgetProps["variant"];
 }
 
 /**

--- a/packages/ui/src/widgets/markdown/remarkDirectiveHandler.ts
+++ b/packages/ui/src/widgets/markdown/remarkDirectiveHandler.ts
@@ -10,6 +10,8 @@
  */
 import { visit, type VisitorResult } from 'unist-util-visit';
 
+type RemarkTree = Parameters<typeof visit>[0];
+
 // Callout types mapped to CSS modifier classes (semantic design system)
 const CALLOUT_TYPES: Record<string, string> = {
     note: 'md-callout-info',
@@ -39,8 +41,7 @@ interface DirectiveNode {
 }
 
 export function remarkDirectiveHandler() {
-     
-    return (tree: any) => {
+    return (tree: RemarkTree) => {
         visit(tree, (node): VisitorResult => {
             if (
                 node.type !== 'containerDirective' &&

--- a/packages/ui/src/widgets/monacoEditor/MonacoEditor.tsx
+++ b/packages/ui/src/widgets/monacoEditor/MonacoEditor.tsx
@@ -117,7 +117,7 @@ export function MonacoEditor({
         const model = editor.getModel();
         if (!model) return;
         const codeBlockRegExp = /```[\s\S]*?```/g;
-        let match;
+        let match: RegExpExecArray | null;
         while ((match = codeBlockRegExp.exec(model.getValue())) !== null) {
             const startLine = model.getPositionAt(match.index).lineNumber;
             const endLine = model.getPositionAt(match.index + match[0].length).lineNumber;

--- a/packages/ui/src/widgets/schema-editor/ManagedSchema.ts
+++ b/packages/ui/src/widgets/schema-editor/ManagedSchema.ts
@@ -120,7 +120,7 @@ export class SchemaNode {
     }
 
     get title() {
-        return this.schema.title;
+        return typeof this.schema.title === 'string' ? this.schema.title : undefined;
     }
 
     set title(value: string | undefined) {
@@ -204,7 +204,7 @@ export class SchemaNode {
 
     findAvailableChildName(prefix: string) {
         const properties = this._getPropertiesSchema().properties || {};
-        let name;
+        let name: string;
         do {
             name = prefix + (++new_prop_name_cnt);
         } while (properties[name]);

--- a/packages/ui/src/widgets/schema-editor/editor/Editable.tsx
+++ b/packages/ui/src/widgets/schema-editor/editor/Editable.tsx
@@ -127,7 +127,8 @@ function DataView<T>({ viewer: Viewer, value, onEdit, editOnClick, outlineOnHove
     const btnStyle = 'invisible group-hover:visible';
 
     return (
-        <div tabIndex={0} onKeyUp={onKeyUp} onClick={onClick} className={clsx("flex justify-start items-center group", outlineOnHover ? VIEW_BOX_HOVER : VIEW_BOX, { 'cursor-pointer': editOnClick })}>
+        // biome-ignore lint/a11y/noStaticElementInteractions: container is interactive only when editOnClick is true; role/keyboard provided conditionally and onClick is a no-op otherwise.
+        <div role={editOnClick ? "button" : undefined} tabIndex={0} onKeyUp={onKeyUp} onClick={onClick} className={clsx("flex justify-start items-center group", outlineOnHover ? VIEW_BOX_HOVER : VIEW_BOX, { 'cursor-pointer': editOnClick })}>
             <Viewer value={value} placeholder={placeholder} />
             <div className='ms-auto flex space-x-2'>
                 {
@@ -180,6 +181,8 @@ function DataEdit<T>({ editor: Editor, value, onSave, onCancel, skipClickOutside
     return (
         <div ref={ref}>
             <div className={EDIT_BOX}>
+                {/* biome-ignore lint/a11y/noStaticElementInteractions: stop-propagation wrapper to keep clicks inside the editor from triggering outer handlers; not a user-facing interaction. */}
+                {/* biome-ignore lint/a11y/useKeyWithClickEvents: same — wrapper exists only to stop event propagation, not as an interactive element. */}
                 <div className="w-full" onClick={(e) => e.stopPropagation()}>
                     <Editor
                         value={actualValue}

--- a/packages/ui/src/widgets/schema-editor/editor/Editable.tsx
+++ b/packages/ui/src/widgets/schema-editor/editor/Editable.tsx
@@ -15,7 +15,7 @@ export interface DataViewerProps<T> {
 
 export interface DataEditorProps<T> {
     value: T | undefined;
-    onChange: (value: any, autoSave?: boolean) => void
+    onChange: (value: T, autoSave?: boolean) => void
     onSave?: () => void
     onCancel?: () => void
 }
@@ -53,7 +53,7 @@ export function Editable<T>({ value, onChange, onDelete,
     const { on, off, isOn } = useFlag(isEditing);
     const [validationError, setValidationError] = useState<string | undefined>();
 
-    const _onChange = (value?: any) => {
+    const _onChange = (value: T) => {
         if (onValidate) {
             const err = onValidate(value);
             if (err) {
@@ -166,7 +166,7 @@ function DataEdit<T>({ editor: Editor, value, onSave, onCancel, skipClickOutside
 
     const ref = useClickOutside<HTMLDivElement>(handleSave, skipClickOutside);
 
-    const _onChange = (value: any, autoSave = false) => {
+    const _onChange = (value: T, autoSave = false) => {
         setActualValue(value);
         latestValue.current = value;
         if (autoSave) {

--- a/packages/ui/src/widgets/schema-editor/editor/Editable.tsx
+++ b/packages/ui/src/widgets/schema-editor/editor/Editable.tsx
@@ -115,7 +115,7 @@ interface DataViewProps<T> {
 }
 function DataView<T>({ viewer: Viewer, value, onEdit, editOnClick, outlineOnHover, placeholder, onDelete, readonly }: DataViewProps<T>) {
     const onClick = () => {
-        editOnClick && onEdit();
+        if (editOnClick) onEdit();
     };
 
     const onKeyUp = (e: KeyboardEvent<HTMLDivElement>) => {

--- a/packages/ui/src/widgets/schema-editor/editor/PropertyEditor.tsx
+++ b/packages/ui/src/widgets/schema-editor/editor/PropertyEditor.tsx
@@ -139,7 +139,7 @@ function EditDescriptionModalForm({ value, onSave }: EditDescriptionModalFormPro
     const ref = useRef<HTMLTextAreaElement>(null);
     const [currentValue, setCurrentValue] = useState(value || '');
     useEffect(() => {
-        ref.current && ref.current.focus();
+        ref.current?.focus();
     }, [ref.current]);
     return (
         <>

--- a/packages/ui/src/widgets/schema-editor/editor/SchemaContext.tsx
+++ b/packages/ui/src/widgets/schema-editor/editor/SchemaContext.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
+import type { JSONSchema } from "@vertesia/common";
 import { ManagedSchema } from "../ManagedSchema.js";
 
-export function useSchema(jsonSchema: any) {
+export function useSchema(jsonSchema: string | JSONSchema | null | undefined) {
     const [schema, setSchema] = useState(new ManagedSchema(jsonSchema || { type: "object", properties: {} }).withChangeListener((schema) => {
         setSchema(schema.clone());
     }));

--- a/packages/ui/src/widgets/schema-editor/editor/SchemaEditor.tsx
+++ b/packages/ui/src/widgets/schema-editor/editor/SchemaEditor.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { ChevronDown, ChevronRight, Plus } from 'lucide-react';
-import { Button, useToast } from '@vertesia/ui/core';
+import { Button, errorMessage, useToast } from '@vertesia/ui/core';
 
 import { useUITranslation } from '@vertesia/ui/i18n';
 import { ManagedSchema, SchemaNode } from '../ManagedSchema.js';
@@ -123,11 +123,11 @@ function PropertyTitleBar({ property, readonly }: PropertyTitleBarProps) {
             if (property.update({ ...update, description: value.description })) {
                 property.reloadTree();
             }
-        } catch (err: any) {
+        } catch (err: unknown) {
             toast({
                 status: 'error',
                 title: t('widgets.schema.invalidPropertyDeclaration'),
-                description: err.message,
+                description: errorMessage(err),
                 duration: 9000
             })
             return false;

--- a/packages/ui/src/widgets/upload/DropZone.tsx
+++ b/packages/ui/src/widgets/upload/DropZone.tsx
@@ -260,6 +260,7 @@ export function DropZone({
     };
 
     return (
+        // biome-ignore lint/a11y/noStaticElementInteractions: drag/drop target; file selection is exposed via the buttons inside.
         <div
             className={`flex flex-col items-center justify-center py-12 border-2 rounded-lg transition-colors ${isDragging ? "border-color-primary bg-color-primary/10" : "border-dashed border-color-border"
                 } ${className}`}

--- a/packages/ui/src/widgets/upload/DropZone.tsx
+++ b/packages/ui/src/widgets/upload/DropZone.tsx
@@ -3,6 +3,32 @@ import { UploadIcon } from "lucide-react";
 import { Button } from "@vertesia/ui/core";
 import { useUITranslation } from "@vertesia/ui/i18n";
 
+interface FileSystemEntry {
+    fullPath: string;
+    isFile: boolean;
+    isDirectory: boolean;
+}
+
+interface FileSystemFileEntry extends FileSystemEntry {
+    isFile: true;
+    file(callback: (file: File) => void): void;
+}
+
+interface FileSystemDirectoryEntry extends FileSystemEntry {
+    isDirectory: true;
+    createReader(): {
+        readEntries(callback: (entries: FileSystemEntry[]) => void): void;
+    };
+}
+
+function isFileEntry(entry: FileSystemEntry): entry is FileSystemFileEntry {
+    return entry.isFile;
+}
+
+function isDirectoryEntry(entry: FileSystemEntry): entry is FileSystemDirectoryEntry {
+    return entry.isDirectory;
+}
+
 /**
  * Props for the DropZone component
  */
@@ -82,8 +108,8 @@ export function DropZone({
             const files: File[] = [];
             const folders = new Set<string>();
 
-            const processEntry = async (entry: any) => {
-                if (entry.isFile) {
+            const processEntry = async (entry: FileSystemEntry) => {
+                if (isFileEntry(entry)) {
                     // Get file
                     const file = await new Promise<File>((resolve) => {
                         entry.file((file: File) => {
@@ -106,11 +132,11 @@ export function DropZone({
                     if (folderPath) {
                         folders.add(folderPath);
                     }
-                } else if (entry.isDirectory) {
+                } else if (isDirectoryEntry(entry)) {
                     // Get folder reader
                     const reader = entry.createReader();
-                    const entries = await new Promise<any[]>((resolve) => {
-                        reader.readEntries((entries: any[]) => {
+                    const entries = await new Promise<FileSystemEntry[]>((resolve) => {
+                        reader.readEntries((entries) => {
                             resolve(entries);
                         });
                     });
@@ -130,7 +156,7 @@ export function DropZone({
                 // Process all dropped items
                 await Promise.all(
                     items.map((item) => {
-                        const entry = item.webkitGetAsEntry ? item.webkitGetAsEntry() : item;
+                        const entry = item.webkitGetAsEntry ? item.webkitGetAsEntry() as FileSystemEntry | null : item as unknown as FileSystemEntry;
                         if (entry) {
                             return processEntry(entry);
                         }
@@ -172,19 +198,19 @@ export function DropZone({
         }
     };
 
-    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        if (e.target.files && e.target.files.length > 0) {
-            const fileArray = Array.from(e.target.files);
+    const handleInputFiles = (fileList: FileList | null) => {
+        if (fileList && fileList.length > 0) {
+            const fileArray = Array.from(fileList);
 
             // Check if there are directories (with webkitRelativePath)
             const hasDirectories = fileArray.some(
-                (file) => (file as any).webkitRelativePath && (file as any).webkitRelativePath.includes("/"),
+                (file) => file.webkitRelativePath && file.webkitRelativePath.includes("/"),
             );
 
             if (hasDirectories) {
                 // Count the unique top-level directories
                 const topLevelDirs = new Set(
-                    fileArray.map((file) => (file as any).webkitRelativePath?.split("/")[0]).filter(Boolean),
+                    fileArray.map((file) => file.webkitRelativePath.split("/")[0]).filter(Boolean),
                 );
 
                 const folderCount = topLevelDirs.size;
@@ -216,8 +242,8 @@ export function DropZone({
         fileInput.multiple = true;
         fileInput.accept = "*";
         fileInput?.click();
-        fileInput.onchange = (event) => {
-            handleChange(event as unknown as React.ChangeEvent<HTMLInputElement>);
+        fileInput.onchange = () => {
+            handleInputFiles(fileInput.files);
         };
     };
 
@@ -226,10 +252,10 @@ export function DropZone({
         folderInput.type = "file";
         folderInput.multiple = true;
         folderInput.accept = "*";
-        (folderInput as any).webkitdirectory = true; // webkitdirectory is not standard but widely supported
+        (folderInput as HTMLInputElement & { webkitdirectory: boolean }).webkitdirectory = true; // webkitdirectory is not standard but widely supported
         folderInput?.click();
-        folderInput.onchange = (event) => {
-            handleChange(event as unknown as React.ChangeEvent<HTMLInputElement>);
+        folderInput.onchange = () => {
+            handleInputFiles(folderInput.files);
         };
     };
 

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "lint": "biome lint src",
     "test": "vitest run",
+    "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
     "build": "pnpm exec tsmod build && node ./bin/bundle-workflows.mjs lib/esm/workflows.js lib/workflows-bundle.js",
     "clean": "rm -rf ./lib tsconfig.tsbuildinfo"
   },

--- a/packages/workflow/src/activities/advanced/createDocumentTypeFromInteractionRun.ts
+++ b/packages/workflow/src/activities/advanced/createDocumentTypeFromInteractionRun.ts
@@ -22,6 +22,12 @@ export interface CreateDocumentTypeFromInteractionRun extends DSLActivitySpec<Cr
     name: 'createDocumentTypeFromInteractionRun';
 }
 
+interface GeneratedDocumentTypeResult {
+    document_type?: string;
+    metadata_schema?: CreateContentObjectTypePayload["object_schema"];
+    is_chunkable?: boolean;
+}
+
 export async function createDocumentTypeFromInteractionRun(payload: DSLActivityExecutionPayload<CreateDocumentTypeFromInteractionRunParams>) {
     const { params, client } = await setupActivity<CreateDocumentTypeFromInteractionRunParams>(payload);
 
@@ -29,10 +35,10 @@ export async function createDocumentTypeFromInteractionRun(payload: DSLActivityE
         throw new ActivityParamNotFoundError("run", payload.activity);
     }
 
-    const jsonResult = InteractionOutput.from(params.run.result).object();
+    const jsonResult = InteractionOutput.from<GeneratedDocumentTypeResult>(params.run.result).object();
 
     if (!jsonResult.document_type) {
-        log.error("No name generated for type: " + JSON.stringify(jsonResult), jsonResult);
+        log.error("No name generated for type: " + JSON.stringify(jsonResult), { jsonResult });
         throw new Error("No name generated for type");
     }
 

--- a/packages/workflow/src/activities/advanced/createOrUpdateDocumentFromInteractionRun.ts
+++ b/packages/workflow/src/activities/advanced/createOrUpdateDocumentFromInteractionRun.ts
@@ -1,5 +1,5 @@
 import { log } from "@temporalio/activity";
-import { ContentObjectStatus, DSLActivityExecutionPayload, DSLActivitySpec } from "@vertesia/common";
+import { ContentObjectStatus, DSLActivityExecutionPayload, DSLActivitySpec, JSONObject } from "@vertesia/common";
 import { setupActivity } from "../../dsl/setup/ActivityContext.js";
 import { ActivityParamNotFoundError, DocumentNotFoundError } from "../../errors.js";
 
@@ -56,13 +56,15 @@ export async function createOrUpdateDocumentFromInteractionRun(payload: DSLActiv
 
     log.debug("Creating document from interaction result", { runId, objectTypeName });
 
-    const run = await client.runs.retrieve(runId).catch((e) => {
-        throw new DocumentNotFoundError(`Error fetching run ${runId}: ${e.message}`);
+    const run = await client.runs.retrieve<Record<string, unknown>, Record<string, unknown>>(runId).catch((e: unknown) => {
+        const message = e instanceof Error ? e.message : String(e);
+        throw new DocumentNotFoundError(`Error fetching run ${runId}: ${message}`);
     });
 
     const type = objectTypeName ?
-        await client.types.getTypeByName(objectTypeName).catch((e) => {
-            throw new DocumentNotFoundError(`Error fetching type ${objectTypeName}: ${e.message}`);
+        await client.types.getTypeByName(objectTypeName).catch((e: unknown) => {
+            const message = e instanceof Error ? e.message : String(e);
+            throw new DocumentNotFoundError(`Error fetching type ${objectTypeName}: ${message}`);
         })
         : undefined;
 
@@ -71,14 +73,15 @@ export async function createOrUpdateDocumentFromInteractionRun(payload: DSLActiv
     const inputData = run.parameters;
 
     // Try to parse result as JSON, fallback to text if not valid JSON
-    let jsonResult: any = null;
+    let jsonResult: JSONObject | null = null;
     try {
-        jsonResult = result.object();
+        jsonResult = result.object<JSONObject>();
     } catch (e) {
         log.debug("Result is not valid JSON, will use text content instead", { error: e instanceof Error ? e.message : String(e) });
     }
 
-    const name = jsonResult?.['name'] || jsonResult?.["title"] || inputData['name'] || params.fallback_name || undefined;
+    const nameValue = jsonResult?.['name'] || jsonResult?.["title"] || inputData['name'] || params.fallback_name || undefined;
+    const name = typeof nameValue === "string" ? nameValue : undefined;
 
     const docPayload = {
         name,
@@ -97,7 +100,7 @@ export async function createOrUpdateDocumentFromInteractionRun(payload: DSLActiv
 
     if (params.update_text_from_property) {
         const text = docPayload.properties[params.update_text_from_property];
-        if (text) {
+        if (typeof text === "string") {
             docPayload.text = text;
         }
     }

--- a/packages/workflow/src/activities/chunkDocument.ts
+++ b/packages/workflow/src/activities/chunkDocument.ts
@@ -6,6 +6,20 @@ import { InteractionExecutionParams, executeInteractionFromActivity } from "./ex
 
 const INT_CHUNK_DOCUMENT = "sys:ChunkDocument"
 
+interface RetryableError extends Error {
+    retryable?: boolean;
+}
+
+interface ChunkDocumentInteractionResult {
+    parts?: DocPart[];
+}
+
+function toRetryableError(error: unknown): RetryableError {
+    if (error instanceof Error) {
+        return error as RetryableError;
+    }
+    return new Error(String(error)) as RetryableError;
+}
 
 
 export interface ChunkDocumentResult {
@@ -79,29 +93,30 @@ export async function chunkDocument(payload: DSLActivityExecutionPayload<ChunkDo
     const lines = document.text.split('\n')
     const instrumented = lines.map((l, i) => `{%${i}%}${l}`).join('\n')
 
-    let res;
+    let res: Awaited<ReturnType<typeof executeInteractionFromActivity>>;
     try {
         res = await executeInteractionFromActivity(client, interactionName, params, {
             objectId: objectId,
             content: instrumented
         });
-    } catch (error: any) {
-        log.error(`Failed to chunk document ${objectId}`, { error, retryable: error.retryable });
+    } catch (error: unknown) {
+        const chunkError = toRetryableError(error);
+        log.error(`Failed to chunk document ${objectId}`, { error: chunkError, retryable: chunkError.retryable });
         
         // Check retryability and convert to ApplicationFailure for Temporal
-        const isRetryable = error.retryable !== undefined 
-            ? error.retryable !== false
+        const isRetryable = chunkError.retryable !== undefined 
+            ? chunkError.retryable !== false
             : undefined;
         
         if (isRetryable !== undefined) {
             if (isRetryable) {
                 throw ApplicationFailure.create({
-                    message: `Document chunking failed for ${objectId}: ${error.message}`,
+                    message: `Document chunking failed for ${objectId}: ${chunkError.message}`,
                     nonRetryable: false,
                 });
             } else {
                 throw ApplicationFailure.create({
-                    message: `Non-retryable document chunking failed for ${objectId}: ${error.message}`,
+                    message: `Non-retryable document chunking failed for ${objectId}: ${chunkError.message}`,
                     nonRetryable: true,
                 });
             }
@@ -111,9 +126,9 @@ export async function chunkDocument(payload: DSLActivityExecutionPayload<ChunkDo
         throw error;
     }
 
-    const jsonResult = res.result.object();
+    const jsonResult = res.result.object<ChunkDocumentInteractionResult>();
 
-    const parts = jsonResult.parts as DocPart[];
+    const parts = jsonResult.parts;
     if (!parts || parts.length === 0) {
         log.warn('No parts found for object ID: ' + objectId, res);
         return { id: objectId, status: "failed", parts: [], message: "no parts found" }
@@ -145,7 +160,7 @@ export async function chunkDocument(payload: DSLActivityExecutionPayload<ChunkDo
                 location: location(),
                 properties: {
                     part_number: i + 1,
-                    etag: document.text_etag,
+                    ...(document.text_etag !== undefined ? { etag: document.text_etag } : {}),
                     source_line_start: part.line_number_start,
                     source_line_end: part.line_number_end,
                     title: part.name

--- a/packages/workflow/src/activities/executeInteraction.test.ts
+++ b/packages/workflow/src/activities/executeInteraction.test.ts
@@ -54,7 +54,7 @@ async function mockInteractionError(error: Error & { statusCode?: number; status
 }
 
 describe('executeInteraction retryability', () => {
-    it('leaves 412 rendition-in-progress failures retryable', async () => {
+    it('should leave 412 rendition-in-progress failures retryable', async () => {
         await mockInteractionError(Object.assign(new Error('rendition in progress'), { statusCode: 412 }));
 
         await expect(testEnv.run(executeInteraction, createPayload())).rejects.toMatchObject({
@@ -65,7 +65,7 @@ describe('executeInteraction retryability', () => {
     it.each([
         ['status', { status: 412 }],
         ['code', { code: 412 }],
-    ])('leaves 412 failures retryable when reported as %s', async (_field, statusProps) => {
+    ])('should leave 412 failures retryable when reported as %s', async (_field, statusProps) => {
         await mockInteractionError(Object.assign(new Error('precondition failed'), statusProps));
 
         await expect(testEnv.run(executeInteraction, createPayload())).rejects.toMatchObject({
@@ -73,7 +73,7 @@ describe('executeInteraction retryability', () => {
         });
     });
 
-    it('marks other 4xx failures as non-retryable', async () => {
+    it('should mark other 4xx failures as non-retryable', async () => {
         await mockInteractionError(Object.assign(new Error('bad request'), { statusCode: 400 }));
 
         await expect(testEnv.run(executeInteraction, createPayload())).rejects.toMatchObject({

--- a/packages/workflow/src/activities/executeInteraction.ts
+++ b/packages/workflow/src/activities/executeInteraction.ts
@@ -1,4 +1,4 @@
-import { CompletionResult, ModelOptions, LlumiverseError } from "@llumiverse/common";
+import { CompletionResult, JSONSchema, ModelOptions, LlumiverseError } from "@llumiverse/common";
 import { activityInfo, ApplicationFailure, log } from "@temporalio/activity";
 import { VertesiaClient } from "@vertesia/client";
 import { NodeStreamSource } from "@vertesia/client/node";
@@ -19,7 +19,7 @@ import { Readable } from "stream";
 
 //Example:
 //@ts-ignore
-const JSON: DSLActivitySpec = {
+const _JSON: DSLActivitySpec = {
     name: "executeInteraction",
     import: ["defaultModel", "guidlineId", "docTypeId"],
     params: {
@@ -79,7 +79,7 @@ export interface InteractionExecutionParams {
     /**
      * Request a JSON schema for the result
      */
-    result_schema?: any;
+    result_schema?: JSONSchema | null;
 
     /** Wether to validate the result against the schema */
     validate_result?: boolean;
@@ -113,13 +113,13 @@ export interface InteractionExecutionParams {
 export interface ExecuteInteractionParams extends InteractionExecutionParams {
     //TODO rename to interaction as in InteractionAsyncExecutionPayload
     interactionName: string;
-    prompt_data: Record<string, any>;
+    prompt_data: Record<string, unknown>;
     /**
      * Additional prompt data passed by the workflow configuration. This will be merged with prompt_data if any.
      * You should use `import: ["static_prompt_data"]` to import the workflow prompt data as static_prompt_data param.
      * Otherwise the workflow prompt data will be ignored.
      */
-    static_prompt_data?: Record<string, any>;
+    static_prompt_data?: Record<string, unknown>;
     truncate?: Record<string, TruncateSpec>;
 }
 
@@ -143,7 +143,10 @@ export async function executeInteraction(payload: DSLActivityExecutionPayload<Ex
     if (params.truncate) {
         const truncate = params.truncate;
         for (const [key, value] of Object.entries(truncate)) {
-            prompt_data[key] = truncByMaxTokens(prompt_data[key], value);
+            const promptValue = prompt_data[key];
+            if (typeof promptValue === "string") {
+                prompt_data[key] = truncByMaxTokens(promptValue, value);
+            }
         }
     }
 
@@ -198,51 +201,52 @@ export async function executeInteraction(payload: DSLActivityExecutionPayload<Ex
             result: completionResult,
         });
 
-    } catch (error: any) {
-        log.error(`Failed to execute interaction ${interactionName}`, { error });
-        if (error.statusCode === 429 && params.exit_on_resource_exhaustion) {
-            throw new ResourceExhaustedError(error.statusCode, "Resource exhausted - rate limit exceeded");
-        } else if (is4xxNonRetryable(error.status) || is4xxNonRetryable(error.statusCode) || is4xxNonRetryable(error.code) || error.retryable === false) {
+    } catch (error: unknown) {
+        const executionError = toExecutionError(error);
+        log.error(`Failed to execute interaction ${interactionName}`, { error: executionError });
+        if (executionError.statusCode === 429 && params.exit_on_resource_exhaustion) {
+            throw new ResourceExhaustedError(executionError.statusCode, "Resource exhausted - rate limit exceeded");
+        } else if (is4xxNonRetryable(executionError.status) || is4xxNonRetryable(executionError.statusCode) || is4xxNonRetryable(executionError.code) || executionError.retryable === false) {
             // 4xx HTTP errors (except retryable statuses) are permanent client errors
             // (e.g. model not found, invalid request).
             // Errors explicitly marked as non-retryable (e.g. LlumiverseError) also fall here.
             // They will not be resolved by retrying.
             throw ApplicationFailure.create({
-                message: `Interaction Execution failed ${interactionName}: ${error.message}`,
+                message: `Interaction Execution failed ${interactionName}: ${executionError.message}`,
                 nonRetryable: true,
             });
-        } else if (error.message.includes("Failed to validate merged prompt schema")) {
+        } else if (executionError.message.includes("Failed to validate merged prompt schema")) {
             //issue with the input data, don't retry
-            throw new ActivityParamInvalidError("prompt_data", payload.activity, error.message);
-        } else if (error.message.includes("modelId: Path `modelId` is required")) {
+            throw new ActivityParamInvalidError("prompt_data", payload.activity, executionError.message);
+        } else if (executionError.message.includes("modelId: Path `modelId` is required")) {
             //issue with the input data, don't retry
-            throw new ActivityParamInvalidError("model", payload.activity, error.message);
+            throw new ActivityParamInvalidError("model", payload.activity, executionError.message);
         }
         
         // Check retryability from error object (set by executeInteractionFromActivity)
         // or from LlumiverseError instance (direct driver errors in some paths)
-        const isRetryable = error.retryable !== undefined 
-            ? error.retryable !== false  // Treat undefined as retryable
+        const isRetryable = executionError.retryable !== undefined 
+            ? true
             : (error instanceof LlumiverseError ? error.retryable !== false : undefined);
         
         if (isRetryable !== undefined) {
             if (isRetryable) {
-                log.debug('Marking error as retryable', { interactionName, errorCode: error.errorCode });
+                log.debug('Marking error as retryable', { interactionName, errorCode: executionError.errorCode });
                 throw ApplicationFailure.create({
-                    message: `Interaction Execution failed ${interactionName}: ${error.message}`,
+                    message: `Interaction Execution failed ${interactionName}: ${executionError.message}`,
                     nonRetryable: false,
                 });
             } else {
-                log.debug('Marking error as non-retryable', { interactionName, errorCode: error.errorCode });
+                log.debug('Marking error as non-retryable', { interactionName, errorCode: executionError.errorCode });
                 throw ApplicationFailure.create({
-                    message: `Non-retryable Interaction Execution failed ${interactionName}: ${error.message}`,
+                    message: `Non-retryable Interaction Execution failed ${interactionName}: ${executionError.message}`,
                     nonRetryable: true,
                 });
             }
         }
         
         // Unknown retryability - rethrow as generic error (Temporal will use default retry policy)
-        throw new Error(`Interaction Execution failed ${interactionName}: ${error.message}`);
+        throw new Error(`Interaction Execution failed ${interactionName}: ${executionError.message}`);
     }
 }
 
@@ -250,7 +254,7 @@ export async function executeInteractionFromActivity(
     client: VertesiaClient,
     interactionName: string,
     params: InteractionExecutionParams,
-    prompt_data: any,
+    prompt_data: Record<string, unknown>,
     debug?: boolean,
 ) {
     const userTags = params.tags;
@@ -331,8 +335,9 @@ export async function executeInteractionFromActivity(
         const error = new Error(errorMessage);
         
         // Attach retryable property so the catch block can access it
-        (error as any).retryable = res.error?.retryable;
-        (error as any).errorCode = res.error?.code;
+        const executionError = error as Error & { retryable?: boolean; errorCode?: string };
+        executionError.retryable = res.error?.retryable;
+        executionError.errorCode = res.error?.code;
         
         throw error;
     }
@@ -348,4 +353,19 @@ export async function executeInteractionFromActivity(
 function is4xxNonRetryable(code: number | undefined): boolean {
     if (code === undefined || typeof code !== 'number') return false;
     return code >= 400 && code < 500 && code !== 412 && code !== 429;
+}
+
+interface ExecutionError extends Error {
+    status?: number;
+    statusCode?: number;
+    code?: number;
+    retryable?: boolean;
+    errorCode?: unknown;
+}
+
+function toExecutionError(error: unknown): ExecutionError {
+    if (error instanceof Error) {
+        return error as ExecutionError;
+    }
+    return new Error(String(error)) as ExecutionError;
 }

--- a/packages/workflow/src/activities/executeRemoteActivity.test.ts
+++ b/packages/workflow/src/activities/executeRemoteActivity.test.ts
@@ -27,14 +27,14 @@ beforeEach(() => {
 const createPayload = (
     overrides: Partial<ExecuteRemoteActivityParams> = {},
 ): DSLActivityExecutionPayload<ExecuteRemoteActivityParams> => {
-    const params: ExecuteRemoteActivityParams = {
+    const params = {
         url: "https://tool-server.test/api/activities/nlp",
         activity_name: "analyze_sentiment",
         params: { text: "Hello world" },
         app_install_id: "install-123",
         app_name: "nlp-app",
         ...overrides,
-    };
+    } satisfies ExecuteRemoteActivityParams;
     return {
         auth_token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwOi8vbW9jay10b2tlbi1zZXJ2ZXIiLCJzdWIiOiJ0ZXN0In0.sig",
         account_id: "acc-123",
@@ -53,7 +53,7 @@ const createPayload = (
 };
 
 describe("executeRemoteActivity", () => {
-    it("posts correct payload and returns result on success", async () => {
+    it("should post correct payload and return result on success", async () => {
         mockFetch.mockResolvedValueOnce(
             new Response(
                 JSON.stringify({ result: { score: 0.95 }, is_error: false }),
@@ -61,7 +61,7 @@ describe("executeRemoteActivity", () => {
             ),
         );
 
-        const result = await testEnv.run(executeRemoteActivity, createPayload());
+        const result: unknown = await testEnv.run(executeRemoteActivity, createPayload());
         expect(result).toEqual({ score: 0.95 });
 
         expect(mockFetch).toHaveBeenCalledOnce();
@@ -85,7 +85,7 @@ describe("executeRemoteActivity", () => {
         expect(body.auth_token).toBeUndefined();
     });
 
-    it("throws on HTTP error (4xx/5xx)", async () => {
+    it("should throw on HTTP error (4xx/5xx)", async () => {
         mockFetch.mockResolvedValueOnce(
             new Response(
                 JSON.stringify({ error: "Activity not found", is_error: true }),
@@ -98,7 +98,7 @@ describe("executeRemoteActivity", () => {
         );
     });
 
-    it("throws on network error (for Temporal retry)", async () => {
+    it("should throw on network error (for Temporal retry)", async () => {
         mockFetch.mockRejectedValueOnce(new Error("Connection refused"));
 
         await expect(testEnv.run(executeRemoteActivity, createPayload())).rejects.toThrow(
@@ -106,7 +106,7 @@ describe("executeRemoteActivity", () => {
         );
     });
 
-    it("throws on invalid JSON response", async () => {
+    it("should throw on invalid JSON response", async () => {
         mockFetch.mockResolvedValueOnce(
             new Response("not json", { status: 200 }),
         );
@@ -116,7 +116,7 @@ describe("executeRemoteActivity", () => {
         );
     });
 
-    it("throws when response indicates is_error", async () => {
+    it("should throw when response indicates is_error", async () => {
         mockFetch.mockResolvedValueOnce(
             new Response(
                 JSON.stringify({ result: null, is_error: true, error: "Something went wrong" }),
@@ -129,7 +129,7 @@ describe("executeRemoteActivity", () => {
         );
     });
 
-    it("forwards app_settings in metadata", async () => {
+    it("should forward app_settings in metadata", async () => {
         mockFetch.mockResolvedValueOnce(
             new Response(
                 JSON.stringify({ result: "ok", is_error: false }),

--- a/packages/workflow/src/activities/executeRemoteActivity.test.ts
+++ b/packages/workflow/src/activities/executeRemoteActivity.test.ts
@@ -48,7 +48,7 @@ const createPayload = (
         event: ContentEventName.create,
         objectIds: [],
         vars: {},
-        activity: { name: "executeRemoteActivity", params },
+        activity: { name: "executeRemoteActivity", params: params as unknown as Record<string, unknown> },
     };
 };
 

--- a/packages/workflow/src/activities/executeRemoteActivity.ts
+++ b/packages/workflow/src/activities/executeRemoteActivity.ts
@@ -16,13 +16,13 @@ export interface ExecuteRemoteActivityParams {
     /** The activity name (unprefixed, as known by the tool server) */
     activity_name: string;
     /** The resolved parameters for the activity */
-    params: Record<string, any>;
+    params: Record<string, unknown>;
     /** App installation ID */
     app_install_id: string;
     /** App name */
     app_name: string;
     /** App installation settings */
-    app_settings?: Record<string, any>;
+    app_settings?: Record<string, unknown>;
 }
 
 /**
@@ -38,7 +38,7 @@ export interface ExecuteRemoteActivityParams {
  */
 export async function executeRemoteActivity(
     payload: DSLActivityExecutionPayload<ExecuteRemoteActivityParams>,
-): Promise<any> {
+): Promise<unknown> {
     const ctx = await setupActivity<ExecuteRemoteActivityParams>(payload);
     const { params, runId, client } = ctx;
     const { url, activity_name, params: activityParams, app_install_id, app_settings } = params;
@@ -126,7 +126,7 @@ export async function executeRemoteActivity(
     let responseJson: RemoteActivityExecutionResponse;
     try {
         responseJson = JSON.parse(responseText);
-    } catch (err: unknown) {
+    } catch {
         const preview = responseText.length > 200 ? responseText.slice(0, 200) + '...' : responseText;
         log.warn("Invalid JSON response from remote activity", {
             activity: activity_name, endpoint: url, runId, app_install_id,

--- a/packages/workflow/src/activities/extractDocumentText.ts
+++ b/packages/workflow/src/activities/extractDocumentText.ts
@@ -1,4 +1,5 @@
 import { log } from "@temporalio/activity";
+import { VertesiaClient } from "@vertesia/client";
 import {
     ContentObject,
     CreateContentObjectPayload,
@@ -20,7 +21,7 @@ import {
 import { countTokens } from "../utils/tokens.js";
 
 //@ts-ignore
-const JSON: DSLActivitySpec = {
+const _JSON: DSLActivitySpec = {
     name: "extractDocumentText",
 };
 
@@ -52,7 +53,7 @@ export async function extractDocumentText(
 }
 
 async function extractFromObject(
-    client: any,
+    client: VertesiaClient,
     objectId: string,
     objectIds: string[],
 ): Promise<TextExtractionResult> {
@@ -85,9 +86,10 @@ async function extractFromObject(
     let fileBuffer: Buffer;
     try {
         fileBuffer = await fetchBlobAsBuffer(client, doc.content.source);
-    } catch (e: any) {
+    } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : String(e);
         log.error(`Error reading file: ${e}`);
-        return createResponse(doc, "", TextExtractionStatus.error, e.message);
+        return createResponse(doc, "", TextExtractionStatus.error, message);
     }
 
     const txt = await extractTextFromBuffer(fileBuffer, doc.content.type);
@@ -118,7 +120,7 @@ async function extractFromObject(
 }
 
 async function extractFromFileSource(
-    client: any,
+    client: VertesiaClient,
     input_file: WorkflowInputFile,
     output_storage_path: string
 ): Promise<TextExtractionResult> {
@@ -127,7 +129,7 @@ async function extractFromFileSource(
     let fileBuffer: Buffer;
     try {
         fileBuffer = await fetchBlobAsBuffer(client, input_file.url);
-    } catch (e: any) {
+    } catch (e: unknown) {
         log.error(`Error reading file: ${e}`);
         return createFileSourceResult(input_file.url, output_storage_path, null);
     }
@@ -258,7 +260,7 @@ function sniffIfText(buf: Buffer) {
     try {
         const s = buf.toString("utf8");
         return s.length > 0 && !s.includes("\uFFFD"); // Replacement character
-    } catch (e) {
+    } catch {
         return false;
     }
 }

--- a/packages/workflow/src/activities/generateDocumentProperties.ts
+++ b/packages/workflow/src/activities/generateDocumentProperties.ts
@@ -1,10 +1,27 @@
 import { ApplicationFailure, log } from "@temporalio/activity";
-import { DSLActivityExecutionPayload, DSLActivitySpec } from "@vertesia/common";
+import { DSLActivityExecutionPayload, DSLActivitySpec, JSONObject } from "@vertesia/common";
 import { setupActivity } from "../dsl/setup/ActivityContext.js";
 import { TruncateSpec, truncByMaxTokens } from "../utils/tokens.js";
 import { InteractionExecutionParams, executeInteractionFromActivity } from "./executeInteraction.js";
 
 const INT_EXTRACT_INFORMATION = "sys:ExtractInformation";
+
+interface RetryableError extends Error {
+    retryable?: boolean;
+}
+
+interface GeneratedPropertiesSummary {
+    title?: unknown;
+    description?: unknown;
+}
+
+function toRetryableError(error: unknown): RetryableError {
+    if (error instanceof Error) {
+        return error as RetryableError;
+    }
+    return new Error(String(error)) as RetryableError;
+}
+
 export interface GenerateDocumentPropertiesParams extends InteractionExecutionParams {
     typesHint?: string[];
     /**
@@ -72,7 +89,7 @@ export async function generateDocumentProperties(
         payload.debug_mode ? { params } : undefined,
     );
 
-    let infoRes;
+    let infoRes: Awaited<ReturnType<typeof executeInteractionFromActivity>>;
     try {
         infoRes = await executeInteractionFromActivity(
             client,
@@ -86,22 +103,23 @@ export async function generateDocumentProperties(
             promptData,
             payload.debug_mode ?? false,
         );
-    } catch (error: any) {
-        log.error(`Failed to extract document properties for ${objectId}`, { error, retryable: error.retryable });
+    } catch (error: unknown) {
+        const extractionError = toRetryableError(error);
+        log.error(`Failed to extract document properties for ${objectId}`, { error: extractionError, retryable: extractionError.retryable });
         
-        const isRetryable = error.retryable !== undefined 
-            ? error.retryable !== false
+        const isRetryable = extractionError.retryable !== undefined 
+            ? extractionError.retryable !== false
             : undefined;
         
         if (isRetryable !== undefined) {
             if (isRetryable) {
                 throw ApplicationFailure.create({
-                    message: `Document property extraction failed for ${objectId}: ${error.message}`,
+                    message: `Document property extraction failed for ${objectId}: ${extractionError.message}`,
                     nonRetryable: false,
                 });
             } else {
                 throw ApplicationFailure.create({
-                    message: `Non-retryable document property extraction failed for ${objectId}: ${error.message}`,
+                    message: `Non-retryable document property extraction failed for ${objectId}: ${extractionError.message}`,
                     nonRetryable: true,
                 });
             }
@@ -115,11 +133,11 @@ export async function generateDocumentProperties(
             return undefined;
         }
         let text = "";
-        const jsonResult = infoRes.result.object();
-        if (jsonResult.title) {
+        const jsonResult = infoRes.result.object<GeneratedPropertiesSummary>();
+        if (typeof jsonResult.title === "string") {
             text += jsonResult.title + "\n";
         }
-        if (jsonResult.description) {
+        if (typeof jsonResult.description === "string") {
             text += jsonResult.description;
         }
         if (text) {
@@ -131,9 +149,9 @@ export async function generateDocumentProperties(
 
     log.info(`Extracted information from object ${objectId} with type ${type.name}`, { runId: infoRes.id });
     await client.objects.update(doc.id, {
-        properties: {
-            ...infoRes.result.object(),
-            etag: doc.text_etag,
+            properties: {
+            ...infoRes.result.object<JSONObject>(),
+            ...(doc.text_etag !== undefined ? { etag: doc.text_etag } : {}),
         },
         text: getText(),
         generation_run_info: {

--- a/packages/workflow/src/activities/generateEmbeddings.ts
+++ b/packages/workflow/src/activities/generateEmbeddings.ts
@@ -94,7 +94,7 @@ export async function generateEmbeddings(
         );
     }
 
-    let document;
+    let document: Awaited<ReturnType<typeof client.objects.retrieve>>;
     try {
         document = await client.objects.retrieve(
             objectId,
@@ -115,7 +115,10 @@ export async function generateEmbeddings(
         throw new DocumentNotFoundError("Document content not found", [objectId]);
     }
 
-    let res;
+    let res:
+        | Awaited<ReturnType<typeof generateTextEmbeddings>>
+        | Awaited<ReturnType<typeof generateImageEmbeddings>>
+        | { id: string; status: string; message: string };
 
     switch (type) {
         case SupportedEmbeddingTypes.text:

--- a/packages/workflow/src/activities/generateOrAssignContentType.ts
+++ b/packages/workflow/src/activities/generateOrAssignContentType.ts
@@ -19,6 +19,29 @@ import {
 const INT_SELECT_DOCUMENT_TYPE = "sys:SelectDocumentType";
 const INT_GENERATE_METADATA_MODEL = "sys:GenerateMetadataModel";
 
+interface RetryableError extends Error {
+  retryable?: boolean;
+}
+
+interface SelectDocumentTypeResult {
+  document_type?: string;
+}
+
+interface GeneratedDocumentTypeResult {
+  document_type?: string;
+  document_type_description?: string;
+  metadata_schema?: CreateContentObjectTypePayload["object_schema"];
+  is_chunkable?: boolean;
+  table_layout?: CreateContentObjectTypePayload["table_layout"];
+}
+
+function toRetryableError(error: unknown): RetryableError {
+  if (error instanceof Error) {
+    return error as RetryableError;
+  }
+  return new Error(String(error)) as RetryableError;
+}
+
 export interface GenerateOrAssignContentTypeParams
   extends InteractionExecutionParams {
   typesHint?: string[];
@@ -122,7 +145,7 @@ export async function generateOrAssignContentType(
     existing_types.filter((t) => !t.tags?.includes("system")),
   );
 
-  let res;
+  let res: Awaited<ReturnType<typeof executeInteractionFromActivity>>;
   try {
     res = await executeInteractionFromActivity(
       client,
@@ -134,22 +157,23 @@ export async function generateOrAssignContentType(
         image: fileRef,
       },
     );
-  } catch (error: any) {
-    log.error(`Failed to select document type`, { error, retryable: error.retryable });
+  } catch (error: unknown) {
+    const selectionError = toRetryableError(error);
+    log.error(`Failed to select document type`, { error: selectionError, retryable: selectionError.retryable });
     
-    const isRetryable = error.retryable !== undefined 
-      ? error.retryable !== false
+    const isRetryable = selectionError.retryable !== undefined 
+      ? selectionError.retryable !== false
       : undefined;
     
     if (isRetryable !== undefined) {
       if (isRetryable) {
         throw ApplicationFailure.create({
-          message: `Document type selection failed: ${error.message}`,
+          message: `Document type selection failed: ${selectionError.message}`,
           nonRetryable: false,
         });
       } else {
         throw ApplicationFailure.create({
-          message: `Non-retryable document type selection failed: ${error.message}`,
+          message: `Non-retryable document type selection failed: ${selectionError.message}`,
           nonRetryable: true,
         });
       }
@@ -158,7 +182,7 @@ export async function generateOrAssignContentType(
     throw error;
   }
 
-  const jsonResult = res.result.object();
+  const jsonResult = res.result.object<SelectDocumentTypeResult>();
 
   log.debug("Selected Content Type Result: " + JSON.stringify(jsonResult));
 
@@ -209,7 +233,7 @@ async function generateNewType(
     params.interactionNames?.generateMetadataModel ??
     INT_GENERATE_METADATA_MODEL;
 
-  let genTypeRes;
+  let genTypeRes: Awaited<ReturnType<typeof executeInteractionFromActivity>>;
   try {
     genTypeRes = await executeInteractionFromActivity(
       client,
@@ -222,22 +246,23 @@ async function generateNewType(
         image: fileRef ? fileRef : undefined,
       },
     );
-  } catch (error: any) {
-    log.error(`Failed to generate new document type`, { error, retryable: error.retryable });
+  } catch (error: unknown) {
+    const generationError = toRetryableError(error);
+    log.error(`Failed to generate new document type`, { error: generationError, retryable: generationError.retryable });
     
-    const isRetryable = error.retryable !== undefined 
-      ? error.retryable !== false
+    const isRetryable = generationError.retryable !== undefined 
+      ? generationError.retryable !== false
       : undefined;
     
     if (isRetryable !== undefined) {
       if (isRetryable) {
         throw ApplicationFailure.create({
-          message: `Document type generation failed: ${error.message}`,
+          message: `Document type generation failed: ${generationError.message}`,
           nonRetryable: false,
         });
       } else {
         throw ApplicationFailure.create({
-          message: `Non-retryable document type generation failed: ${error.message}`,
+          message: `Non-retryable document type generation failed: ${generationError.message}`,
           nonRetryable: true,
         });
       }
@@ -246,7 +271,7 @@ async function generateNewType(
     throw error;
   }
 
-  const jsonResult = genTypeRes.result.object();
+  const jsonResult = genTypeRes.result.object<GeneratedDocumentTypeResult>();
 
   if (!jsonResult.document_type) {
     log.error("No name generated for type", genTypeRes);

--- a/packages/workflow/src/activities/getObjectFromStore.ts
+++ b/packages/workflow/src/activities/getObjectFromStore.ts
@@ -31,9 +31,10 @@ export async function getObjectFromStore(payload: DSLActivityExecutionPayload<Ge
         throw err;
     }
 
-    const projection = projectResult(payload, params, obj, obj);
+    const projection = projectResult(payload, params, obj, obj) as Partial<ContentObject>;
 
     return {
+        ...obj,
         ...projection,
         id: obj.id,
     }

--- a/packages/workflow/src/activities/media/prepareAudio.ts
+++ b/packages/workflow/src/activities/media/prepareAudio.ts
@@ -1,6 +1,6 @@
 import { log } from '@temporalio/activity';
 import { DSLActivityExecutionPayload, DSLActivitySpec, AudioMetadata, AUDIO_RENDITION_NAME, ContentNature, Rendition } from '@vertesia/common';
-import { exec } from 'child_process';
+import { execFile as execFileCallback } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -11,7 +11,7 @@ import { saveBlobToTempFile } from '../../utils/blobs.js';
 import { VertesiaClient } from '@vertesia/client';
 import { RequestError } from '@vertesia/api-fetch-client';
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFileCallback);
 
 // Default configuration constants
 const DEFAULT_AUDIO_BITRATE = '128k'; // Default audio bitrate for AAC encoding
@@ -71,9 +71,9 @@ export interface PrepareAudioResult {
  */
 async function getAudioMetadata(audioPath: string): Promise<AudioMetadataExtended> {
     try {
-        const command = `ffprobe -v quiet -print_format json -show_format -show_streams "${audioPath}"`;
-        const { stdout } = await execAsync(command);
-        const metadata = JSON.parse(stdout) as FFProbeOutput;
+        const args = ['-v', 'quiet', '-print_format', 'json', '-show_format', '-show_streams', audioPath];
+        const { stdout } = await execFileAsync('ffprobe', args);
+        const metadata = JSON.parse(stdout.toString()) as FFProbeOutput;
 
         const audioStream = metadata.streams.find(
             (stream) => stream.codec_type === 'audio',
@@ -112,22 +112,22 @@ async function generateAudioRendition(
     const outputFile = path.join(outputDir, 'audio.m4a');
 
     const command = [
-        'ffmpeg',
         '-y', // Overwrite output
-        '-i', `"${audioPath}"`,
+        '-i', audioPath,
         '-c:a', 'aac', // AAC codec
         '-b:a', audioBitrate, // Audio bitrate
         '-movflags', '+faststart', // Enable streaming
-        `"${outputFile}"`,
-    ].join(' ');
+        outputFile,
+    ];
 
-    log.info('Generating web audio rendition (AAC M4A)', { command, audioBitrate });
+    log.info('Generating web audio rendition (AAC M4A)', { command: 'ffmpeg', args: command, audioBitrate });
 
     try {
-        const { stderr } = await execAsync(command, { maxBuffer: FFMPEG_MAX_BUFFER });
+        const { stderr } = await execFileAsync('ffmpeg', command, { maxBuffer: FFMPEG_MAX_BUFFER });
+        const stderrText = stderr.toString();
 
-        if (stderr && !stderr.includes('frame=')) {
-            log.debug(`FFmpeg stderr for audio rendition: ${stderr}`);
+        if (stderrText && !stderrText.includes('frame=')) {
+            log.debug(`FFmpeg stderr for audio rendition: ${stderrText}`);
         }
 
         // Verify output file was created

--- a/packages/workflow/src/activities/media/prepareVideo.ts
+++ b/packages/workflow/src/activities/media/prepareVideo.ts
@@ -1,6 +1,6 @@
 import { ApplicationFailure, log } from '@temporalio/activity';
 import { DSLActivityExecutionPayload, DSLActivitySpec, VideoMetadata, VideoRendition, POSTER_RENDITION_NAME, AUDIO_RENDITION_NAME, WEB_VIDEO_RENDITION_NAME, ContentNature } from '@vertesia/common';
-import { exec } from 'child_process';
+import { execFile as execFileCallback } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -11,7 +11,7 @@ import { saveBlobToTempFile } from '../../utils/blobs.js';
 import { VertesiaClient } from '@vertesia/client';
 import { RequestError } from '@vertesia/api-fetch-client';
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFileCallback);
 
 // Default configuration constants
 const DEFAULT_MAX_RESOLUTION = 1920; // Max resolution for video rendition (produces 1080p)
@@ -75,9 +75,9 @@ interface FFProbeOutput {
  */
 async function getVideoMetadata(videoPath: string): Promise<VideoMetadataExtended> {
     try {
-        const command = `ffprobe -v quiet -print_format json -show_format -show_streams "${videoPath}"`;
-        const { stdout } = await execAsync(command);
-        const metadata = JSON.parse(stdout) as FFProbeOutput;
+        const args = ['-v', 'quiet', '-print_format', 'json', '-show_format', '-show_streams', videoPath];
+        const { stdout } = await execFileAsync('ffprobe', args);
+        const metadata = JSON.parse(stdout.toString()) as FFProbeOutput;
 
         const videoStream = metadata.streams.find(
             (stream) => stream.codec_type === 'video',
@@ -196,10 +196,9 @@ async function generateVideoRendition(
     const videoFilters = `scale=${dimensions.width}:${dimensions.height},format=yuv420p`;
 
     const command = [
-        'ffmpeg',
         '-y', // Overwrite output
-        '-i', `"${videoPath}"`,
-        '-vf', `"${videoFilters}"`,
+        '-i', videoPath,
+        '-vf', videoFilters,
         '-c:v', 'libx264', // H.264 codec
         '-preset', 'medium', // Balance between speed and compression
         '-crf', VIDEO_CRF, // Constant Rate Factor (18-28, lower = better quality)
@@ -208,16 +207,17 @@ async function generateVideoRendition(
         '-b:a', AUDIO_BITRATE, // Audio bitrate
         '-movflags', '+faststart', // Enable streaming
         '-max_muxing_queue_size', '1024', // Prevent muxing issues
-        `"${outputFile}"`,
-    ].join(' ');
+        outputFile,
+    ];
 
-    log.info(`Generating ${maxResolution}p video rendition`, { command });
+    log.info(`Generating ${maxResolution}p video rendition`, { command: 'ffmpeg', args: command });
 
     try {
-        const { stderr } = await execAsync(command, { maxBuffer: FFMPEG_MAX_BUFFER });
+        const { stderr } = await execFileAsync('ffmpeg', command, { maxBuffer: FFMPEG_MAX_BUFFER });
+        const stderrText = stderr.toString();
 
-        if (stderr && !stderr.includes('frame=')) {
-            log.debug(`FFmpeg stderr for video rendition: ${stderr}`);
+        if (stderrText && !stderrText.includes('frame=')) {
+            log.debug(`FFmpeg stderr for video rendition: ${stderrText}`);
         }
 
         // Verify output file was created
@@ -251,22 +251,22 @@ async function generateAudioRendition(
     const outputFile = path.join(outputDir, 'audio.m4a');
 
     const command = [
-        'ffmpeg',
         '-y', // Overwrite output
-        '-i', `"${videoPath}"`,
+        '-i', videoPath,
         '-vn', // No video
         '-c:a', 'aac', // Audio codec
         '-b:a', AUDIO_BITRATE, // Audio bitrate
-        `"${outputFile}"`,
-    ].join(' ');
+        outputFile,
+    ];
 
-    log.info('Generating audio-only rendition', { command });
+    log.info('Generating audio-only rendition', { command: 'ffmpeg', args: command });
 
     try {
-        const { stderr } = await execAsync(command, { maxBuffer: FFMPEG_MAX_BUFFER });
+        const { stderr } = await execFileAsync('ffmpeg', command, { maxBuffer: FFMPEG_MAX_BUFFER });
+        const stderrText = stderr.toString();
 
-        if (stderr && !stderr.includes('frame=')) {
-            log.debug(`FFmpeg stderr for audio rendition: ${stderr}`);
+        if (stderrText && !stderrText.includes('frame=')) {
+            log.debug(`FFmpeg stderr for audio rendition: ${stderrText}`);
         }
 
         // Verify output file was created
@@ -305,23 +305,23 @@ async function generateScreenshot(
     const scaleFilter = `scale=${dimensions.width}:${dimensions.height}`;
 
     const command = [
-        'ffmpeg',
         '-y',
         '-ss', timestamp.toString(),
-        '-i', `"${videoPath}"`,
+        '-i', videoPath,
         '-vframes', '1',
-        '-vf', `"${scaleFilter}"`,
+        '-vf', scaleFilter,
         '-q:v', JPEG_QUALITY, // High quality JPEG
-        `"${outputFile}"`,
-    ].join(' ');
+        outputFile,
+    ];
 
-    log.info(`Generating ${name} at ${timestamp}s`, { command });
+    log.info(`Generating ${name} at ${timestamp}s`, { command: 'ffmpeg', args: command });
 
     try {
-        const { stderr } = await execAsync(command);
+        const { stderr } = await execFileAsync('ffmpeg', command);
+        const stderrText = stderr.toString();
 
-        if (stderr && !stderr.includes('frame=')) {
-            log.debug(`FFmpeg stderr for ${name}: ${stderr}`);
+        if (stderrText && !stderrText.includes('frame=')) {
+            log.debug(`FFmpeg stderr for ${name}: ${stderrText}`);
         }
 
         // Verify output file was created

--- a/packages/workflow/src/activities/media/probeMediaStreams.test.ts
+++ b/packages/workflow/src/activities/media/probeMediaStreams.test.ts
@@ -33,14 +33,14 @@ const createPayload = (objectId = 'test-object-id'): DSLActivityExecutionPayload
     auth_token: 'mock-token',
     account_id: 'test-account',
     project_id: 'test-project',
-    params: {},
+    params: {} satisfies ProbeMediaStreamsParams,
     config: { studio_url: 'http://mock-studio', store_url: 'http://mock-store' },
     workflow_name: 'test-workflow',
     event: ContentEventName.create,
     objectIds: [objectId],
     input: { inputType: 'objectIds', objectIds: [objectId] },
     vars: {},
-    activity: { name: 'probeMediaStreams', params: {} },
+    activity: { name: 'probeMediaStreams', params: {} satisfies ProbeMediaStreamsParams },
 });
 
 function mockExec(stdout: string) {
@@ -68,7 +68,7 @@ async function setupMockContext(objectId: string, signedUrl: string): Promise<vo
 }
 
 describe('probeMediaStreams', () => {
-    it('returns hasVideo=true and hasAudio=true for a video+audio container', async () => {
+    it('should return hasVideo=true and hasAudio=true for a video+audio container', async () => {
         await setupMockContext('test-object-id', 'https://storage.example.com/file.mp4?token=abc');
         mockExec(JSON.stringify({ streams: [{ codec_type: 'video' }, { codec_type: 'audio' }] }));
 
@@ -77,7 +77,7 @@ describe('probeMediaStreams', () => {
         expect(result).toEqual({ hasVideo: true, hasAudio: true });
     });
 
-    it('returns hasVideo=true and hasAudio=false for a video-only container', async () => {
+    it('should return hasVideo=true and hasAudio=false for a video-only container', async () => {
         await setupMockContext('test-object-id', 'https://storage.example.com/file.mp4');
         mockExec(JSON.stringify({ streams: [{ codec_type: 'video' }] }));
 
@@ -86,7 +86,7 @@ describe('probeMediaStreams', () => {
         expect(result).toEqual({ hasVideo: true, hasAudio: false });
     });
 
-    it('returns hasVideo=false and hasAudio=true for an audio-only container (the bug case)', async () => {
+    it('should return hasVideo=false and hasAudio=true for an audio-only container (the bug case)', async () => {
         await setupMockContext('test-object-id', 'https://storage.example.com/audio-only.mp4');
         mockExec(JSON.stringify({ streams: [{ codec_type: 'audio' }] }));
 
@@ -95,7 +95,7 @@ describe('probeMediaStreams', () => {
         expect(result).toEqual({ hasVideo: false, hasAudio: true });
     });
 
-    it('throws nonRetryable ApplicationFailure when no usable streams are found', async () => {
+    it('should throw nonRetryable ApplicationFailure when no usable streams are found', async () => {
         await setupMockContext('test-object-id', 'https://storage.example.com/bad.mp4');
         mockExec(JSON.stringify({ streams: [] }));
 
@@ -104,7 +104,7 @@ describe('probeMediaStreams', () => {
         );
     });
 
-    it('throws DocumentNotFoundError when the object has no source', async () => {
+    it('should throw DocumentNotFoundError when the object has no source', async () => {
         const { setupActivity } = await import('../../dsl/setup/ActivityContext.js');
         const mockClient = {
             objects: {
@@ -116,7 +116,7 @@ describe('probeMediaStreams', () => {
             client: mockClient,
             objectId: 'test-object-id',
             inputType: 'objectIds',
-            params: {},
+            params: {} satisfies ProbeMediaStreamsParams,
         } as unknown as ActivityContext<ProbeMediaStreamsParams>);
 
         await expect(testEnv.run(probeMediaStreams, createPayload())).rejects.toThrow(

--- a/packages/workflow/src/activities/media/saveGladiaTranscription.test.ts
+++ b/packages/workflow/src/activities/media/saveGladiaTranscription.test.ts
@@ -133,9 +133,9 @@ describe("SaveGladiaTranscription", () => {
             },
         } as unknown as VertesiaClient;
 
-        const params: SaveGladiaTranscriptionParams = {
+        const params = {
             gladiaTranscriptionId: "test-transcription-id",
-        };
+        } satisfies SaveGladiaTranscriptionParams;
 
         // Mock setupActivity
         vi.mocked(setupActivity).mockResolvedValue({
@@ -183,10 +183,10 @@ describe("SaveGladiaTranscription", () => {
             },
         } as unknown as VertesiaClient;
 
-        const params: SaveGladiaTranscriptionParams = {
+        const params = {
             gladiaTranscriptionId: "test-transcription-id",
             output_storage_path: "test-storage-path",
-        };
+        } satisfies SaveGladiaTranscriptionParams;
 
         vi.mocked(setupActivity).mockResolvedValue({
             client: mockClient,
@@ -223,9 +223,9 @@ describe("SaveGladiaTranscription", () => {
             },
         } as unknown as VertesiaClient;
 
-        const params: SaveGladiaTranscriptionParams = {
+        const params = {
             gladiaTranscriptionId: "test-transcription-id",
-        };
+        } satisfies SaveGladiaTranscriptionParams;
 
         vi.mocked(setupActivity).mockResolvedValue({
             client: mockClient,
@@ -272,9 +272,9 @@ describe("SaveGladiaTranscription", () => {
             },
         } as unknown as VertesiaClient;
 
-        const params: SaveGladiaTranscriptionParams = {
+        const params = {
             gladiaTranscriptionId: "test-transcription-id",
-        };
+        } satisfies SaveGladiaTranscriptionParams;
 
         vi.mocked(setupActivity).mockResolvedValue({
             client: mockClient,
@@ -321,9 +321,9 @@ describe("SaveGladiaTranscription", () => {
             },
         } as unknown as VertesiaClient;
 
-        const params: SaveGladiaTranscriptionParams = {
+        const params = {
             gladiaTranscriptionId: "test-transcription-id",
-        };
+        } satisfies SaveGladiaTranscriptionParams;
 
         vi.mocked(setupActivity).mockResolvedValue({
             client: mockClient,
@@ -383,9 +383,9 @@ describe("SaveGladiaTranscription", () => {
             },
         } as unknown as VertesiaClient;
 
-        const params: SaveGladiaTranscriptionParams = {
+        const params = {
             gladiaTranscriptionId: "test-transcription-id",
-        };
+        } satisfies SaveGladiaTranscriptionParams;
 
         vi.mocked(setupActivity).mockResolvedValue({
             client: mockClient,

--- a/packages/workflow/src/activities/media/saveGladiaTranscription.test.ts
+++ b/packages/workflow/src/activities/media/saveGladiaTranscription.test.ts
@@ -58,7 +58,7 @@ const createTestPayload = (
             ? { inputType: 'objectIds' as const, objectIds: [objectId] }
             : undefined,
         vars: {},
-        activity: { name: "SaveGladiaTranscription", params }
+        activity: { name: "SaveGladiaTranscription", params: params as unknown as Record<string, unknown> }
     };
 };
 
@@ -110,8 +110,8 @@ describe("SaveGladiaTranscription", () => {
             withHeaders: vi.fn().mockReturnThis(),
             get: vi.fn().mockResolvedValue(mockGladiaTranscriptionResult),
         };
-        vi.mocked(FetchClient).mockImplementation(function(this: any) {
-            return mockFetchClient as any;
+        vi.mocked(FetchClient).mockImplementation(function(this: unknown) {
+            return mockFetchClient as unknown;
         });
 
         // Mock client
@@ -164,8 +164,8 @@ describe("SaveGladiaTranscription", () => {
             withHeaders: vi.fn().mockReturnThis(),
             get: vi.fn().mockResolvedValue(mockGladiaTranscriptionResult),
         };
-        vi.mocked(FetchClient).mockImplementation(function(this: any) {
-            return mockFetchClient as any;
+        vi.mocked(FetchClient).mockImplementation(function(this: unknown) {
+            return mockFetchClient as unknown;
         });
 
         const mockClient = {
@@ -256,8 +256,8 @@ describe("SaveGladiaTranscription", () => {
                 status: "error",
             }),
         };
-        vi.mocked(FetchClient).mockImplementation(function(this: any) {
-            return mockFetchClient as any;
+        vi.mocked(FetchClient).mockImplementation(function(this: unknown) {
+            return mockFetchClient as unknown;
         });
 
         const mockClient = {
@@ -305,8 +305,8 @@ describe("SaveGladiaTranscription", () => {
                 status: "processing",
             }),
         };
-        vi.mocked(FetchClient).mockImplementation(function(this: any) {
-            return mockFetchClient as any;
+        vi.mocked(FetchClient).mockImplementation(function(this: unknown) {
+            return mockFetchClient as unknown;
         });
 
         const mockClient = {
@@ -361,8 +361,8 @@ describe("SaveGladiaTranscription", () => {
                 },
             }),
         };
-        vi.mocked(FetchClient).mockImplementation(function(this: any) {
-            return mockFetchClient as any;
+        vi.mocked(FetchClient).mockImplementation(function(this: unknown) {
+            return mockFetchClient as unknown;
         });
 
         const mockClient = {

--- a/packages/workflow/src/activities/media/transcribeMediaWithGladia.test.ts
+++ b/packages/workflow/src/activities/media/transcribeMediaWithGladia.test.ts
@@ -109,7 +109,7 @@ describe("TranscribeMedia", () => {
             },
         } as unknown as VertesiaClient;
 
-        const params: TranscriptMediaParams = {};
+        const params = {} satisfies TranscriptMediaParams;
 
         vi.mocked(setupActivity).mockResolvedValue({
             client: mockClient,
@@ -191,7 +191,7 @@ describe("TranscribeMedia", () => {
             },
         } as unknown as VertesiaClient;
 
-        const params: TranscriptMediaParams = {};
+        const params = {} satisfies TranscriptMediaParams;
 
         vi.mocked(setupActivity).mockResolvedValue({
             client: mockClient,
@@ -230,7 +230,7 @@ describe("TranscribeMedia", () => {
             },
         } as unknown as VertesiaClient;
 
-        const params: TranscriptMediaParams = {};
+        const params = {} satisfies TranscriptMediaParams;
 
         vi.mocked(setupActivity).mockResolvedValue({
             client: mockClient,
@@ -293,9 +293,9 @@ describe("TranscribeMedia", () => {
             },
         } as unknown as VertesiaClient;
 
-        const params: TranscriptMediaParams = {
+        const params = {
             force: true,
-        };
+        } satisfies TranscriptMediaParams;
 
         vi.mocked(setupActivity).mockResolvedValue({
             client: mockClient,
@@ -346,9 +346,9 @@ describe("TranscribeMedia", () => {
             },
         } as unknown as VertesiaClient;
 
-        const params: TranscriptMediaParams = {
+        const params = {
             output_storage_path: "test-storage-path",
-        };
+        } satisfies TranscriptMediaParams;
 
         vi.mocked(setupActivity).mockResolvedValue({
             client: mockClient,
@@ -383,7 +383,7 @@ describe("TranscribeMedia", () => {
             },
         } as unknown as VertesiaClient;
 
-        const params: TranscriptMediaParams = {};
+        const params = {} satisfies TranscriptMediaParams;
 
         vi.mocked(setupActivity).mockResolvedValue({
             client: mockClient,
@@ -416,7 +416,7 @@ describe("TranscribeMedia", () => {
             },
         } as unknown as VertesiaClient;
 
-        const params: TranscriptMediaParams = {};
+        const params = {} satisfies TranscriptMediaParams;
 
         vi.mocked(setupActivity).mockResolvedValue({
             client: mockClient,
@@ -455,7 +455,7 @@ describe("TranscribeMedia", () => {
             },
         } as unknown as VertesiaClient;
 
-        const params: TranscriptMediaParams = {};
+        const params = {} satisfies TranscriptMediaParams;
 
         vi.mocked(setupActivity).mockResolvedValue({
             client: mockClient,
@@ -518,7 +518,7 @@ describe("TranscribeMedia", () => {
             },
         } as unknown as VertesiaClient;
 
-        const params: TranscriptMediaParams = {};
+        const params = {} satisfies TranscriptMediaParams;
 
         vi.mocked(setupActivity).mockResolvedValue({
             client: mockClient,
@@ -565,7 +565,7 @@ describe("TranscribeMedia", () => {
             },
         } as unknown as VertesiaClient;
 
-        const params: TranscriptMediaParams = {};
+        const params = {} satisfies TranscriptMediaParams;
 
         vi.mocked(setupActivity).mockResolvedValue({
             client: mockClient,

--- a/packages/workflow/src/activities/media/transcribeMediaWithGladia.test.ts
+++ b/packages/workflow/src/activities/media/transcribeMediaWithGladia.test.ts
@@ -60,7 +60,7 @@ const createTestPayload = (
             ? { inputType: 'objectIds' as const, objectIds: [objectId] }
             : undefined,
         vars: {},
-        activity: { name: "TranscribeMedia", params }
+        activity: { name: "TranscribeMedia", params: params as unknown as Record<string, unknown> }
     };
 };
 
@@ -76,8 +76,8 @@ describe("TranscribeMedia", () => {
                 result_url: "https://api.gladia.io/v2/transcription/test-transcription-id",
             }),
         };
-        vi.mocked(FetchClient).mockImplementation(function(this: any) {
-            return mockFetchClient as any;
+        vi.mocked(FetchClient).mockImplementation(function(this: unknown) {
+            return mockFetchClient as unknown;
         });
 
         const mockClient = {
@@ -147,8 +147,8 @@ describe("TranscribeMedia", () => {
                 result_url: "https://api.gladia.io/v2/transcription/test-transcription-id",
             }),
         };
-        vi.mocked(FetchClient).mockImplementation(function(this: any) {
-            return mockFetchClient as any;
+        vi.mocked(FetchClient).mockImplementation(function(this: unknown) {
+            return mockFetchClient as unknown;
         });
 
         const mockClient = {
@@ -261,8 +261,8 @@ describe("TranscribeMedia", () => {
                 result_url: "https://api.gladia.io/v2/transcription/test-transcription-id",
             }),
         };
-        vi.mocked(FetchClient).mockImplementation(function(this: any) {
-            return mockFetchClient as any;
+        vi.mocked(FetchClient).mockImplementation(function(this: unknown) {
+            return mockFetchClient as unknown;
         });
 
         const mockClient = {
@@ -322,8 +322,8 @@ describe("TranscribeMedia", () => {
                 result_url: "https://api.gladia.io/v2/transcription/test-transcription-id",
             }),
         };
-        vi.mocked(FetchClient).mockImplementation(function(this: any) {
-            return mockFetchClient as any;
+        vi.mocked(FetchClient).mockImplementation(function(this: unknown) {
+            return mockFetchClient as unknown;
         });
 
         const mockClient = {
@@ -486,8 +486,8 @@ describe("TranscribeMedia", () => {
                 new RequestError("Invalid audio format", mockRequest, 422, { error: "Invalid audio format" })
             ),
         };
-        vi.mocked(FetchClient).mockImplementation(function(this: any) {
-            return mockFetchClient as any;
+        vi.mocked(FetchClient).mockImplementation(function(this: unknown) {
+            return mockFetchClient as unknown;
         });
 
         const mockClient = {

--- a/packages/workflow/src/activities/media/transcribeMediaWithGladia.ts
+++ b/packages/workflow/src/activities/media/transcribeMediaWithGladia.ts
@@ -120,7 +120,7 @@ export async function transcribeMedia(payload: DSLActivityExecutionPayload<Trans
             }
         }) as GladiaTranscriptRequestResponse;
         log.info(`Transcription request sent to Gladia`, { storageId, res });
-    } catch (error: any) {
+    } catch (error: unknown) {
         if (error instanceof RequestError && error.status === 422) {
             return {
                 hasText: false,

--- a/packages/workflow/src/activities/mergeChildArtifacts.ts
+++ b/packages/workflow/src/activities/mergeChildArtifacts.ts
@@ -1,4 +1,5 @@
 import { log } from "@temporalio/activity";
+import { VertesiaClient } from "@vertesia/client";
 import { NodeStreamSource } from "@vertesia/client/node";
 import { DSLActivityExecutionPayload, DSLActivitySpec } from "@vertesia/common";
 import { Readable } from "stream";
@@ -72,8 +73,9 @@ export async function mergeChildArtifacts(
             const namespacedPath = createNamespacedPath(relativePath, childRunId);
             await copyArtifact(client, childRunId, parentRunId, relativePath, namespacedPath);
             mergedFiles.push(namespacedPath);
-        } catch (err: any) {
-            log.warn(`Failed to merge ${relativePath}: ${err.message}`);
+        } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : String(err);
+            log.warn(`Failed to merge ${relativePath}: ${message}`);
         }
     }
 
@@ -132,7 +134,7 @@ function extractRelativePath(fullPath: string, runId: string): string | null {
  * Copy a single artifact from child to parent agent space with a new path
  */
 async function copyArtifact(
-    client: any,
+    client: VertesiaClient,
     childRunId: string,
     parentRunId: string,
     sourcePath: string,
@@ -142,7 +144,7 @@ async function copyArtifact(
     const stream = await client.files.downloadArtifact(childRunId, sourcePath);
 
     // Convert web stream to node stream for upload
-    const nodeStream = Readable.fromWeb(stream as any);
+    const nodeStream = Readable.fromWeb(stream as ReadableStream<Uint8Array>);
 
     // Determine mime type from extension
     const mimeType = getMimeType(sourcePath);

--- a/packages/workflow/src/activities/notifyWebhook.test.ts
+++ b/packages/workflow/src/activities/notifyWebhook.test.ts
@@ -3,7 +3,7 @@ import {
 } from "@temporalio/testing";
 import { ApiVersions, ContentEventName, DSLActivityExecutionPayload, WebHookSpec } from "@vertesia/common";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { notifyWebhook, NotifyWebhookParams, WebhookNotificationPayload } from "./notifyWebhook.js";
+import { notifyWebhook, NotifyWebhookParams, NotifyWebhookResult, WebhookNotificationPayload } from "./notifyWebhook.js";
 
 // Mock fetch globally
 vi.stubGlobal('fetch', vi.fn());
@@ -50,7 +50,7 @@ const createTestPayload = (params: Partial<NotifyWebhookParams> = {}): DSLActivi
 };
 
 describe("Webhook should be notified", () => {
-  it("test POST success", async () => {
+  it("should send POST notification successfully", async () => {
     // Mock successful response
     const mockResponse = {
       ok: true,
@@ -61,7 +61,7 @@ describe("Webhook should be notified", () => {
     mockFetch.mockResolvedValueOnce(mockResponse as Response);
 
     const payload = createTestPayload();
-    const res = await testEnv.run(notifyWebhook, payload);
+    const res: NotifyWebhookResult = await testEnv.run(notifyWebhook, payload);
 
     // Verify fetch was called with correct parameters (old format wraps detail in result)
     expect(mockFetch).toHaveBeenCalledWith(defaultParams.webhook, {
@@ -85,7 +85,7 @@ describe("Webhook should be notified", () => {
     });
   });
 
-  it("test POST server error", async () => {
+  it("should throw when POST returns server error", async () => {
     // Mock error response with response body
     const mockResponse = {
       ok: false,
@@ -121,7 +121,7 @@ describe("Webhook should be notified", () => {
     expect(mockResponse.text).toHaveBeenCalled();
   });
 
-  it("test POST network error", async () => {
+  it("should throw when POST fails with network error", async () => {
     // Mock fetch to throw a network error
     const networkError = new Error('Network request failed');
     mockFetch.mockRejectedValueOnce(networkError);
@@ -146,7 +146,7 @@ describe("Webhook should be notified", () => {
     });
   });
 
-  it("test POST with undefined detail still sends body with workflow info (new format)", async () => {
+  it("should send workflow info in new POST format when detail is undefined", async () => {
     // Mock successful response
     const mockResponse = {
       ok: true,
@@ -169,7 +169,7 @@ describe("Webhook should be notified", () => {
       event_name: 'workflow_failed'
     });
 
-    const res = await testEnv.run(notifyWebhook, payload);
+    const res: NotifyWebhookResult = await testEnv.run(notifyWebhook, payload);
 
     // Verify fetch was called
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -199,7 +199,7 @@ describe("Webhook should be notified", () => {
     });
   });
 
-  it("test POST with undefined detail still sends body with workflow info (old format)", async () => {
+  it("should send workflow info in old POST format when detail is undefined", async () => {
     // Mock successful response
     const mockResponse = {
       ok: true,
@@ -216,7 +216,7 @@ describe("Webhook should be notified", () => {
       event_name: 'workflow_completed'
     });
 
-    const res = await testEnv.run(notifyWebhook, payload);
+    const res: NotifyWebhookResult = await testEnv.run(notifyWebhook, payload);
 
     // Verify fetch was called
     expect(mockFetch).toHaveBeenCalledTimes(1);

--- a/packages/workflow/src/activities/notifyWebhook.ts
+++ b/packages/workflow/src/activities/notifyWebhook.ts
@@ -11,7 +11,7 @@ export interface NotifyWebhookParams {
     workflow_type: string; //The type of workflow sending the notification (the wf function name)
     workflow_run_id: string; //The ID of the specific workflow run sending the notification
     event_name: string; //The event that triggered the notification (e.g. "completed", "failed", etc.)
-    detail?: Record<string, any>; // additional data about the event if any. It will be send to the webhook when using POST 
+    detail?: Record<string, unknown>; // additional data about the event if any. It will be send to the webhook when using POST 
     //target_url: string; //URL to send the notification to
     method: 'GET' | 'POST'; //HTTP method to use
     headers?: Record<string, string>; // additional headers to send
@@ -22,7 +22,7 @@ export interface WebhookNotificationPayload {
     workflow_name: string,
     workflow_run_id: string,
     event_name: string,
-    detail?: Record<string, any>,
+    detail?: unknown,
 }
 
 export interface NotifyWebhook extends DSLActivitySpec<NotifyWebhookParams> {
@@ -101,7 +101,7 @@ function getWorkflowName(workflowType: string): string {
     return workflowType.replace(/_?workflow$/i, '');
 }
 
-async function createRequestBody(payload: WorkflowExecutionBaseParams, params: NotifyWebhookParams, api_version: number | undefined): Promise<string> {
+async function createRequestBody(payload: WorkflowExecutionBaseParams<unknown>, params: NotifyWebhookParams, api_version: number | undefined): Promise<string> {
     if (api_version === undefined || Number(api_version) < ApiVersions.COMPLETION_RESULT_V1) {
         return createOldRequestBody(payload, params);
     } else {
@@ -109,7 +109,7 @@ async function createRequestBody(payload: WorkflowExecutionBaseParams, params: N
     }
 }
 
-async function createLatestRequestBody(payload: WorkflowExecutionBaseParams, params: NotifyWebhookParams, api_version: number | undefined): Promise<string> {
+async function createLatestRequestBody(payload: WorkflowExecutionBaseParams<unknown>, params: NotifyWebhookParams, api_version: number | undefined): Promise<string> {
     const data = await createEventData(payload, params, api_version);
     return JSON.stringify({
         workflow_id: params.workflow_id,
@@ -120,18 +120,19 @@ async function createLatestRequestBody(payload: WorkflowExecutionBaseParams, par
     } satisfies WebhookNotificationPayload);
 }
 
-async function createEventData(payload: WorkflowExecutionBaseParams, params: NotifyWebhookParams, api_version: number | undefined): Promise<any> {
+async function createEventData(payload: WorkflowExecutionBaseParams<unknown>, params: NotifyWebhookParams, api_version: number | undefined): Promise<unknown> {
     const data = params.detail;
-    if (data && data.run_id && params.event_name === "workflow_completed" && params.workflow_type === 'ExecuteInteractionWorkflow') {
+    const runId = typeof data?.run_id === "string" ? data.run_id : undefined;
+    if (runId && params.event_name === "workflow_completed" && params.workflow_type === 'ExecuteInteractionWorkflow') {
         const client = getVersionedVertesiaClient(payload, api_version); //ensure client is initialized
         // we replace the result property with the full execution run object
-        return await client.runs.retrieve(data.run_id);
+        return await client.runs.retrieve(runId);
     }
     return data;
 }
 
 
-function getVersionedVertesiaClient(payload: WorkflowExecutionBaseParams, version: string | number | undefined | null) {
+function getVersionedVertesiaClient(payload: WorkflowExecutionBaseParams<unknown>, version: string | number | undefined | null) {
     // set the api version header
     return new VertesiaClient(getVertesiaClientOptions(payload)).withApiVersion(version ? String(version) : null);
 }
@@ -176,12 +177,13 @@ where ExecutionRun contains a result property with the new completion result for
 */
 
 //@ts-ignore
-async function createOldRequestBody(payload: WorkflowExecutionBaseParams, params: NotifyWebhookParams): Promise<string> {
+async function createOldRequestBody(payload: WorkflowExecutionBaseParams<unknown>, params: NotifyWebhookParams): Promise<string> {
     let data = params.detail;
-    if (data && data.run_id && params.event_name === "workflow_completed" && params.workflow_type === 'ExecuteInteractionWorkflow') {
+    const runId = typeof data?.run_id === "string" ? data.run_id : undefined;
+    if (runId && params.event_name === "workflow_completed" && params.workflow_type === 'ExecuteInteractionWorkflow') {
         const client = getVersionedVertesiaClient(payload, null); //ensure client is using no specific version
         // Important Note: we cannot use client.runs.retrieve since it will transform the run result to the new format because of InteractionOutput
-        const run = await client.runs.get(data.run_id);
+        const run = await client.runs.get<{ id: string; status: string; result?: unknown }>(runId);
         // since we use an unversioned client the run will be in old format so we don't need to tranform the result
         const result = run.result;
         data = {

--- a/packages/workflow/src/activities/notifyWebhook.ts
+++ b/packages/workflow/src/activities/notifyWebhook.ts
@@ -29,8 +29,13 @@ export interface NotifyWebhook extends DSLActivitySpec<NotifyWebhookParams> {
     name: 'notifyWebhook';
 }
 
+export interface NotifyWebhookResult {
+    status: number;
+    message: string;
+    url: string;
+}
 
-export async function notifyWebhook(payload: DSLActivityExecutionPayload<NotifyWebhookParams>) {
+export async function notifyWebhook(payload: DSLActivityExecutionPayload<NotifyWebhookParams>): Promise<NotifyWebhookResult> {
 
     const { params } = await setupActivity<NotifyWebhookParams>(payload);
     const { webhook, method, headers: defaultHeaders } = params

--- a/packages/workflow/src/activities/renditions/generateImageRendition.ts
+++ b/packages/workflow/src/activities/renditions/generateImageRendition.ts
@@ -10,6 +10,11 @@ import {
 
 interface GenerateImageRenditionParams extends ImageRenditionParams { }
 
+interface LegacyImageRenditionParams {
+    maxHeightWidth?: number;
+    format_output?: ImageRenditionParams["format"];
+}
+
 export interface GenerateImageRendition
     extends DSLActivitySpec<GenerateImageRenditionParams> {
     name: "generateImageRendition";
@@ -25,10 +30,11 @@ export async function generateImageRendition(
     } = await setupActivity<GenerateImageRenditionParams>(payload);
 
     // Fix: Use maxHeightWidth if max_hw is not provided
+    const legacyParams = originParams as LegacyImageRenditionParams;
     const params = {
         ...originParams,
-        max_hw: originParams.max_hw || (originParams as any).maxHeightWidth || 1596, // Default to 1596 if both are missing
-        format: originParams.format || (originParams as any).format_output || "png", // Default to png if format is missing
+        max_hw: originParams.max_hw || legacyParams.maxHeightWidth || 1596, // Default to 1596 if both are missing
+        format: originParams.format || legacyParams.format_output || "png", // Default to png if format is missing
     };
 
     log.debug(`Generating image rendition for ${objectId}`, {
@@ -36,9 +42,10 @@ export async function generateImageRendition(
         params,
     });
 
-    const inputObject = await client.objects.retrieve(objectId).catch((err) => {
+    const inputObject = await client.objects.retrieve(objectId).catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
         log.error(`Failed to retrieve document ${objectId}`, { err });
-        if (err.message.includes("not found")) {
+        if (message.includes("not found")) {
             throw new DocumentNotFoundError(`Document ${objectId} not found`, [objectId]);
         }
         throw err;

--- a/packages/workflow/src/activities/renditions/generateVideoRendition.ts
+++ b/packages/workflow/src/activities/renditions/generateVideoRendition.ts
@@ -17,6 +17,11 @@ const execAsync = promisify(exec);
 
 interface GenerateVideoRenditionParams extends ImageRenditionParams { }
 
+interface LegacyVideoRenditionParams {
+    maxHeightWidth?: number;
+    format_output?: ImageRenditionParams["format"];
+}
+
 export interface GenerateVideoRendition
     extends DSLActivitySpec<GenerateVideoRenditionParams> {
     name: "generateImageRendition";
@@ -32,12 +37,15 @@ async function getVideoMetadata(videoPath: string): Promise<VideoMetadata> {
     try {
         const command = `ffprobe -v quiet -print_format json -show_format -show_streams "${videoPath}"`;
         const { stdout } = await execAsync(command);
-        const metadata = JSON.parse(stdout);
+        const metadata = JSON.parse(stdout) as {
+            streams?: Array<{ codec_type?: string; width?: number; height?: number }>;
+            format?: { duration?: string };
+        };
 
-        const videoStream = metadata.streams.find(
-            (stream: any) => stream.codec_type === "video",
+        const videoStream = metadata.streams?.find(
+            (stream) => stream.codec_type === "video",
         );
-        const duration = parseFloat(metadata.format.duration) || 0;
+        const duration = parseFloat(metadata.format?.duration ?? "") || 0;
         const width = videoStream?.width || 0;
         const height = videoStream?.height || 0;
 
@@ -120,12 +128,13 @@ export async function generateVideoRendition(
     } = await setupActivity<GenerateVideoRenditionParams>(payload);
 
     // Fix: Use maxHeightWidth if max_hw is not provided
+    const legacyParams = originParams as LegacyVideoRenditionParams;
     const params = {
         ...originParams,
         max_hw:
-            originParams.max_hw || (originParams as any).maxHeightWidth || 1024, // Default to 1024 if both are missing
+            originParams.max_hw || legacyParams.maxHeightWidth || 1024, // Default to 1024 if both are missing
         format:
-            originParams.format || (originParams as any).format_output || "png", // Default to png if format is missing
+            originParams.format || legacyParams.format_output || "png", // Default to png if format is missing
     };
 
     log.info(`Generating video rendition for ${objectId}`, {
@@ -133,9 +142,10 @@ export async function generateVideoRendition(
         params,
     });
 
-    const inputObject = await client.objects.retrieve(objectId).catch((err) => {
+    const inputObject = await client.objects.retrieve(objectId).catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
         log.error(`Failed to retrieve document ${objectId}`, { err });
-        if (err.message.includes("not found")) {
+        if (message.includes("not found")) {
             throw new DocumentNotFoundError(`Document ${objectId} not found`, [
                 objectId,
             ]);
@@ -266,7 +276,7 @@ export async function generateVideoRendition(
             if (fs.existsSync(videoFile)) {
                 fs.unlinkSync(videoFile);
             }
-        } catch (cleanupError) {
+        } catch {
             log.warn(`Failed to cleanup temporary video file: ${videoFile}`);
         }
     }

--- a/packages/workflow/src/activities/renditions/generateVideoRendition.ts
+++ b/packages/workflow/src/activities/renditions/generateVideoRendition.ts
@@ -91,7 +91,7 @@ async function generateThumbnail(
         "2", // High quality
         `"${outputFile}"`,
     ].join(" ");
-    log.info(`Generating thumbnail at ${timestamp}s`), { command };
+    log.info(`Generating thumbnail at ${timestamp}s`, { command });
     try {
         const { stderr } = await execAsync(command);
 

--- a/packages/workflow/src/activities/renditions/generateVideoRendition.ts
+++ b/packages/workflow/src/activities/renditions/generateVideoRendition.ts
@@ -1,6 +1,6 @@
 import { log } from "@temporalio/activity";
 import { DSLActivityExecutionPayload, DSLActivitySpec } from "@vertesia/common";
-import { exec } from "child_process";
+import { execFile as execFileCallback } from "child_process";
 import fs from "fs";
 import os from "os";
 import path from "path";
@@ -13,7 +13,7 @@ import {
     uploadRenditionPages,
 } from "../../utils/renditions.js";
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFileCallback);
 
 interface GenerateVideoRenditionParams extends ImageRenditionParams { }
 
@@ -35,9 +35,9 @@ interface VideoMetadata {
 
 async function getVideoMetadata(videoPath: string): Promise<VideoMetadata> {
     try {
-        const command = `ffprobe -v quiet -print_format json -show_format -show_streams "${videoPath}"`;
-        const { stdout } = await execAsync(command);
-        const metadata = JSON.parse(stdout) as {
+        const args = ["-v", "quiet", "-print_format", "json", "-show_format", "-show_streams", videoPath];
+        const { stdout } = await execFileAsync("ffprobe", args);
+        const metadata = JSON.parse(stdout.toString()) as {
             streams?: Array<{ codec_type?: string; width?: number; height?: number }>;
             format?: { duration?: string };
         };
@@ -77,28 +77,28 @@ async function generateThumbnail(
     const scaleFilter = `scale=${maxSize}:${maxSize}:force_original_aspect_ratio=decrease`;
 
     const command = [
-        "ffmpeg",
         "-y", // Overwrite output files
         "-ss",
         timestamp.toString(), // Seek to timestamp
         "-i",
-        `"${videoPath}"`, // Input file
+        videoPath, // Input file
         "-vframes",
         "1", // Extract only 1 frame
         "-vf",
-        `"${scaleFilter}"`, // Scale maintaining aspect ratio
+        scaleFilter, // Scale maintaining aspect ratio
         "-q:v",
         "2", // High quality
-        `"${outputFile}"`,
-    ].join(" ");
-    log.info(`Generating thumbnail at ${timestamp}s`, { command });
+        outputFile,
+    ];
+    log.info(`Generating thumbnail at ${timestamp}s`, { command: "ffmpeg", args: command });
     try {
-        const { stderr } = await execAsync(command);
+        const { stderr } = await execFileAsync("ffmpeg", command);
+        const stderrText = stderr.toString();
 
         // Log any warnings from ffmpeg
-        if (stderr && !stderr.includes("frame=")) {
+        if (stderrText && !stderrText.includes("frame=")) {
             log.debug(
-                `FFmpeg stderr for thumbnail at ${timestamp}s: ${stderr}`,
+                `FFmpeg stderr for thumbnail at ${timestamp}s: ${stderrText}`,
             );
         }
 

--- a/packages/workflow/src/activities/resolveRemoteActivities.test.ts
+++ b/packages/workflow/src/activities/resolveRemoteActivities.test.ts
@@ -10,7 +10,7 @@ const mockGetInstalledApps = vi.fn();
 vi.mock("../utils/client.js", () => ({
     getVertesiaClient: vi.fn().mockReturnValue({
         apps: {
-            getInstalledApps: (...args: any[]) => mockGetInstalledApps(...args),
+            getInstalledApps: (...args: unknown[]) => mockGetInstalledApps(...args),
             validateUrl: vi.fn().mockResolvedValue({ valid: true }),
         },
     }),

--- a/packages/workflow/src/activities/resolveRemoteActivities.test.ts
+++ b/packages/workflow/src/activities/resolveRemoteActivities.test.ts
@@ -31,7 +31,7 @@ const createPayload = (): DSLActivityExecutionPayload<ResolveRemoteActivitiesPar
     auth_token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwOi8vbW9jay10b2tlbi1zZXJ2ZXIiLCJzdWIiOiJ0ZXN0In0.sig",
     account_id: "acc-123",
     project_id: "proj-456",
-    params: {},
+    params: {} satisfies ResolveRemoteActivitiesParams,
     config: {
         studio_url: "http://mock-studio",
         store_url: "http://mock-store",
@@ -40,11 +40,11 @@ const createPayload = (): DSLActivityExecutionPayload<ResolveRemoteActivitiesPar
     event: ContentEventName.create,
     objectIds: [],
     vars: {},
-    activity: { name: "resolveRemoteActivities", params: {} },
+    activity: { name: "resolveRemoteActivities", params: {} satisfies ResolveRemoteActivitiesParams },
 });
 
 describe("resolveRemoteActivities", () => {
-    it("returns empty map when no apps installed", async () => {
+    it("should return empty map when no apps installed", async () => {
         mockGetInstalledApps.mockResolvedValueOnce([]);
 
         const result: RemoteActivityMap = await testEnv.run(resolveRemoteActivities, createPayload());
@@ -52,7 +52,7 @@ describe("resolveRemoteActivities", () => {
         expect(mockGetInstalledApps).toHaveBeenCalledWith("tools");
     });
 
-    it("returns qualified activity map from single app", async () => {
+    it("should return qualified activity map from single app", async () => {
         mockGetInstalledApps.mockResolvedValueOnce([{
             id: "install-1",
             manifest: {
@@ -89,7 +89,7 @@ describe("resolveRemoteActivities", () => {
         expect(entry.url).toBe("https://nlp-server.test/api/activities/nlp");
     });
 
-    it("merges activities from multiple apps", async () => {
+    it("should merge activities from multiple apps", async () => {
         mockGetInstalledApps.mockResolvedValueOnce([
             {
                 id: "install-1",
@@ -116,7 +116,7 @@ describe("resolveRemoteActivities", () => {
         expect(result["app:app-two:main:task_b"]).toBeDefined();
     });
 
-    it("skips app with no activities", async () => {
+    it("should skip app with no activities", async () => {
         mockGetInstalledApps.mockResolvedValueOnce([{
             id: "install-1",
             manifest: { name: "empty-app", endpoint: "https://empty.test/api/package" },
@@ -130,7 +130,7 @@ describe("resolveRemoteActivities", () => {
         expect(result).toEqual({});
     });
 
-    it("skips app with no endpoint", async () => {
+    it("should skip app with no endpoint", async () => {
         mockGetInstalledApps.mockResolvedValueOnce([{
             id: "install-1",
             manifest: { name: "no-endpoint" },
@@ -141,7 +141,7 @@ describe("resolveRemoteActivities", () => {
         expect(mockFetch).not.toHaveBeenCalled();
     });
 
-    it("handles duplicate qualified names across apps (first wins)", async () => {
+    it("should handle duplicate qualified names across apps (first wins)", async () => {
         mockGetInstalledApps.mockResolvedValueOnce([
             {
                 id: "install-1",
@@ -166,7 +166,7 @@ describe("resolveRemoteActivities", () => {
         expect(result["app:same-app:main:task"].app_install_id).toBe("install-1");
     });
 
-    it("continues with other apps when one fetch fails", async () => {
+    it("should continue with other apps when one fetch fails", async () => {
         mockGetInstalledApps.mockResolvedValueOnce([
             {
                 id: "install-1",
@@ -189,14 +189,14 @@ describe("resolveRemoteActivities", () => {
         expect(result["app:working-app:main:task"]).toBeDefined();
     });
 
-    it("returns empty map when getInstalledApps fails", async () => {
+    it("should return empty map when getInstalledApps fails", async () => {
         mockGetInstalledApps.mockRejectedValueOnce(new Error("API error"));
 
         const result: RemoteActivityMap = await testEnv.run(resolveRemoteActivities, createPayload());
         expect(result).toEqual({});
     });
 
-    it("skips activities without collection", async () => {
+    it("should skip activities without collection", async () => {
         mockGetInstalledApps.mockResolvedValueOnce([{
             id: "install-1",
             manifest: { name: "bad-app", endpoint: "https://bad.test/api/package" },

--- a/packages/workflow/src/activities/resolveRemoteActivities.ts
+++ b/packages/workflow/src/activities/resolveRemoteActivities.ts
@@ -25,7 +25,7 @@ export interface RemoteActivityInfo {
     /** The app name */
     app_name: string;
     /** The app installation settings */
-    app_settings?: Record<string, any>;
+    app_settings?: Record<string, unknown>;
     /** The activity definition from the tool server */
     definition: RemoteActivityDefinition;
 }

--- a/packages/workflow/src/activities/setDocumentStatus.ts
+++ b/packages/workflow/src/activities/setDocumentStatus.ts
@@ -22,9 +22,11 @@ export async function setDocumentStatus(payload: DSLActivityExecutionPayload<Set
     try {
         const res = await client.objects.update(objectId, { status: params.status });
         return res.status;
-    } catch (err: any) {
+    } catch (err: unknown) {
         // If document was deleted, nothing to update - log warning and continue
-        if (err.status === 404 || err.name === 'ZenoClientNotFoundError') {
+        const status = err && typeof err === 'object' && 'status' in err ? err.status : undefined;
+        const name = err instanceof Error ? err.name : undefined;
+        if (status === 404 || name === 'ZenoClientNotFoundError') {
             log.warn(`Document ${objectId} not found - may have been deleted. Skipping status update to '${params.status}'`);
             return undefined; // Signal that document wasn't found
         }

--- a/packages/workflow/src/conversion/TextractProcessor.ts
+++ b/packages/workflow/src/conversion/TextractProcessor.ts
@@ -33,7 +33,7 @@ interface TextractProcessorOptions {
     region: string;
     bucket: string;
     credentials?: AwsCredentialIdentityProvider;
-    log?: any;
+    log?: TextractLogger;
     detectImages?: boolean;
     /**
      * NEW: If true, includes cell-confidence information in the table CSV
@@ -41,12 +41,16 @@ interface TextractProcessorOptions {
     includeConfidenceInTables?: boolean;
 }
 
+interface TextractLogger {
+    info(message: string, metadata?: Record<string, unknown>): void;
+}
+
 export class TextractProcessor {
     private textractClient: TextractClient;
     private s3Client: S3Client;
     private fileKey: string;
     private bucket: string;
-    private log: any;
+    private log?: TextractLogger;
     private detectImages: boolean;
     /**
      * Whether or not to include confidence values in CSV output for tables.
@@ -239,7 +243,7 @@ export class TextractProcessor {
     }
 
     async upload(fileBuf: Buffer): Promise<void> {
-        this.log.info('Uploading file to S3', { fileKey: this.fileKey });
+        this.log?.info('Uploading file to S3', { fileKey: this.fileKey });
         const command = new PutObjectCommand({
             Bucket: this.bucket,
             Key: this.fileKey,

--- a/packages/workflow/src/conversion/image.test.ts
+++ b/packages/workflow/src/conversion/image.test.ts
@@ -15,7 +15,7 @@ vi.mock("@temporalio/activity", () => ({
 }));
 
 // Import after mocking
-import { imageResizer } from "../conversion/image";
+import { imageResizer } from "../conversion/image.js";
 
 const execAsync = promisify(exec);
 

--- a/packages/workflow/src/conversion/mutool.test.ts
+++ b/packages/workflow/src/conversion/mutool.test.ts
@@ -12,58 +12,58 @@ beforeAll(async () => {
 
 const TIMEOUT = 10000;
 
-test('[mutool] should convert pdf to text', async () => {
+test('should convert pdf to text with mutool', async () => {
   const pdf = fs.readFileSync(path.join(__dirname, '../../fixtures', 'test-pdf1.pdf'));
   const buf = Buffer.from(pdf);
   console.log("Running mutoolPdfToText")
-  const result = await activityContext.run(mutoolPdfToText, buf);
+  const result: string = await activityContext.run(mutoolPdfToText, buf);
   expect(result).toContain('VF primarily uses foreign currency exchange');
  
 }, TIMEOUT);
 
-test('[mutool] should convert pdf to images', async () => {
+test('should convert pdf to images with mutool', async () => {
   const filename = path.join(__dirname, '../../fixtures', 'test-pdf1.pdf');
   
   console.log("Running pdfToImages")
-  const result = await activityContext.run(pdfToImages, filename);
+  const result: string[] = await activityContext.run(pdfToImages, filename);
   console.log(result);
 
   expect(result).toBeInstanceOf(Array);
-  expect((result as string[]).length).toBe(119);
+  expect(result.length).toBe(119);
 
 }, TIMEOUT); 
 
-test('[mutool] should convert pdf to images with pages', async () => {
+test('should convert pdf to images with pages using mutool', async () => {
   const filename = path.join(__dirname, '../../fixtures', 'test-pdf1.pdf');
   const pages = [7, 8, 9];
   
   console.log("Running pdfToImages with pages")
-  const result = await activityContext.run(pdfToImages, filename, pages);
+  const result: string[] = await activityContext.run(pdfToImages, filename, pages);
   console.log(result);
 
   expect(result).toBeInstanceOf(Array);
-  expect((result as string[]).length).toBe(3);
+  expect(result.length).toBe(3);
 
 }, TIMEOUT);
 
-test('[mutool] should extract 3 pages from PDF into new PDF', async () => {
+test('should extract 3 pages from PDF into new PDF with mutool', async () => {
   const filename = path.join(__dirname, '../../fixtures', 'test-pdf1.pdf');
   const pages = [7, 8, 9];
   
   console.log("Running pdfGetPages")
-  const result = await activityContext.run(pdfExtractPages, filename, pages);
+  const result: string = await activityContext.run(pdfExtractPages, filename, pages);
   console.log(result);
 
   expect(result).toContain(".pdf");
 
 }, TIMEOUT);
 
-test('[mutool] should extract 1 pages from PDF into new PDF', async () => {
+test('should extract 1 page from PDF into new PDF with mutool', async () => {
   const filename = path.join(__dirname, '../../fixtures', 'test-pdf1.pdf');
   const pages = [12];
   
   console.log("Running pdfGetPages")
-  const result = await activityContext.run(pdfExtractPages, filename, pages);
+  const result: string = await activityContext.run(pdfExtractPages, filename, pages);
   console.log(result);
 
   expect(result).toContain(".pdf");

--- a/packages/workflow/src/conversion/pandoc.test.ts
+++ b/packages/workflow/src/conversion/pandoc.test.ts
@@ -2,7 +2,7 @@ import { MockActivityEnvironment } from '@temporalio/testing';
 import fs from 'fs';
 import path from 'path';
 import { beforeAll, expect, test } from 'vitest';
-import { markdownWithPandoc } from '../conversion/pandoc';
+import { markdownWithPandoc } from '../conversion/pandoc.js';
 
 let activityContext: MockActivityEnvironment;
 

--- a/packages/workflow/src/conversion/pandoc.test.ts
+++ b/packages/workflow/src/conversion/pandoc.test.ts
@@ -16,6 +16,6 @@ test('should convert docx to markdown', async () => {
     const filepath = path.join(__dirname, '../../fixtures', 'us-ciia.docx');
     console.log("Converting file from", filepath);
     const docx = fs.readFileSync(filepath);
-    const result = await activityContext.run(markdownWithPandoc, Buffer.from(docx), 'docx');
+    const result: string = await activityContext.run(markdownWithPandoc, Buffer.from(docx), 'docx');
     expect(result).to.include('confidential');
 });

--- a/packages/workflow/src/dsl/conditions.ts
+++ b/packages/workflow/src/dsl/conditions.ts
@@ -1,13 +1,13 @@
 import equal from 'fast-deep-equal';
 
-function $exists(value: any, arg: boolean) {
+function $exists(value: unknown, arg: boolean) {
     return (value !== undefined) === arg;
 }
-function $null(value: any, arg: boolean) {
+function $null(value: unknown, arg: boolean) {
     return (value == null) === arg;
 }
 
-function $eq(value: any, arg: any) {
+function $eq(value: unknown, arg: unknown) {
     if (Array.isArray(arg)) {
         return equal(value, arg);
     } else if (typeof arg === 'object') {
@@ -16,16 +16,16 @@ function $eq(value: any, arg: any) {
         return value === arg;
     }
 }
-function $ne(value: any, arg: any) {
+function $ne(value: unknown, arg: unknown) {
     return !$eq(value, arg);
 }
-function $or(value: any, arg: any[]) {
+function $or(value: unknown, arg: unknown[]) {
     return arg.some(c => matchCondition(value, c));
 }
-function $in(value: any, arg: any[]) {
+function $in(value: unknown, arg: unknown[]) {
     return arg.includes(value);
 }
-function $nin(value: any, arg: any[]) {
+function $nin(value: unknown, arg: unknown[]) {
     return !$in(value, arg);
 }
 function $regexp(value: string, arg: string) {
@@ -53,16 +53,34 @@ function $gte(value: number, arg: number) {
     return value >= arg;
 }
 
-const conditionFns: Record<string, any> = {
-    $exists, $null,
-    $eq, $ne,
-    $in, $nin,
-    $regexp, $startsWith, $endsWith, $contains,
-    $lt, $gt, $lte, $gte,
-    $or,
+type ConditionFn = (value: unknown, arg: unknown) => boolean;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
-export function matchCondition(value: any, conditions: Record<string, any>) {
+const conditionFns: Record<string, ConditionFn> = {
+    $exists: (value, arg) => typeof arg === 'boolean' && $exists(value, arg),
+    $null: (value, arg) => typeof arg === 'boolean' && $null(value, arg),
+    $eq,
+    $ne,
+    $in: (value, arg) => Array.isArray(arg) && $in(value, arg),
+    $nin: (value, arg) => Array.isArray(arg) && $nin(value, arg),
+    $regexp: (value, arg) => typeof value === 'string' && typeof arg === 'string' && $regexp(value, arg),
+    $startsWith: (value, arg) => typeof value === 'string' && typeof arg === 'string' && $startsWith(value, arg),
+    $endsWith: (value, arg) => typeof value === 'string' && typeof arg === 'string' && $endsWith(value, arg),
+    $contains: (value, arg) => typeof value === 'string' && typeof arg === 'string' && $contains(value, arg),
+    $lt: (value, arg) => typeof value === 'number' && typeof arg === 'number' && $lt(value, arg),
+    $gt: (value, arg) => typeof value === 'number' && typeof arg === 'number' && $gt(value, arg),
+    $lte: (value, arg) => typeof value === 'number' && typeof arg === 'number' && $lte(value, arg),
+    $gte: (value, arg) => typeof value === 'number' && typeof arg === 'number' && $gte(value, arg),
+    $or: (value, arg) => Array.isArray(arg) && $or(value, arg),
+}
+
+export function matchCondition(value: unknown, conditions: unknown) {
+    if (!isRecord(conditions)) {
+        return $eq(value, conditions);
+    }
     for (const key of Object.keys(conditions)) {
         const cond = conditionFns[key];
         if (!cond) {

--- a/packages/workflow/src/dsl/dsl-workflow.test.ts
+++ b/packages/workflow/src/dsl/dsl-workflow.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect } from "vitest";
 import { computeActivityOptions } from "./dsl-workflow.js";
 
 describe('Workflow DSL', () => {
-    test('compute activity options without custom options', () => {
+    test('should compute activity options without custom options', () => {
         expect(computeActivityOptions({}, {
             startToCloseTimeout: 1000,
             scheduleToCloseTimeout: 2000,
@@ -28,7 +28,7 @@ describe('Workflow DSL', () => {
         })
     })
 
-    test('compute activity options with some custom options', () => {
+    test('should compute activity options with some custom options', () => {
         expect(computeActivityOptions({
             startToCloseTimeout: 100,
         }, {

--- a/packages/workflow/src/dsl/dsl-workflow.test.ts
+++ b/packages/workflow/src/dsl/dsl-workflow.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { computeActivityOptions } from "./dsl-workflow.ts";
+import { computeActivityOptions } from "./dsl-workflow.js";
 
 describe('Workflow DSL', () => {
     test('compute activity options without custom options', () => {

--- a/packages/workflow/src/dsl/dsl-workflow.ts
+++ b/packages/workflow/src/dsl/dsl-workflow.ts
@@ -43,7 +43,7 @@ interface RemoteActivityEntry {
     activity_name: string;
     app_install_id: string;
     app_name: string;
-    app_settings?: Record<string, any>;
+    app_settings?: Record<string, unknown>;
 }
 type RemoteActivityMap = Record<string, RemoteActivityEntry>;
 
@@ -52,7 +52,7 @@ interface BaseActivityPayload extends WorkflowExecutionPayload {
     debug_mode?: boolean;
 }
 
-function dslActivityPayload<ParamsT extends Record<string, any>>(basePayload: BaseActivityPayload, activity: DSLActivitySpec, params: ParamsT) {
+function dslActivityPayload<ParamsT extends object>(basePayload: BaseActivityPayload, activity: DSLActivitySpec, params: ParamsT) {
     return {
         ...basePayload,
         activity,
@@ -89,7 +89,7 @@ export async function dslWorkflow(payload: DSLWorkflowExecutionPayload) {
         workflow_name: definition.name,
         debug_mode: !!definition.debug_mode,
     }
-    delete (basePayload as any).workflow;
+    delete (basePayload as BaseActivityPayload & { workflow?: unknown }).workflow;
 
     const defaultOptions: ActivityOptions = {
         ...convertDSLActivityOptions(definition.options),
@@ -152,8 +152,8 @@ export async function dslWorkflow(payload: DSLWorkflowExecutionPayload) {
                     names: Object.keys(remoteActivities),
                 });
             }
-        } catch (e: any) {
-            log.warn("Failed to resolve remote activities, continuing without them", { error: e.message });
+        } catch (e: unknown) {
+            log.warn("Failed to resolve remote activities, continuing without them", { error: e instanceof Error ? e.message : String(e) });
         }
     }
 
@@ -210,16 +210,17 @@ function hasRemoteActivitySteps(definition: DSLWorkflowSpec): boolean {
     return steps.some(step => 'name' in step && step.name?.startsWith(REMOTE_ACTIVITY_PREFIX));
 }
 
-async function handleError(originalError: any, basePayload: BaseActivityPayload, defaultOptions: ActivityOptions) {
+async function handleError(originalError: unknown, basePayload: BaseActivityPayload, defaultOptions: ActivityOptions) {
     const { handleDslError } = proxyActivities<typeof activities>(defaultOptions);
+    const errorMessage = originalError instanceof Error ? originalError.message : String(originalError);
 
     const payload = dslActivityPayload(
         basePayload,
         {
             name: "handleDslError",
-            params: { errorMessage: originalError.message },
+            params: { errorMessage },
         } as DSLActivitySpec,
-        { errorMessage: originalError.message } satisfies HandleDslErrorParams,
+        { errorMessage } satisfies HandleDslErrorParams,
     )
 
     if (isCancellation(originalError)) {
@@ -336,7 +337,7 @@ async function executeChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWork
     }
 }
 
-function buildRateLimitParams(activity: DSLActivitySpec, executionPayload: DSLActivityExecutionPayload<any>): RateLimitParams {
+function buildRateLimitParams(activity: DSLActivitySpec, executionPayload: DSLActivityExecutionPayload<Record<string, unknown>>): RateLimitParams {
     // resolve payload params
     const vars = new Vars({
         ...executionPayload.params, // imported params (doesn't contain expressions)
@@ -345,31 +346,35 @@ function buildRateLimitParams(activity: DSLActivitySpec, executionPayload: DSLAc
     const params = vars.resolve();
 
     let interactionId: string;
+    const interactionName = typeof params.interactionName === "string" ? params.interactionName : undefined;
+    const interactionNames = params.interactionNames && typeof params.interactionNames === "object"
+        ? params.interactionNames as { selectDocumentType?: unknown }
+        : undefined;
 
     switch (activity.name) {
         case "executeInteraction":
-            interactionId = params.interactionName;
+            interactionId = interactionName || "";
             break;
 
         case "generateDocumentProperties":
-            interactionId = params.interactionName || "sys:ExtractInformation";
+            interactionId = interactionName || "sys:ExtractInformation";
             break;
 
         case "identifyTextSections":
-            interactionId = params.interactionName || "sys:IdentifyTextSections";
+            interactionId = interactionName || "sys:IdentifyTextSections";
             break;
 
         case "generateOrAssignContentType":
-            interactionId = params.interactionNames?.selectDocumentType || "sys:SelectDocumentType";
+            interactionId = typeof interactionNames?.selectDocumentType === "string" ? interactionNames.selectDocumentType : "sys:SelectDocumentType";
             break;
 
         case "chunkDocument":
-            interactionId = params.interactionName || "sys:ChunkDocument";
+            interactionId = interactionName || "sys:ChunkDocument";
             break;
 
         default:
             // For any other rate-limited activities, try to extract what we can
-            interactionId = params.interactionName;
+            interactionId = interactionName || "";
             break;
     }
 
@@ -379,8 +384,8 @@ function buildRateLimitParams(activity: DSLActivitySpec, executionPayload: DSLAc
 
     return {
         interactionIdOrEndpoint: interactionId,
-        environmentId: params.environment,
-        modelId: params.model,
+        environmentId: typeof params.environment === "string" ? params.environment : undefined,
+        modelId: typeof params.model === "string" ? params.model : undefined,
     };
 }
 

--- a/packages/workflow/src/dsl/dslProxyActivities.ts
+++ b/packages/workflow/src/dsl/dslProxyActivities.ts
@@ -1,17 +1,15 @@
 import { ActivityOptions, proxyActivities } from "@temporalio/workflow";
 import { DSLActivityExecutionPayload, WorkflowExecutionBaseParams, WorkflowExecutionPayload } from "@vertesia/common";
 
-export interface DslActivityFunction<ParamsT extends Record<string, any> = any, ReturnT = any> {
+export interface DslActivityFunction<ParamsT extends object = Record<string, unknown>, ReturnT = unknown> {
     (payload: DSLActivityExecutionPayload<ParamsT>): Promise<ReturnT>;
 }
 
-export interface DslSimplifiedActivityFunction<ParamsT = any, ReturnT = any> {
-    (payload: WorkflowExecutionBaseParams, params: ParamsT): Promise<ReturnT>;
+export interface DslSimplifiedActivityFunction<ParamsT extends object = Record<string, unknown>, ReturnT = unknown> {
+    (payload: WorkflowExecutionBaseParams<unknown>, params: ParamsT): Promise<ReturnT>;
 }
 
-export function dslProxyActivities<
-    ActivitiesT extends Record<string, DslActivityFunction<any, any>>
->(workflowName: string, options: ActivityOptions = {}) {
+export function dslProxyActivities<ActivitiesT extends object>(workflowName: string, options: ActivityOptions = {}) {
     type DslActivities = {
         [K in keyof ActivitiesT]: ActivitiesT[K] extends DslActivityFunction<infer ParamsT, infer ReturnT>
         ? DslSimplifiedActivityFunction<ParamsT, ReturnT>
@@ -22,8 +20,8 @@ export function dslProxyActivities<
 
     return new Proxy({}, {
         get(_target, prop) {
-            const activityFn = activities[prop as keyof ActivitiesT] as DslActivityFunction;
-            return (payload: WorkflowExecutionPayload, params: any) => {
+            const activityFn = activities[prop as keyof ActivitiesT] as unknown as DslActivityFunction<Record<string, unknown>, unknown>;
+            return (payload: WorkflowExecutionPayload, params: Record<string, unknown>) => {
                 return activityFn({
                     ...payload,
                     activity: {

--- a/packages/workflow/src/dsl/projections.test.ts
+++ b/packages/workflow/src/dsl/projections.test.ts
@@ -3,7 +3,7 @@ import { makeProjection } from "./projections.js";
 
 describe('Result Projections', () => {
 
-    test('simple projection', () => {
+    test('should make a simple projection', () => {
         const params: Record<string, unknown> = {
             docTypes: [{ id: 1, name: "type1" }, { id: 2, name: "type2" }],
             objectId: "123"
@@ -29,7 +29,7 @@ describe('Result Projections', () => {
         expect(out.foo).toBeUndefined();
     })
 
-    test('$element match', () => {
+    test('should resolve $element match', () => {
         const params: Record<string, unknown> = {
             docTypes: [{ id: 1, name: "type1" }, { id: 2, name: "type2" }],
             objectId: "123"
@@ -62,7 +62,7 @@ describe('Result Projections', () => {
         expect(out.isNewType).toBe(false);
     })
 
-    test('$element does not match', () => {
+    test('should resolve $element fallback when it does not match', () => {
         const params: Record<string, unknown> = {
             docTypes: [{ id: 1, name: "type1" }, { id: 2, name: "type2" }],
             objectId: "123"
@@ -95,7 +95,7 @@ describe('Result Projections', () => {
         expect(out.isNewType).toBe(true);
     })
 
-    test('$element with field', () => {
+    test('should resolve $element with field', () => {
         const params: Record<string, unknown> = {
             docTypes: [{ id: 1, name: "type1" }, { id: 2, name: "type2" }],
             objectId: "123"
@@ -125,7 +125,7 @@ describe('Result Projections', () => {
         expect(out).toStrictEqual({ id: 2, name: "type2", other: null });
     })
 
-    test('$element with field - no match', () => {
+    test('should resolve $element with field fallback when it does not match', () => {
         const params: Record<string, unknown> = {
             docTypes: [{ id: 1, name: "type1" }, { id: 2, name: "type2" }],
             objectId: "123"

--- a/packages/workflow/src/dsl/projections.test.ts
+++ b/packages/workflow/src/dsl/projections.test.ts
@@ -1,11 +1,10 @@
 import { describe, test, expect } from "vitest";
-import { Vars } from "./vars.ts";
-import { makeProjection } from "./projections.ts";
+import { makeProjection } from "./projections.js";
 
 describe('Result Projections', () => {
 
     test('simple projection', () => {
-        const params: Record<string, any> = {
+        const params: Record<string, unknown> = {
             docTypes: [{ id: 1, name: "type1" }, { id: 2, name: "type2" }],
             objectId: "123"
         }
@@ -31,7 +30,7 @@ describe('Result Projections', () => {
     })
 
     test('$element match', () => {
-        const params: Record<string, any> = {
+        const params: Record<string, unknown> = {
             docTypes: [{ id: 1, name: "type1" }, { id: 2, name: "type2" }],
             objectId: "123"
         }
@@ -64,7 +63,7 @@ describe('Result Projections', () => {
     })
 
     test('$element does not match', () => {
-        const params: Record<string, any> = {
+        const params: Record<string, unknown> = {
             docTypes: [{ id: 1, name: "type1" }, { id: 2, name: "type2" }],
             objectId: "123"
         }
@@ -97,7 +96,7 @@ describe('Result Projections', () => {
     })
 
     test('$element with field', () => {
-        const params: Record<string, any> = {
+        const params: Record<string, unknown> = {
             docTypes: [{ id: 1, name: "type1" }, { id: 2, name: "type2" }],
             objectId: "123"
         }
@@ -127,7 +126,7 @@ describe('Result Projections', () => {
     })
 
     test('$element with field - no match', () => {
-        const params: Record<string, any> = {
+        const params: Record<string, unknown> = {
             docTypes: [{ id: 1, name: "type1" }, { id: 2, name: "type2" }],
             objectId: "123"
         }

--- a/packages/workflow/src/dsl/projections.ts
+++ b/packages/workflow/src/dsl/projections.ts
@@ -4,22 +4,38 @@ import { Vars } from "./vars.js";
 
 
 interface ProjectOperation {
-    (arg: any, vars: Vars): any
+    (arg: unknown, vars: Vars): unknown
 }
 
 interface ElementOperation {
     field?: string,
-    from: any[],
-    where: Record<string, any>,
-    else: any
+    from: unknown[],
+    where: Record<string, unknown>,
+    else: unknown
 }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function asRecord(value: object): Record<string, unknown> {
+    return value as Record<string, unknown>;
+}
+
+function isElementOperation(value: unknown): value is ElementOperation {
+    return isRecord(value) && Array.isArray(value.from) && isRecord(value.where);
+}
+
 const operations: Record<string, ProjectOperation> = {
-    $element(arg: ElementOperation, _vars: Vars) {
+    $element(arg: unknown, _vars: Vars) {
+        if (!isElementOperation(arg)) {
+            return undefined;
+        }
         const where = arg.where;
         const whereKeys = Object.keys(where);
-        const r = arg.from.find((elem: any) => {
+        const r = arg.from.find((elem: unknown) => {
             for (const key of whereKeys) {
-                const value = key === '_' ? elem : elem[key];
+                const value = key === '_' ? elem : isRecord(elem) ? elem[key] : undefined;
                 if (matchCondition(value, where[key])) {
                     return true;
                 }
@@ -27,18 +43,18 @@ const operations: Record<string, ProjectOperation> = {
             return false;
         })
         if (arg.field) {
-            return r ? r[arg.field] : arg.else;
+            return isRecord(r) ? r[arg.field] : arg.else;
         } else {
             return r || arg.else;
         }
     },
-    $eval(arg: any, vars: Vars) {
-        return vars.match(arg);
+    $eval(arg: unknown, vars: Vars) {
+        return isRecord(arg) ? vars.match(arg) : false;
     }
 }
 
-function runProjection(obj: any, vars: Vars) {
-    if (obj && !Array.isArray(obj) && typeof obj === "object") {
+function runProjection(obj: unknown, vars: Vars) {
+    if (isRecord(obj)) {
         const keys = Object.keys(obj)
         if (keys.length === 1) {
             const key = keys[0];
@@ -51,11 +67,11 @@ function runProjection(obj: any, vars: Vars) {
     return obj; // return the value as is
 }
 
-export function projectResult<TParams extends Record<string, any>>(payload: DSLActivityExecutionPayload<TParams>, params: Record<string, any>, result: any, fallback: any) {
-    return payload.activity.projection ? makeProjection(payload.activity.projection, params, result) : fallback;
+export function projectResult<TParams extends object>(payload: DSLActivityExecutionPayload<TParams>, params: TParams, result: unknown, fallback: unknown) {
+    return payload.activity.projection ? makeProjection(payload.activity.projection, asRecord(params), result) : fallback;
 }
 
-export function makeProjection(spec: Record<string, any>, params: Record<string, any>, result: any) {
+export function makeProjection(spec: Record<string, unknown>, params: Record<string, unknown>, result: unknown) {
     const vars = new Vars({
         ...params,
         '#': result,
@@ -63,7 +79,7 @@ export function makeProjection(spec: Record<string, any>, params: Record<string,
 
     const projection = vars.resolveParams(spec);
 
-    const out: any = {}
+    const out: Record<string, unknown> = {}
     for (const [key, value] of Object.entries(projection)) {
         out[key] = runProjection(value, vars);
     }

--- a/packages/workflow/src/dsl/setup/ActivityContext.test.ts
+++ b/packages/workflow/src/dsl/setup/ActivityContext.test.ts
@@ -27,7 +27,7 @@ describe("setupActivity", () => {
     // verbatim when the activity is dispatched from TypeScript code (no activity.params,
     // no activity.fetch). Previously Vars.parse/resolve would treat any "${...}" as a
     // template ref and silently drop the key when it failed to resolve.
-    it("preserves user data containing literal ${} in code-dispatched activities", async () => {
+    it("should preserve user data containing literal ${} in code-dispatched activities", async () => {
         const data = {
             task: 'preserve "${}" literal',
             other: "also has ${undefined_ref}",
@@ -38,7 +38,7 @@ describe("setupActivity", () => {
         expect(ctx.params.data.other).toBe("also has ${undefined_ref}");
     });
 
-    it("returns empty params when code-dispatched activity has no params", async () => {
+    it("should return empty params when code-dispatched activity has no params", async () => {
         const payload = basePayload({ name: "testActivity" }, undefined as unknown as Record<string, unknown>);
         const ctx = await setupActivity(payload);
         expect(ctx.params).toEqual({});
@@ -46,7 +46,7 @@ describe("setupActivity", () => {
 
     // Counter-test: DSL-defined activities (those carrying activity.params) must
     // still have their ${refs} resolved against payload.params (imported vars).
-    it("still resolves ${refs} in activity.params for DSL-dispatched activities", async () => {
+    it("should still resolve ${refs} in activity.params for DSL-dispatched activities", async () => {
         const payload = basePayload(
             { name: "dslActivity", params: { message: "Hello ${name}" } },
             { name: "World" } as unknown as Record<string, unknown>,

--- a/packages/workflow/src/dsl/setup/ActivityContext.test.ts
+++ b/packages/workflow/src/dsl/setup/ActivityContext.test.ts
@@ -5,7 +5,7 @@ import { setupActivity } from "./ActivityContext.js";
 const MOCK_AUTH_TOKEN =
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwOi8vbW9jay10b2tlbi1zZXJ2ZXIiLCJzdWIiOiJ0ZXN0In0.signature";
 
-function basePayload<T extends Record<string, any>>(
+function basePayload<T extends object>(
     activity: DSLActivityExecutionPayload<T>["activity"],
     params: T,
 ): DSLActivityExecutionPayload<T> {
@@ -39,7 +39,7 @@ describe("setupActivity", () => {
     });
 
     it("returns empty params when code-dispatched activity has no params", async () => {
-        const payload = basePayload({ name: "testActivity" }, undefined as any);
+        const payload = basePayload({ name: "testActivity" }, undefined as unknown as Record<string, unknown>);
         const ctx = await setupActivity(payload);
         expect(ctx.params).toEqual({});
     });
@@ -49,9 +49,9 @@ describe("setupActivity", () => {
     it("still resolves ${refs} in activity.params for DSL-dispatched activities", async () => {
         const payload = basePayload(
             { name: "dslActivity", params: { message: "Hello ${name}" } },
-            { name: "World" } as any,
+            { name: "World" } as unknown as Record<string, unknown>,
         );
         const ctx = await setupActivity(payload);
-        expect((ctx.params as any).message).toBe("Hello World");
+        expect((ctx.params as { message: string }).message).toBe("Hello World");
     });
 });

--- a/packages/workflow/src/dsl/setup/ActivityContext.ts
+++ b/packages/workflow/src/dsl/setup/ActivityContext.ts
@@ -36,7 +36,7 @@ registerFetchProviderFactory(
     InteractionRunProvider.factory,
 );
 
-export class ActivityContext<ParamsT extends Record<string, any>> {
+export class ActivityContext<ParamsT extends object> {
     client: VertesiaClient;
     _project?: Promise<Project | undefined>;
 
@@ -180,7 +180,7 @@ export class ActivityContext<ParamsT extends Record<string, any>> {
     }
 }
 
-export async function setupActivity<ParamsT extends Record<string, any>>(
+export async function setupActivity<ParamsT extends object>(
     payload: DSLActivityExecutionPayload<ParamsT>,
 ) {
     const client = await getVertesiaClient(payload);

--- a/packages/workflow/src/dsl/setup/fetch/DataProvider.ts
+++ b/packages/workflow/src/dsl/setup/fetch/DataProvider.ts
@@ -13,7 +13,7 @@ function parseSelector(selector: string) {
     return result;
 }
 
-function applyProjection(result: Record<string, any>, select: string) {
+function applyProjection(result: Record<string, unknown>, select: string) {
     if (!result) return result;
     let selectorObj: Record<string, number | boolean>;
     if (typeof select === 'string') {
@@ -22,7 +22,7 @@ function applyProjection(result: Record<string, any>, select: string) {
         selectorObj = select;
     }
 
-    const out: Record<string, any> = {};
+    const out: Record<string, unknown> = {};
     for (const key of Object.keys(result)) {
         if (selectorObj[key]) {
             out[key] = result[key];
@@ -37,9 +37,9 @@ export abstract class DataProvider {
     async fetch(payload: FindPayload) {
         let results = await this.doFetch(payload);
         if (payload.select && !this.isProjectionSupported) {
-            results = results.map((result: Record<string, any>) => applyProjection(result, payload.select!));
+            results = results.map((result: Record<string, unknown>) => applyProjection(result, payload.select!));
         }
         return results;
     }
-    abstract doFetch(payload: FindPayload): Promise<Record<string, any>[]>;
+    abstract doFetch(payload: FindPayload): Promise<Record<string, unknown>[]>;
 }

--- a/packages/workflow/src/dsl/setup/fetch/providers.ts
+++ b/packages/workflow/src/dsl/setup/fetch/providers.ts
@@ -2,13 +2,16 @@ import { FindPayload } from "@vertesia/common";
 import { VertesiaClient } from "@vertesia/client";
 import { DataProvider } from "./DataProvider.js";
 
-function useMongoId(query: Record<string, any>) {
+function useMongoId(query: Record<string, unknown>) {
     if (query.id) {
-        const result = { ...query, _id: query.id }
-        delete (result as any).id;
-        return result;
+        const { id, ...rest } = query;
+        return { ...rest, _id: id };
     }
     return query;
+}
+
+function asRecords<T extends object>(items: T[]): Record<string, unknown>[] {
+    return items as unknown as Record<string, unknown>[];
 }
 
 export class DocumentProvider extends DataProvider {
@@ -17,11 +20,11 @@ export class DocumentProvider extends DataProvider {
         super(DocumentProvider.ID, true);
     }
 
-    doFetch(payload: FindPayload): Promise<Record<string, any>[]> {
+    doFetch(payload: FindPayload): Promise<Record<string, unknown>[]> {
         const query = useMongoId(payload.query);
         return this.client.objects.find({
             query, select: payload.select, limit: payload.limit
-        });
+        }).then(asRecords);
     }
 
     static factory(client: VertesiaClient) {
@@ -35,11 +38,11 @@ export class DocumentTypeProvider extends DataProvider {
         super(DocumentTypeProvider.ID, true);
     }
 
-    doFetch(payload: FindPayload): Promise<Record<string, any>[]> {
+    doFetch(payload: FindPayload): Promise<Record<string, unknown>[]> {
         const query = useMongoId(payload.query);
         return this.client.types.find({
             query, select: payload.select, limit: payload.limit
-        });
+        }).then(asRecords);
     }
 
     static factory(client: VertesiaClient) {
@@ -53,11 +56,11 @@ export class InteractionRunProvider extends DataProvider {
         super(DocumentProvider.ID, true);
     }
 
-    doFetch(payload: FindPayload): Promise<Record<string, any>[]> {
+    doFetch(payload: FindPayload): Promise<Record<string, unknown>[]> {
         const query = useMongoId(payload.query);
         return this.client.runs.find({
             query, select: payload.select, limit: payload.limit
-        });
+        }).then(asRecords);
     }
 
     static factory(client: VertesiaClient) {

--- a/packages/workflow/src/dsl/validation.test.ts
+++ b/packages/workflow/src/dsl/validation.test.ts
@@ -1,61 +1,62 @@
+import type { DSLWorkflowSpec } from "@vertesia/common";
 import { describe, expect, test } from "vitest";
-import { validateWorkflow } from "./validation.ts";
+import { validateWorkflow } from "./validation.js";
 
 describe('workflow validation', () => {
 
     test('empty object is not a valid workflow', () => {
-        const workflow: any = {
+        const workflow = {
         }
-        const errors = validateWorkflow(workflow);
+        const errors = validateWorkflow(workflow as unknown as DSLWorkflowSpec);
         expect(errors.length).toBe(2);
     })
 
     test('activities is required', () => {
-        const workflow: any = {
+        const workflow = {
             name: "test",
         }
-        const errors = validateWorkflow(workflow);
+        const errors = validateWorkflow(workflow as unknown as DSLWorkflowSpec);
         expect(errors.length).toBe(1);
     })
 
     test('activities should be an array', () => {
-        const workflow: any = {
+        const workflow = {
             name: "test",
             activities: {}
         }
-        const errors = validateWorkflow(workflow);
+        const errors = validateWorkflow(workflow as unknown as DSLWorkflowSpec);
         expect(errors.length).toBe(1);
     })
 
     test('activities array should have at least one item', () => {
-        const workflow: any = {
+        const workflow = {
             name: "test",
             activities: []
         }
-        const errors = validateWorkflow(workflow);
+        const errors = validateWorkflow(workflow as unknown as DSLWorkflowSpec);
         expect(errors.length).toBe(1);
     })
 
     test('activity should have a name', () => {
-        const workflow: any = {
+        const workflow = {
             name: "test",
             activities: [{}]
         }
-        const errors = validateWorkflow(workflow);
+        const errors = validateWorkflow(workflow as unknown as DSLWorkflowSpec);
         expect(errors.length).toBe(1);
     })
 
     test('allow empty activity', () => {
-        const workflow: any = {
+        const workflow = {
             name: "test",
             activities: [{ name: "test" }]
         }
-        const errors = validateWorkflow(workflow);
+        const errors = validateWorkflow(workflow as unknown as DSLWorkflowSpec);
         expect(errors.length).toBe(0);
     })
 
     test('import undeclared var', () => {
-        const workflow: any = {
+        const workflow = {
             name: "test",
             vars: { "foo": true },
             activities: [{
@@ -63,13 +64,13 @@ describe('workflow validation', () => {
                 import: ["foo", "bar"]
             }]
         }
-        const errors = validateWorkflow(workflow);
+        const errors = validateWorkflow(workflow as unknown as DSLWorkflowSpec);
         expect(errors.length).toBe(1);
     })
 
 
     test('import declared vars', () => {
-        const workflow: any = {
+        const workflow = {
             name: "test",
             vars: { "foo": true, "bar": true },
             activities: [{
@@ -77,12 +78,12 @@ describe('workflow validation', () => {
                 import: ["foo", "bar"]
             }]
         }
-        const errors = validateWorkflow(workflow);
+        const errors = validateWorkflow(workflow as unknown as DSLWorkflowSpec);
         expect(errors.length).toBe(0);
     })
 
     test('import unknown imported var through expressions', () => {
-        const workflow: any = {
+        const workflow = {
             name: "test",
             vars: { "foo": true },
             activities: [{
@@ -90,12 +91,12 @@ describe('workflow validation', () => {
                 import: [{ "foo": "foo", "barLen": "bar.length" }]
             }]
         }
-        const errors = validateWorkflow(workflow);
+        const errors = validateWorkflow(workflow as unknown as DSLWorkflowSpec);
         expect(errors.length).toBe(1);
     })
 
     test('import declared vars through expressions', () => {
-        const workflow: any = {
+        const workflow = {
             name: "test",
             vars: { "foo": true, "bar": "true" },
             activities: [{
@@ -103,12 +104,12 @@ describe('workflow validation', () => {
                 import: [{ "foo": "foo", "barLen": "bar.length" }]
             }]
         }
-        const errors = validateWorkflow(workflow);
+        const errors = validateWorkflow(workflow as unknown as DSLWorkflowSpec);
         expect(errors.length).toBe(0);
     })
 
     test('detect self references', () => {
-        const workflow: any = {
+        const workflow = {
             name: "test",
             vars: { "object_type": "thetype" },
             activities: [{
@@ -119,13 +120,13 @@ describe('workflow validation', () => {
                 }
             }]
         }
-        const errors = validateWorkflow(workflow);
+        const errors = validateWorkflow(workflow as unknown as DSLWorkflowSpec);
         expect(errors.length).toBe(1);
         expect(errors[0].includes("Self referencing parameter")).toBe(true);
     })
 
     test('reference known vars in fetch', () => {
-        const workflow: any = {
+        const workflow = {
             name: "test",
             vars: { "foo": true, "bar": "true" },
             activities: [{
@@ -141,14 +142,14 @@ describe('workflow validation', () => {
                 }
             }]
         }
-        const errors = validateWorkflow(workflow);
+        const errors = validateWorkflow(workflow as unknown as DSLWorkflowSpec);
         console.log('##############errors', errors);
 
         expect(errors.length).toBe(0);
     })
 
     test('reference unknown vars in fetch', () => {
-        const workflow: any = {
+        const workflow = {
             name: "test",
             vars: { "foo": true, "bar": "true" },
             activities: [{
@@ -164,12 +165,12 @@ describe('workflow validation', () => {
                 }
             }]
         }
-        const errors = validateWorkflow(workflow);
+        const errors = validateWorkflow(workflow as unknown as DSLWorkflowSpec);
         expect(errors.length).toBe(2);
     })
 
     test('reference one unknown and one known var in fetch', () => {
-        const workflow: any = {
+        const workflow = {
             name: "test",
             vars: { "foo": true, "bar": "true" },
             activities: [{
@@ -185,12 +186,12 @@ describe('workflow validation', () => {
                 }
             }]
         }
-        const errors = validateWorkflow(workflow);
+        const errors = validateWorkflow(workflow as unknown as DSLWorkflowSpec);
         expect(errors.length).toBe(1);
     })
 
     test('reference 2 unknown vars in params', () => {
-        const workflow: any = {
+        const workflow = {
             name: "test",
             vars: { "foo": true, "bar": "true" },
             activities: [{
@@ -202,12 +203,12 @@ describe('workflow validation', () => {
                 }
             }]
         }
-        const errors = validateWorkflow(workflow);
+        const errors = validateWorkflow(workflow as unknown as DSLWorkflowSpec);
         expect(errors.length).toBe(2);
     })
 
     test('reference 1 unknown vars in params', () => {
-        const workflow: any = {
+        const workflow = {
             name: "test",
             vars: { "foo": true, "bar": "true" },
             activities: [{
@@ -219,12 +220,12 @@ describe('workflow validation', () => {
                 }
             }]
         }
-        const errors = validateWorkflow(workflow);
+        const errors = validateWorkflow(workflow as unknown as DSLWorkflowSpec);
         expect(errors.length).toBe(1);
     })
 
     test('reference known vars in params', () => {
-        const workflow: any = {
+        const workflow = {
             name: "test",
             vars: { "foo": true, "bar": "true" },
             activities: [
@@ -250,7 +251,7 @@ describe('workflow validation', () => {
                     }
                 }]
         }
-        const errors = validateWorkflow(workflow);
+        const errors = validateWorkflow(workflow as unknown as DSLWorkflowSpec);
         expect(errors.length).toBe(0);
     })
 

--- a/packages/workflow/src/dsl/validation.test.ts
+++ b/packages/workflow/src/dsl/validation.test.ts
@@ -4,14 +4,14 @@ import { validateWorkflow } from "./validation.js";
 
 describe('workflow validation', () => {
 
-    test('empty object is not a valid workflow', () => {
+    test('should reject an empty object as a workflow', () => {
         const workflow = {
         }
         const errors = validateWorkflow(workflow as unknown as DSLWorkflowSpec);
         expect(errors.length).toBe(2);
     })
 
-    test('activities is required', () => {
+    test('should require activities', () => {
         const workflow = {
             name: "test",
         }
@@ -19,7 +19,7 @@ describe('workflow validation', () => {
         expect(errors.length).toBe(1);
     })
 
-    test('activities should be an array', () => {
+    test('should require activities to be an array', () => {
         const workflow = {
             name: "test",
             activities: {}
@@ -28,7 +28,7 @@ describe('workflow validation', () => {
         expect(errors.length).toBe(1);
     })
 
-    test('activities array should have at least one item', () => {
+    test('should require activities array to have at least one item', () => {
         const workflow = {
             name: "test",
             activities: []
@@ -37,7 +37,7 @@ describe('workflow validation', () => {
         expect(errors.length).toBe(1);
     })
 
-    test('activity should have a name', () => {
+    test('should require activity to have a name', () => {
         const workflow = {
             name: "test",
             activities: [{}]
@@ -46,7 +46,7 @@ describe('workflow validation', () => {
         expect(errors.length).toBe(1);
     })
 
-    test('allow empty activity', () => {
+    test('should allow empty activity', () => {
         const workflow = {
             name: "test",
             activities: [{ name: "test" }]
@@ -55,7 +55,7 @@ describe('workflow validation', () => {
         expect(errors.length).toBe(0);
     })
 
-    test('import undeclared var', () => {
+    test('should reject imported undeclared vars', () => {
         const workflow = {
             name: "test",
             vars: { "foo": true },
@@ -69,7 +69,7 @@ describe('workflow validation', () => {
     })
 
 
-    test('import declared vars', () => {
+    test('should allow importing declared vars', () => {
         const workflow = {
             name: "test",
             vars: { "foo": true, "bar": true },
@@ -82,7 +82,7 @@ describe('workflow validation', () => {
         expect(errors.length).toBe(0);
     })
 
-    test('import unknown imported var through expressions', () => {
+    test('should reject unknown imported vars through expressions', () => {
         const workflow = {
             name: "test",
             vars: { "foo": true },
@@ -95,7 +95,7 @@ describe('workflow validation', () => {
         expect(errors.length).toBe(1);
     })
 
-    test('import declared vars through expressions', () => {
+    test('should allow declared vars through expressions', () => {
         const workflow = {
             name: "test",
             vars: { "foo": true, "bar": "true" },
@@ -108,7 +108,7 @@ describe('workflow validation', () => {
         expect(errors.length).toBe(0);
     })
 
-    test('detect self references', () => {
+    test('should detect self references', () => {
         const workflow = {
             name: "test",
             vars: { "object_type": "thetype" },
@@ -125,7 +125,7 @@ describe('workflow validation', () => {
         expect(errors[0].includes("Self referencing parameter")).toBe(true);
     })
 
-    test('reference known vars in fetch', () => {
+    test('should allow known vars in fetch', () => {
         const workflow = {
             name: "test",
             vars: { "foo": true, "bar": "true" },
@@ -148,7 +148,7 @@ describe('workflow validation', () => {
         expect(errors.length).toBe(0);
     })
 
-    test('reference unknown vars in fetch', () => {
+    test('should reject unknown vars in fetch', () => {
         const workflow = {
             name: "test",
             vars: { "foo": true, "bar": "true" },
@@ -169,7 +169,7 @@ describe('workflow validation', () => {
         expect(errors.length).toBe(2);
     })
 
-    test('reference one unknown and one known var in fetch', () => {
+    test('should reject one unknown var in fetch while allowing known vars', () => {
         const workflow = {
             name: "test",
             vars: { "foo": true, "bar": "true" },
@@ -190,7 +190,7 @@ describe('workflow validation', () => {
         expect(errors.length).toBe(1);
     })
 
-    test('reference 2 unknown vars in params', () => {
+    test('should reject two unknown vars in params', () => {
         const workflow = {
             name: "test",
             vars: { "foo": true, "bar": "true" },
@@ -207,7 +207,7 @@ describe('workflow validation', () => {
         expect(errors.length).toBe(2);
     })
 
-    test('reference 1 unknown vars in params', () => {
+    test('should reject one unknown var in params', () => {
         const workflow = {
             name: "test",
             vars: { "foo": true, "bar": "true" },
@@ -224,7 +224,7 @@ describe('workflow validation', () => {
         expect(errors.length).toBe(1);
     })
 
-    test('reference known vars in params', () => {
+    test('should allow known vars in params', () => {
         const workflow = {
             name: "test",
             vars: { "foo": true, "bar": "true" },

--- a/packages/workflow/src/dsl/validation.ts
+++ b/packages/workflow/src/dsl/validation.ts
@@ -100,7 +100,7 @@ export function validateActivity(activity: DSLActivitySpec, workflowVars: Set<st
 }
 
 
-function validateExpressions(target: Record<string, any>, localVars: Record<string, boolean>, errors: string[], checkSelfReference = false) {
+function validateExpressions(target: Record<string, unknown>, localVars: Record<string, boolean>, errors: string[], checkSelfReference = false) {
     const vars = new Vars(localVars);
     const refs = vars.getUnknownReferences(target);
     for (const ref of refs) {

--- a/packages/workflow/src/dsl/vars.test.ts
+++ b/packages/workflow/src/dsl/vars.test.ts
@@ -6,7 +6,7 @@ type Tree = { readonly [key: string]: Tree };
 
 describe('Workflow vars', () => {
 
-    test('access initial variables', () => {
+    test('should access initial variables', () => {
         const vars = new Vars({
             objectId: "123",
             timestamp: 123456,
@@ -16,7 +16,7 @@ describe('Workflow vars', () => {
         expect(vars.getValue("foo")).toBeUndefined();
     })
 
-    test('set and access variables', () => {
+    test('should set and access variables', () => {
         const vars = new Vars({
             objectId: "123",
             timestamp: 123456,
@@ -26,7 +26,7 @@ describe('Workflow vars', () => {
         expect(vars.getValue("objectId")).toBe("456");
     })
 
-    test('access and modify ref variables', () => {
+    test('should access and modify ref variables', () => {
         const vars = new Vars({
             objectId: "123",
             config: {
@@ -43,7 +43,7 @@ describe('Workflow vars', () => {
         expect(vars.getValue("configNameAlias")).toBe("bar");
     })
 
-    test('replace literal with ref', () => {
+    test('should replace literal with ref', () => {
         const vars = new Vars({
             objectId: "123",
             otherId: "1234",
@@ -56,14 +56,14 @@ describe('Workflow vars', () => {
         expect(vars.getValue("otherId")).toBe("456");
     });
 
-    test("undefined ref variable", () => {
+    test("should return undefined for undefined ref variable", () => {
         const vars = new Vars({
             otherId: "${objectId}",
         });
         expect(vars.getValue("otherId")).toBeUndefined();
     })
 
-    test("default values", () => {
+    test("should resolve default values", () => {
         const vars = new Vars({
             squote: "${objectId ?? '123'}",
             dquote: "${objectId ?? \"123\"}",
@@ -79,7 +79,7 @@ describe('Workflow vars', () => {
         expect(vars.getValue("array")).toEqual([1, 2]);
     })
 
-    test("array map", () => {
+    test("should map arrays through path expressions", () => {
         const vars = new Vars({
             docs: [{ text: "hello" }, { text: "world" }],
         });
@@ -87,7 +87,7 @@ describe('Workflow vars', () => {
         expect(vars.getValue("docs.text").join(' ')).toBe("hello world");
     })
 
-    test("resolveParams", () => {
+    test("should resolve params", () => {
         const vars = new Vars({
             objectIds: ["123", "456"],
             objectId: "123",
@@ -112,7 +112,7 @@ describe('Workflow vars', () => {
 
     });
 
-    test("resolve", () => {
+    test("should resolve variables", () => {
         const vars = new Vars({
             objectId: "123",
             message: "hello",
@@ -132,7 +132,7 @@ describe('Workflow vars', () => {
     });
 
 
-    test("createImportVars", () => {
+    test("should create import vars", () => {
         const vars = new Vars({
             person: { name: "John", age: 30 },
             objectId: "123",
@@ -147,7 +147,7 @@ describe('Workflow vars', () => {
         expect(params.data2).toStrictEqual({ message: "hello" });
     });
 
-    test("evaluate null and exists conditions", () => {
+    test("should evaluate null and exists conditions", () => {
         const vars = new Vars({
             objectId: "123",
             docType: {
@@ -170,7 +170,7 @@ describe('Workflow vars', () => {
         expect(vars.match({ "docType.idNull": { $null: true } })).toBe(true);
     });
 
-    test("evaluate $eq conditions", () => {
+    test("should evaluate $eq conditions", () => {
         const vars = new Vars({
             objectId: "123",
             otherId: "${objectId}",
@@ -192,14 +192,14 @@ describe('Workflow vars', () => {
         expect(vars.match({ "config": { $eq: { name: { foo: "bar" }, tags: ["a", "b", "c"] } } })).toBe(true);
     });
 
-    test("evaluate $regexp conditions", () => {
+    test("should evaluate $regexp conditions", () => {
         const vars = new Vars({
             expr: "a=2",
         });
         expect(vars.match({ expr: { $regexp: "^.*\\s*=\\s*.*$" } })).toBe(true);
     });
 
-    test("evaluate string compare conditions", () => {
+    test("should evaluate string compare conditions", () => {
         const vars = new Vars({
             expr: "<tag />",
         });
@@ -208,7 +208,7 @@ describe('Workflow vars', () => {
         expect(vars.match({ expr: { $endsWith: "/>" } })).toBe(true);
     });
 
-    test("evaluate $in conditions", () => {
+    test("should evaluate $in conditions", () => {
         const vars = new Vars({
             name: "foo",
         });
@@ -216,7 +216,7 @@ describe('Workflow vars', () => {
         expect(vars.match({ name: { $nin: ["hello", "world"] } })).toBe(true);
     });
 
-    test("evaluate $lt, $gt conditions", () => {
+    test("should evaluate $lt, $gt conditions", () => {
         const vars = new Vars({
             value: 5,
         });
@@ -226,7 +226,7 @@ describe('Workflow vars', () => {
         expect(vars.match({ value: { $gte: 5 } })).toBe(true);
     });
 
-    test("evaluate $or conditions", () => {
+    test("should evaluate $or conditions", () => {
         const vars = new Vars({
             value: 5,
             name: "foo"
@@ -236,7 +236,7 @@ describe('Workflow vars', () => {
         expect(vars.match({ name: { $or: [{ $eq: "bar" }, { $eq: "fooo" }] } })).toBe(false);
     });
 
-    test("evaluate nested conditions", () => {
+    test("should evaluate nested conditions", () => {
         const vars = new Vars({
             config: {
                 name: "foo",

--- a/packages/workflow/src/dsl/vars.test.ts
+++ b/packages/workflow/src/dsl/vars.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "vitest";
-import { Vars } from "./vars.ts";
+import { Vars } from "./vars.js";
+
+/** Permissive recursive type for navigating untyped resolver results in test assertions. */
+type Tree = { readonly [key: string]: Tree };
 
 describe('Workflow vars', () => {
 
@@ -98,7 +101,7 @@ describe('Workflow vars', () => {
             secondDocId: "${objectIds.1}",
             secondDocIdByBracket: "${objectIds[1]}",
         }
-        const resolved = vars.resolveParams(params);
+        const resolved = vars.resolveParams(params) as unknown as Tree;
         expect(Object.keys(resolved).length).toBe(3);
         expect(resolved.query).toBeTypeOf("object");
         expect(resolved.query._id).toBe("123");
@@ -117,7 +120,7 @@ describe('Workflow vars', () => {
             data2: "${prompt_data}",
             unknown: "${notdefined}"
         });
-        const resolved = vars.resolve();
+        const resolved = vars.resolve() as unknown as Tree;
         console.log('@@@@@@@@@@@@@@@@@@@', resolved);
         expect(Object.keys(resolved).length).toBe(4); // since unknown will be undefined it will not be included
         expect(resolved.objectId).toBe("123");

--- a/packages/workflow/src/dsl/vars.ts
+++ b/packages/workflow/src/dsl/vars.ts
@@ -4,6 +4,10 @@ import { ObjectKey, ObjectVisitor, ObjectWalker } from "./walk.js";
 
 const FALLBACK_VALUE_SEP = "??";
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
 function decodeLiteralValue(value: string) {
     if (value.startsWith("'") && value.endsWith("'")) {
         value = '"' + value.slice(1, -1).replace(/(?<!\\)"/g, '\\"') + '"'
@@ -26,7 +30,7 @@ export function splitPath(path: string) {
  * @param name the name of the property.
  * @returns the property value
  */
-function _prop(object: any, name: string) {
+function _prop(object: unknown, name: string) {
     if (object === undefined) {
         return undefined;
     }
@@ -35,22 +39,23 @@ function _prop(object: any, name: string) {
         const index = +name;
         if (isNaN(index)) {
             // map array to property
-            return object.map(item => item[name]);
+            return object.map(item => isRecord(item) ? item[name] : undefined);
         } else {
             return _valueOf(object[index]);
         }
-    } else {
+    } else if (isRecord(object)) {
         return _valueOf(object[name]);
     }
+    return undefined;
 
 }
 
-function _valueOf(value: any) {
+function _valueOf(value: unknown) {
     return value instanceof Value ? value.value : value;
 }
 
-export function resolveField(object: any, path: string[]) {
-    let p = object as any;
+export function resolveField(object: unknown, path: string[]) {
+    let p = object as unknown;
     if (!p) return p;
     if (!path.length) return _valueOf(p);
     const last = path.length - 1;
@@ -63,11 +68,11 @@ export function resolveField(object: any, path: string[]) {
     return _prop(p, path[last]);
 }
 
-abstract class Value<T = any> {
+abstract class Value<T = unknown> {
     abstract value: T;
     abstract stringify(): string;
 }
-class LiteralValue<T = any> extends Value<T> {
+class LiteralValue<T = unknown> extends Value<T> {
     constructor(public value: T) {
         super();
     }
@@ -77,7 +82,7 @@ class LiteralValue<T = any> extends Value<T> {
 }
 
 class RefValue extends Value {
-    constructor(public vars: Vars, public path: string[], public defaultValue?: any) {
+    constructor(public vars: Vars, public path: string[], public defaultValue?: unknown) {
         super();
     }
     get value() {
@@ -125,7 +130,7 @@ class ExprValue extends Value {
 
 
 export class Vars {
-    map: Record<string, any>;
+    map: Record<string, unknown>;
     /**
      * This property is used when resolving params. It contains the list of references that should not be resolved to their value
      * but instead they need to return the string representation of the expression to be able to regenerate another Vars instance with the same expression
@@ -133,12 +138,12 @@ export class Vars {
     //TODO this feature is no more used - it was replaced by importVars so we can now delete `preserveRefs`
     preserveRefs: Set<string> | undefined;
 
-    constructor(vars?: Record<string, any>) {
+    constructor(vars?: Record<string, unknown>) {
         this.map = vars ? this.parse(vars) : {};
     }
 
-    parse(vars: Record<string, any>): Record<string, any> {
-        return new ObjectWalker().map(vars, (_key, value) => {
+    parse(vars: Record<string, unknown>): Record<string, unknown> {
+        return new ObjectWalker().map<Record<string, unknown>>(vars, (_key, value) => {
             if (typeof value === 'string') {
                 return this.createValue(this, value);
             } else {
@@ -147,7 +152,7 @@ export class Vars {
         });
     }
 
-    load(vars: Record<string, any>) {
+    load(vars: Record<string, unknown>) {
         const toAppend = this.parse(vars);
         this.map = Object.assign(this.map, toAppend);
         return this;
@@ -159,7 +164,7 @@ export class Vars {
      * @param name
      * @param value
      */
-    setValue(name: string, value: any) {
+    setValue(name: string, value: unknown) {
         this.map[name] = value;
     }
 
@@ -175,7 +180,7 @@ export class Vars {
         return this.map[name] !== undefined;
     }
 
-    match(match: Record<string, any>) {
+    match(match: Record<string, unknown>) {
         for (const name of Object.keys(match)) {
             const value = this.getValue(name);
             if (!matchCondition(value, match[name])) {
@@ -185,10 +190,10 @@ export class Vars {
         return true;
     }
 
-    resolveParams(params: Record<string, any>, preserveRefs?: Set<string>) {
+    resolveParams(params: Record<string, unknown>, preserveRefs?: Set<string>) {
         this.preserveRefs = preserveRefs;
         try {
-            return new ObjectWalker().map(params, (_key, value) => {
+            return new ObjectWalker().map<Record<string, unknown>>(params, (_key, value) => {
                 if (typeof value === 'string') {
                     const v = this.createValue(this, value)
                     return v instanceof Value ? v.value : v;
@@ -201,15 +206,15 @@ export class Vars {
         }
     }
 
-    resolve(preserveRefs?: Set<string>): Record<string, any> {
-        function map(_key: ObjectKey, value: any) {
+    resolve(preserveRefs?: Set<string>): Record<string, unknown> {
+        function map(_key: ObjectKey, value: unknown) {
             if (value instanceof Value) {
                 const v = value.value;
                 if (v && typeof v === 'object') {
                     if (Array.isArray(v) || v.constructor === Object) {
                         // an array or plain object - recurse into the
                         // value to find other nested Ref values if any...
-                        return new ObjectWalker().map(v, map);
+                        return new ObjectWalker().map<Record<string, unknown> | unknown[]>(v, map);
                     }
                 } else {
                     return v;
@@ -220,7 +225,7 @@ export class Vars {
         }
         try {
             this.preserveRefs = preserveRefs;
-            return new ObjectWalker().map(this.map, map);
+            return new ObjectWalker().map<Record<string, unknown>>(this.map, map);
         } finally {
             this.preserveRefs = undefined;
         }
@@ -228,7 +233,7 @@ export class Vars {
 
     createRefValue(ref: string) {
         const index = ref.indexOf(FALLBACK_VALUE_SEP);
-        let defaultValue: any;
+        let defaultValue: unknown;
         if (index > -1) {
             defaultValue = decodeLiteralValue(ref.substring(index + FALLBACK_VALUE_SEP.length).trim());
             ref = ref.substring(0, index).trim();
@@ -239,7 +244,7 @@ export class Vars {
         return new RefValue(this, splitPath(ref), defaultValue);
     }
 
-    createValue(vars: Vars, obj: any) {
+    createValue(vars: Vars, obj: unknown) {
         if (!obj) {
             return obj;
         }
@@ -276,7 +281,7 @@ export class Vars {
         if (!importSpec || importSpec.length === 0) {
             return {};
         }
-        const result: Record<string, any> = {};
+        const result: Record<string, unknown> = {};
 
         for (const importVar of importSpec) {
             if (typeof importVar === "string") {
@@ -290,14 +295,14 @@ export class Vars {
         return result;
     }
 
-    getUnknownReferences(obj: any) {
+    getUnknownReferences(obj: unknown) {
         const visitor = new UnknownReferencesVisitor(this);
         new ObjectWalker().walk(obj, visitor);
         return visitor.result;
     }
 }
 
-function addImportVar(varPath: string, asName: string | undefined, vars: Vars, result: Record<string, any>) {
+function addImportVar(varPath: string, asName: string | undefined, vars: Vars, result: Record<string, unknown>) {
     let isRequired = false;
     if (varPath.endsWith("!")) {
         isRequired = true;
@@ -318,7 +323,7 @@ class UnknownReferencesVisitor implements ObjectVisitor {
     constructor(public vars: Vars) {
     }
 
-    onValue(_key: ObjectKey, value: any) {
+    onValue(_key: ObjectKey, value: unknown) {
         const vars = this.vars;
         if (typeof value === "string") {
             const v = vars.createValue(vars, value);

--- a/packages/workflow/src/dsl/walk.test.ts
+++ b/packages/workflow/src/dsl/walk.test.ts
@@ -6,7 +6,7 @@ type Tree = { readonly [key: string]: Tree };
 
 describe('walk object', () => {
 
-    test('find string values', () => {
+    test('should find string values', () => {
         const obj = {
             name: "foo",
             age: 42,
@@ -36,7 +36,7 @@ describe('walk object', () => {
         expect(found.sort().join(',')).toBe(values);
     })
 
-    test('map numbers to string values', () => {
+    test('should map numbers to string values', () => {
         const obj = {
             name: "foo",
             age: 42,
@@ -66,7 +66,7 @@ describe('walk object', () => {
         expect(r.folder.subfolder.name).toBe("123");
     })
 
-    test('map numbers in an array to string values', () => {
+    test('should map numbers in an array to string values', () => {
         const obj = [123, { x: 1 }, { y: 2 }, { z: 3 }]
         const r = new ObjectWalker().map(obj, (_key, value) => {
             if (typeof value === "number") {

--- a/packages/workflow/src/dsl/walk.test.ts
+++ b/packages/workflow/src/dsl/walk.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "vitest";
-import { ObjectWalker } from "./walk.ts";
+import { ObjectWalker } from "./walk.js";
+
+/** Permissive recursive type for navigating untyped walker results in test assertions. */
+type Tree = { readonly [key: string]: Tree };
 
 describe('walk object', () => {
 
@@ -24,7 +27,7 @@ describe('walk object', () => {
         const values = ["foo", "bar", "baz", "file"].sort().join(',');
         const found: string[] = [];
         new ObjectWalker().walk(obj, {
-            onValue(key, value) {
+            onValue(_key, value) {
                 if (typeof value === "string") {
                     found.push(value);
                 }
@@ -56,7 +59,7 @@ describe('walk object', () => {
                 return String(value)
             }
             return value;
-        });
+        }) as Tree;
         expect(r.age).toBe("42");
         expect(r.children[0].age).toBe("12");
         expect(r.children[1].age).toBe("15");
@@ -70,7 +73,7 @@ describe('walk object', () => {
                 return String(value)
             }
             return value;
-        });
+        }) as unknown as Tree;
         expect(r.length).toBe(4);
         expect(r[0]).toBe("123");
         expect(r[1].x).toBe("1");

--- a/packages/workflow/src/dsl/walk.ts
+++ b/packages/workflow/src/dsl/walk.ts
@@ -1,11 +1,32 @@
 
 export type ObjectKey = string | number | undefined;
 export interface ObjectVisitor {
-    onStartObject?: (key: ObjectKey, value: any) => void;
-    onEndObject?: (key: ObjectKey, value: any) => void;
-    onStartIteration?: (key: ObjectKey, value: Iterable<any>) => void;
-    onEndIteration?: (key: ObjectKey, value: Iterable<any>) => void;
-    onValue?: (key: ObjectKey, value: any) => void;
+    onStartObject?: (key: ObjectKey, value: unknown) => void;
+    onEndObject?: (key: ObjectKey, value: unknown) => void;
+    onStartIteration?: (key: ObjectKey, value: Iterable<unknown>) => void;
+    onEndIteration?: (key: ObjectKey, value: Iterable<unknown>) => void;
+    onValue?: (key: ObjectKey, value: unknown) => void;
+}
+
+type MutableContainer = Record<string, unknown> | unknown[];
+
+function isIterable(value: unknown): value is Iterable<unknown> {
+    return !!value && typeof value === 'object' && Symbol.iterator in value && typeof value[Symbol.iterator] === 'function';
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+    return !!value && typeof value === 'object' && value.constructor === Object;
+}
+
+function setValue(target: MutableContainer | undefined, key: ObjectKey, value: unknown) {
+    if (!target || key === undefined) {
+        return;
+    }
+    if (Array.isArray(target) && typeof key === 'number') {
+        target[key] = value;
+    } else if (!Array.isArray(target) && typeof key === 'string') {
+        target[key] = value;
+    }
 }
 
 export class ObjectWalker {
@@ -13,25 +34,25 @@ export class ObjectWalker {
     constructor(supportIterators = false) {
         this.supportIterators = supportIterators;
     }
-    walk(obj: any, visitor: ObjectVisitor) {
+    walk(obj: unknown, visitor: ObjectVisitor) {
         this._walk(undefined, obj, visitor);
     }
-    _walk(key: ObjectKey, obj: any, visitor: ObjectVisitor) {
+    _walk(key: ObjectKey, obj: unknown, visitor: ObjectVisitor) {
         const type = typeof obj;
         if (!obj || type !== 'object' || obj instanceof Date) {
             visitor.onValue && visitor.onValue(key, obj);
         } else if (Array.isArray(obj)) {
             this._walkIterable(key, obj, visitor);
-        } else if (this.supportIterators && obj[Symbol.iterator] === 'function') {
+        } else if (this.supportIterators && isIterable(obj)) {
             this._walkIterable(key, obj, visitor);
-        } else if (obj.constructor === Object) { // a plain object
+        } else if (isPlainRecord(obj)) { // a plain object
             this._walkObject(key, obj, visitor);
         } else { // a random object - we treat it as a value
             visitor.onValue && visitor.onValue(key, obj);
         }
     }
 
-    _walkIterable(key: ObjectKey, obj: any, visitor: ObjectVisitor) {
+    _walkIterable(key: ObjectKey, obj: Iterable<unknown>, visitor: ObjectVisitor) {
         visitor.onStartIteration && visitor.onStartIteration(key, obj);
         let i = 0;
         for (const value of obj) {
@@ -40,7 +61,7 @@ export class ObjectWalker {
         visitor.onEndIteration && visitor.onEndIteration(key, obj);
     }
 
-    _walkObject(key: ObjectKey, obj: any, visitor: ObjectVisitor) {
+    _walkObject(key: ObjectKey, obj: Record<string, unknown>, visitor: ObjectVisitor) {
         visitor.onStartObject && visitor.onStartObject(key, obj);
         for (const k of Object.keys(obj)) {
             this._walk(k, obj[k], visitor);
@@ -48,27 +69,28 @@ export class ObjectWalker {
         visitor.onEndObject && visitor.onEndObject(key, obj);
     }
 
-    map(obj: any, mapFn: (key: ObjectKey, value: any) => any) {
+    map<T = unknown>(obj: unknown, mapFn: (key: ObjectKey, value: unknown) => unknown): T {
         const visitor = new MapVisitor(mapFn);
         this.walk(obj, visitor);
-        return visitor.result;
+        return visitor.result as T;
     }
 }
 
 class MapVisitor implements ObjectVisitor {
-    result: any;
-    current: any;
-    stack: any[] = [];
-    constructor(private mapFn: (key: ObjectKey, value: any) => any) { }
+    result: unknown;
+    current: MutableContainer | undefined;
+    stack: (MutableContainer | undefined)[] = [];
+    constructor(private mapFn: (key: ObjectKey, value: unknown) => unknown) { }
 
     onStartObject(key: ObjectKey) {
         if (key === undefined) {
-            this.result = {};
-            this.current = this.result;
+            const obj: Record<string, unknown> = {};
+            this.result = obj;
+            this.current = obj;
         } else {
             this.stack.push(this.current);
-            const obj = {};
-            this.current[key] = obj;
+            const obj: Record<string, unknown> = {};
+            setValue(this.current, key, obj);
             this.current = obj;
         }
     }
@@ -78,12 +100,13 @@ class MapVisitor implements ObjectVisitor {
 
     onStartIteration(key: ObjectKey) {
         if (key === undefined) {
-            this.result = [];
-            this.current = this.result;
+            const ar: unknown[] = [];
+            this.result = ar;
+            this.current = ar;
         } else {
             this.stack.push(this.current);
-            const ar: any[] = [];
-            this.current[key] = ar;
+            const ar: unknown[] = [];
+            setValue(this.current, key, ar);
             this.current = ar;
         }
     }
@@ -92,12 +115,12 @@ class MapVisitor implements ObjectVisitor {
         this.current = this.stack.pop();
     }
 
-    onValue(key: ObjectKey, value: any) {
+    onValue(key: ObjectKey, value: unknown) {
         const r = this.mapFn(key, value);
         if (key === undefined) {
             this.result = r;
         } else if (r !== undefined) {
-            this.current[key] = r;
+            setValue(this.current, key, r);
         }
     }
 }

--- a/packages/workflow/src/dsl/walk.ts
+++ b/packages/workflow/src/dsl/walk.ts
@@ -40,7 +40,7 @@ export class ObjectWalker {
     _walk(key: ObjectKey, obj: unknown, visitor: ObjectVisitor) {
         const type = typeof obj;
         if (!obj || type !== 'object' || obj instanceof Date) {
-            visitor.onValue && visitor.onValue(key, obj);
+            visitor.onValue?.(key, obj);
         } else if (Array.isArray(obj)) {
             this._walkIterable(key, obj, visitor);
         } else if (this.supportIterators && isIterable(obj)) {
@@ -48,25 +48,25 @@ export class ObjectWalker {
         } else if (isPlainRecord(obj)) { // a plain object
             this._walkObject(key, obj, visitor);
         } else { // a random object - we treat it as a value
-            visitor.onValue && visitor.onValue(key, obj);
+            visitor.onValue?.(key, obj);
         }
     }
 
     _walkIterable(key: ObjectKey, obj: Iterable<unknown>, visitor: ObjectVisitor) {
-        visitor.onStartIteration && visitor.onStartIteration(key, obj);
+        visitor.onStartIteration?.(key, obj);
         let i = 0;
         for (const value of obj) {
             this._walk(i++, value, visitor);
         }
-        visitor.onEndIteration && visitor.onEndIteration(key, obj);
+        visitor.onEndIteration?.(key, obj);
     }
 
     _walkObject(key: ObjectKey, obj: Record<string, unknown>, visitor: ObjectVisitor) {
-        visitor.onStartObject && visitor.onStartObject(key, obj);
+        visitor.onStartObject?.(key, obj);
         for (const k of Object.keys(obj)) {
             this._walk(k, obj[k], visitor);
         }
-        visitor.onEndObject && visitor.onEndObject(key, obj);
+        visitor.onEndObject?.(key, obj);
     }
 
     map<T = unknown>(obj: unknown, mapFn: (key: ObjectKey, value: unknown) => unknown): T {

--- a/packages/workflow/src/dsl/workflow-exec-child.test.ts
+++ b/packages/workflow/src/dsl/workflow-exec-child.test.ts
@@ -70,6 +70,7 @@ const steps2: DSLWorkflowStep[] = [
         name: 'dslWorkflow',
         output: 'child',
         spec: {
+            spec_format: 'steps',
             name: 'testChildWorkflow',
             steps: childSteps,
             vars: {}
@@ -95,6 +96,7 @@ const steps3: DSLWorkflowStep[] = [
         name: 'dslWorkflow',
         output: 'child',
         spec: {
+            spec_format: 'steps',
             name: 'testChildWorkflow',
             steps: childSteps,
             vars: {}
@@ -169,6 +171,7 @@ describe('DSL Workflow with child workflows', () => {
                 store_url: process.env.CP_STORE_URL || "http://localhost:8082",
             },
             workflow: {
+                spec_format: 'steps',
                 steps: steps1,
                 vars: {
                     name,
@@ -213,6 +216,7 @@ describe('DSL Workflow with child workflows', () => {
                 store_url: process.env.CP_STORE_URL || "http://localhost:8082",
             },
             workflow: {
+                spec_format: 'steps',
                 steps: steps2,
                 vars: {
                     name,
@@ -257,6 +261,7 @@ describe('DSL Workflow with child workflows', () => {
                 store_url: process.env.CP_STORE_URL || "http://localhost:8082",
             },
             workflow: {
+                spec_format: 'steps',
                 steps: steps3,
                 vars: {
                     name,

--- a/packages/workflow/src/dsl/workflow-exec-child.test.ts
+++ b/packages/workflow/src/dsl/workflow-exec-child.test.ts
@@ -145,7 +145,7 @@ describe('DSL Workflow with child workflows', () => {
         await testEnv?.teardown();
     });
 
-    test('execute child workflow', async () => {
+    test('should execute child workflow', async () => {
         const { client, nativeConnection } = testEnv;
         const taskQueue = 'test';
 
@@ -190,7 +190,7 @@ describe('DSL Workflow with child workflows', () => {
 
     });
 
-    test('execute DSL child workflow', async () => {
+    test('should execute DSL child workflow', async () => {
         const { client, nativeConnection } = testEnv;
         const taskQueue = 'test';
 
@@ -235,7 +235,7 @@ describe('DSL Workflow with child workflows', () => {
 
     });
 
-    test('execute DSL child workflow with variable resolution', async () => {
+    test('should execute DSL child workflow with variable resolution', async () => {
         const { client, nativeConnection } = testEnv;
         const taskQueue = 'test';
 

--- a/packages/workflow/src/dsl/workflow-fetch.test.ts
+++ b/packages/workflow/src/dsl/workflow-fetch.test.ts
@@ -20,7 +20,7 @@ class DocumentTestProvider extends DataProvider {
         super(DocumentTestProvider.ID, true);
     }
 
-    doFetch(payload: FindPayload): Promise<Record<string, any>[]> {
+    doFetch(payload: FindPayload): Promise<Record<string, unknown>[]> {
         const query = payload.query;
         console.log('query', query);
         if (query.lang === 'en') {
@@ -116,6 +116,7 @@ describe('DSL Workflow', () => {
                 store_url: process.env.CP_STORE_URL || "http://localhost:8082",
             },
             workflow: {
+                spec_format: 'activities',
                 activities,
                 vars: {
                     lang,

--- a/packages/workflow/src/dsl/workflow-fetch.test.ts
+++ b/packages/workflow/src/dsl/workflow-fetch.test.ts
@@ -90,7 +90,7 @@ describe('DSL Workflow', () => {
         await testEnv?.teardown();
     });
 
-    it('successfully completes a mock workflow', async () => {
+    it('should successfully complete a mock workflow', async () => {
         const { client, nativeConnection } = testEnv;
         const taskQueue = 'test';
 

--- a/packages/workflow/src/dsl/workflow-import.test.ts
+++ b/packages/workflow/src/dsl/workflow-import.test.ts
@@ -6,7 +6,7 @@ import { dslWorkflow } from './dsl-workflow.js';
 import { setupActivity } from "./setup/ActivityContext.js";
 
 
-async function testImportedVars(payload: DSLActivityExecutionPayload<Record<string, any>>) {
+async function testImportedVars(payload: DSLActivityExecutionPayload<Record<string, unknown>>) {
     const { params } = await setupActivity(payload);
     if (!params.object_name) throw new Error('object_name is required');
     console.log('!!!!!!!!!!@@@@@@@@@@@@@@!!!!!!!!!!!!!!', params.object_name);
@@ -70,6 +70,7 @@ describe('DSL Workflow import vars', () => {
                 store_url: process.env.CP_STORE_URL || "http://localhost:8082",
             },
             workflow: {
+                spec_format: 'activities',
                 activities,
                 vars: {
                     object_name,

--- a/packages/workflow/src/dsl/workflow-import.test.ts
+++ b/packages/workflow/src/dsl/workflow-import.test.ts
@@ -42,7 +42,7 @@ describe('DSL Workflow import vars', () => {
     });
 
 
-    it('import vars are part of activity params', async () => {
+    it('should include import vars in activity params', async () => {
 
 
         const { client, nativeConnection } = testEnv;

--- a/packages/workflow/src/dsl/workflow.test.ts
+++ b/packages/workflow/src/dsl/workflow.test.ts
@@ -74,7 +74,7 @@ describe('DSL Workflow', () => {
         await testEnv?.teardown();
     });
 
-    it('successfully completes a mock workflow', async () => {
+    it('should successfully complete a mock workflow', async () => {
         const { client, nativeConnection } = testEnv;
         const taskQueue = 'test';
 

--- a/packages/workflow/src/dsl/workflow.test.ts
+++ b/packages/workflow/src/dsl/workflow.test.ts
@@ -6,17 +6,17 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { dslWorkflow } from './dsl-workflow.js';
 import { setupActivity } from "./setup/ActivityContext.js";
 
-async function sayHello(payload: DSLActivityExecutionPayload<Record<string, any>>): Promise<string> {
+async function sayHello(payload: DSLActivityExecutionPayload<Record<string, unknown>>): Promise<string> {
     const { params } = await setupActivity(payload);
     return params.lang === 'fr' ? "Bonjour" : "Hello";
 }
 
-async function sayName(payload: DSLActivityExecutionPayload<Record<string, any>>): Promise<string> {
+async function sayName(payload: DSLActivityExecutionPayload<Record<string, unknown>>): Promise<string> {
     const { params } = await setupActivity(payload);
     return params.lang === 'fr' ? "Monde" : "World";
 }
 
-async function sayGreeting(payload: DSLActivityExecutionPayload<Record<string, any>>): Promise<string> {
+async function sayGreeting(payload: DSLActivityExecutionPayload<Record<string, unknown>>): Promise<string> {
     const { params } = await setupActivity(payload);
     return `${params.hello}, ${params.name}!`;
 }
@@ -100,6 +100,7 @@ describe('DSL Workflow', () => {
                 store_url: process.env.CP_STORE_URL || "http://localhost:8082",
             },
             workflow: {
+                spec_format: 'activities',
                 activities,
                 vars: {
                     lang,

--- a/packages/workflow/src/system/notifyWebhookWorkflow.ts
+++ b/packages/workflow/src/system/notifyWebhookWorkflow.ts
@@ -21,17 +21,21 @@ const {
 export interface NotifyWebhookWorfklowParams {
     workflow_type: string;
     endpoints: (string | WebHookSpec)[],
-    data: Record<string, any>
+    data: Record<string, unknown>
 }
 
 
-export async function notifyWebhookWorkflow(payload: WorkflowExecutionPayload<NotifyWebhookWorfklowParams>): Promise<any> {
+export async function notifyWebhookWorkflow(payload: WorkflowExecutionPayload<NotifyWebhookWorfklowParams>): Promise<unknown> {
 
     const info = workflowInfo();
     const { objectIds, vars } = payload;
     const notifications = [];
-    const endpoints = vars.endpoints ?? (vars as any).webhooks ?? [];
-    const data = vars.data ?? (vars as any).webhook_data ?? undefined;
+    const legacyVars = vars as NotifyWebhookWorfklowParams & {
+        webhooks?: (string | WebHookSpec)[];
+        webhook_data?: Record<string, unknown>;
+    };
+    const endpoints = legacyVars.endpoints ?? legacyVars.webhooks ?? [];
+    const data = legacyVars.data ?? legacyVars.webhook_data ?? undefined;
     const workflow_type = vars.workflow_type ?? info.workflowType;
     const eventName = payload.event;
 

--- a/packages/workflow/src/utils/blobs.ts
+++ b/packages/workflow/src/utils/blobs.ts
@@ -11,14 +11,15 @@ tmp.setGracefulCleanup();
 export async function fetchBlobAsStream(client: VertesiaClient, blobUri: string): Promise<ReadableStream<Uint8Array>> {
     try {
         return await client.files.downloadFile(blobUri);
-    } catch (err: any) {
-        if (err.message.includes("not found")) {
+    } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (message.includes("not found")) {
             //TODO improve error handling with a fetch fail error class in the client
-            throw new DocumentNotFoundError(`Not found at ${blobUri}: ${err.message}`, []);
-        } else if (err.message.includes("forbidden")) {
-            throw new DocumentNotFoundError(`Forbidden at ${blobUri}: ${err.message}`);
+            throw new DocumentNotFoundError(`Not found at ${blobUri}: ${message}`, []);
+        } else if (message.includes("forbidden")) {
+            throw new DocumentNotFoundError(`Forbidden at ${blobUri}: ${message}`);
         } else {
-            throw new Error(`Failed to download blob ${blobUri}: ${err.message}`);
+            throw new Error(`Failed to download blob ${blobUri}: ${message}`);
         }
     }
 }

--- a/packages/workflow/src/utils/client.ts
+++ b/packages/workflow/src/utils/client.ts
@@ -10,12 +10,12 @@ import {
 import { WorkflowExecutionBaseParams } from "@vertesia/common";
 import { WorkflowParamNotFoundError } from "../errors.js";
 
-export function getVertesiaClient(payload: WorkflowExecutionBaseParams) {
+export function getVertesiaClient(payload: WorkflowExecutionBaseParams<unknown>) {
     return new VertesiaClient(getVertesiaClientOptions(payload));
 }
 
 export function getVertesiaClientOptions(
-    payload: WorkflowExecutionBaseParams,
+    payload: WorkflowExecutionBaseParams<unknown>,
 ): VertesiaClientProps {
     if (!payload.auth_token) {
         throw new WorkflowParamNotFoundError(

--- a/packages/workflow/src/utils/expand-vars.ts
+++ b/packages/workflow/src/utils/expand-vars.ts
@@ -7,7 +7,7 @@ const VARS_RX = /\${\s*([^}]+)\s*}/g;
  * @param expr
  * @param vars
  */
-export function expandVars(expr: string, vars: Record<string, any>) {
+export function expandVars(expr: string, vars: Record<string, unknown>) {
     return expr.replace(VARS_RX, (_: string, name: string) => {
         const path = name.split('.');
         const value = resolveProp(vars, path);
@@ -19,10 +19,14 @@ export function expandVars(expr: string, vars: Record<string, any>) {
     });
 }
 
-function resolveProp(object: object, path: string[]) {
-    let value: any = object;
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return !!value && typeof value === 'object';
+}
+
+function resolveProp(object: Record<string, unknown>, path: string[]) {
+    let value: unknown = object;
     for (const part of path) {
-        if (value === undefined) {
+        if (!isRecord(value)) {
             return undefined;
         }
         value = value[part];

--- a/packages/workflow/src/utils/renditions.ts
+++ b/packages/workflow/src/utils/renditions.ts
@@ -105,27 +105,30 @@ export async function uploadRenditionPages(
 
             const result = await client.files
                 .uploadFile(source)
-                .catch((err) => {
+                .catch((err: unknown) => {
+                    const message = err instanceof Error ? err.message : String(err);
+                    const stack = err instanceof Error ? err.stack : undefined;
                     log.error(
                         `Failed to upload rendition for ${contentEtag} page ${i}`,
                         {
                             error: err,
-                            errorMessage: err.message,
-                            stack: err.stack,
+                            errorMessage: message,
+                            stack,
                         },
                     );
-                    return Promise.reject(`Upload failed: ${err.message}`);
+                    return Promise.reject(`Upload failed: ${message}`);
                 });
             log.debug(`Rendition uploaded for ${contentEtag} page ${i}`, {
                 result,
             });
 
             return result;
-        } catch (err: any) {
+        } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : String(err);
             log.error(`Failed to upload rendition for ${contentEtag} page ${i}`, {
                 error: err,
             });
-            return Promise.reject(`Upload failed: ${err.message}`);
+            return Promise.reject(`Upload failed: ${message}`);
         }
     }));
 

--- a/packages/workflow/src/utils/storage.ts
+++ b/packages/workflow/src/utils/storage.ts
@@ -39,7 +39,7 @@ export async function saveAgentArtifact(
     try {
         const source = new NodeStreamSource(fileContent, `${id}-${basename(filePath)}`, mimeType, filePath);
         return await client.files.uploadFile(source);
-    } catch (err: any) {
+    } catch (err: unknown) {
         log.error(`Failed to save agent artifact for run ${id}`, {
             err,
             file: filePath,

--- a/packages/workflow/tsconfig.test.json
+++ b/packages/workflow/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": true,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "lib"
+  ]
+}

--- a/patches/ts-dual-module@0.6.3.patch
+++ b/patches/ts-dual-module@0.6.3.patch
@@ -1,4 +1,5 @@
 diff --git a/lib/build.js b/lib/build.js
+index 5a5de9fcf..1da1f1d04 100644
 --- a/lib/build.js
 +++ b/lib/build.js
 @@ -1,7 +1,9 @@
@@ -21,7 +22,7 @@ diff --git a/lib/build.js b/lib/build.js
      return params;
  }
  export async function build(pkg, args) {
-@@ -105,13 +108,13 @@ export async function build(pkg, args) {
+@@ -105,13 +107,13 @@ export async function build(pkg, args) {
      }
  }
  function _build(params) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ overrides:
   '@protobufjs/utf8@<=1.1.0': ^1.1.1
 
 patchedDependencies:
-  ts-dual-module@0.6.3: fa2655a6470821a60e6e431a2f196a259c9fc67e51c0a71fc38f63017cc4213f
+  ts-dual-module@0.6.3: fb5b155c773bf52a3ebc4991f0bcff2b430cabfe8524bd6089fd0183cb8e7b63
 
 importers:
 
@@ -90,7 +90,7 @@ importers:
         version: 6.1.3
       ts-dual-module:
         specifier: ^0.6.3
-        version: 0.6.3(patch_hash=fa2655a6470821a60e6e431a2f196a259c9fc67e51c0a71fc38f63017cc4213f)
+        version: 0.6.3(patch_hash=fb5b155c773bf52a3ebc4991f0bcff2b430cabfe8524bd6089fd0183cb8e7b63)
       typescript:
         specifier: ^6.0.2
         version: 6.0.3
@@ -124,7 +124,7 @@ importers:
         version: 10.8.2
       ts-dual-module:
         specifier: ^0.6.3
-        version: 0.6.3(patch_hash=fa2655a6470821a60e6e431a2f196a259c9fc67e51c0a71fc38f63017cc4213f)
+        version: 0.6.3(patch_hash=fb5b155c773bf52a3ebc4991f0bcff2b430cabfe8524bd6089fd0183cb8e7b63)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.15.21)(@types/node@25.6.0)(typescript@6.0.3)
@@ -176,7 +176,7 @@ importers:
         version: 4.60.1
       ts-dual-module:
         specifier: ^0.6.3
-        version: 0.6.3(patch_hash=fa2655a6470821a60e6e431a2f196a259c9fc67e51c0a71fc38f63017cc4213f)
+        version: 0.6.3(patch_hash=fb5b155c773bf52a3ebc4991f0bcff2b430cabfe8524bd6089fd0183cb8e7b63)
       typescript:
         specifier: ^6.0.2
         version: 6.0.3
@@ -305,7 +305,7 @@ importers:
         version: 4.60.1
       ts-dual-module:
         specifier: ^0.6.3
-        version: 0.6.3(patch_hash=fa2655a6470821a60e6e431a2f196a259c9fc67e51c0a71fc38f63017cc4213f)
+        version: 0.6.3(patch_hash=fb5b155c773bf52a3ebc4991f0bcff2b430cabfe8524bd6089fd0183cb8e7b63)
       typescript:
         specifier: ^6.0.2
         version: 6.0.3
@@ -339,7 +339,7 @@ importers:
         version: 4.60.1
       ts-dual-module:
         specifier: ^0.6.3
-        version: 0.6.3(patch_hash=fa2655a6470821a60e6e431a2f196a259c9fc67e51c0a71fc38f63017cc4213f)
+        version: 0.6.3(patch_hash=fb5b155c773bf52a3ebc4991f0bcff2b430cabfe8524bd6089fd0183cb8e7b63)
       typescript:
         specifier: ^6.0.2
         version: 6.0.3
@@ -361,7 +361,7 @@ importers:
         version: 0.2.6
       ts-dual-module:
         specifier: ^0.6.3
-        version: 0.6.3(patch_hash=fa2655a6470821a60e6e431a2f196a259c9fc67e51c0a71fc38f63017cc4213f)
+        version: 0.6.3(patch_hash=fb5b155c773bf52a3ebc4991f0bcff2b430cabfe8524bd6089fd0183cb8e7b63)
       typescript:
         specifier: ^6.0.2
         version: 6.0.3
@@ -459,7 +459,7 @@ importers:
         version: 4.60.1
       ts-dual-module:
         specifier: ^0.6.3
-        version: 0.6.3(patch_hash=fa2655a6470821a60e6e431a2f196a259c9fc67e51c0a71fc38f63017cc4213f)
+        version: 0.6.3(patch_hash=fb5b155c773bf52a3ebc4991f0bcff2b430cabfe8524bd6089fd0183cb8e7b63)
       typescript:
         specifier: ^6.0.2
         version: 6.0.3
@@ -568,7 +568,7 @@ importers:
         version: 24.12.2
       ts-dual-module:
         specifier: ^0.6.3
-        version: 0.6.3(patch_hash=fa2655a6470821a60e6e431a2f196a259c9fc67e51c0a71fc38f63017cc4213f)
+        version: 0.6.3(patch_hash=fb5b155c773bf52a3ebc4991f0bcff2b430cabfe8524bd6089fd0183cb8e7b63)
       typescript:
         specifier: ^6.0.2
         version: 6.0.3
@@ -954,7 +954,7 @@ importers:
         version: 0.2.6
       ts-dual-module:
         specifier: ^0.6.3
-        version: 0.6.3(patch_hash=fa2655a6470821a60e6e431a2f196a259c9fc67e51c0a71fc38f63017cc4213f)
+        version: 0.6.3(patch_hash=fb5b155c773bf52a3ebc4991f0bcff2b430cabfe8524bd6089fd0183cb8e7b63)
       vitest:
         specifier: ^4.0.16
         version: 4.0.18(@types/node@24.12.2)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
@@ -13851,7 +13851,7 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
-  ts-dual-module@0.6.3(patch_hash=fa2655a6470821a60e6e431a2f196a259c9fc67e51c0a71fc38f63017cc4213f):
+  ts-dual-module@0.6.3(patch_hash=fb5b155c773bf52a3ebc4991f0bcff2b430cabfe8524bd6089fd0183cb8e7b63):
     dependencies:
       enquirer: 2.4.1
 

--- a/templates/plugin-template/biome.json.template
+++ b/templates/plugin-template/biome.json.template
@@ -25,20 +25,20 @@
     "rules": {
       "recommended": false,
       "correctness": {
-        "noUnusedFunctionParameters": "warn",
-        "noUnusedImports": "warn",
-        "noUnusedVariables": "warn",
+        "noUnusedFunctionParameters": "error",
+        "noUnusedImports": "error",
+        "noUnusedVariables": "error",
         "useExhaustiveDependencies": "warn",
-        "useHookAtTopLevel": "warn"
+        "useHookAtTopLevel": "error"
       },
       "suspicious": {
-        "noExplicitAny": "warn",
-        "noImplicitAnyLet": "warn",
-        "noUnusedExpressions": "off"
+        "noExplicitAny": "error",
+        "noImplicitAnyLet": "error",
+        "noUnusedExpressions": "error"
       },
       "style": {
         "useComponentExportOnlyModules": {
-          "level": "warn",
+          "level": "error",
           "options": {
             "allowConstantExport": true
           }
@@ -57,11 +57,11 @@
         "useButtonType": "error",
         "useFocusableInteractive": "error",
         "useSemanticElements": "error",
-        "useKeyWithClickEvents": "warn",
-        "useKeyWithMouseEvents": "warn",
-        "noStaticElementInteractions": "warn",
-        "useAriaActivedescendantWithTabindex": "warn",
-        "noLabelWithoutControl": "warn"
+        "useKeyWithClickEvents": "error",
+        "useKeyWithMouseEvents": "error",
+        "noStaticElementInteractions": "error",
+        "useAriaActivedescendantWithTabindex": "error",
+        "noLabelWithoutControl": "error"
       }
     }
   },

--- a/templates/plugin-template/rollup.config.js
+++ b/templates/plugin-template/rollup.config.js
@@ -52,6 +52,14 @@ const serverBuild = {
         // Externalize all node modules and absolute imports
         return true;
     },
+    // Treat TypeScript diagnostics from @rollup/plugin-typescript as build errors
+    // instead of warnings, so type issues fail the build.
+    onwarn(warning, defaultHandler) {
+        if (warning.plugin === 'typescript') {
+            throw new Error(warning.message ?? String(warning));
+        }
+        defaultHandler(warning);
+    },
     plugins: [
         vertesiaImportPlugin({
             transformers: [

--- a/templates/plugin-template/rollup.config.widgets.js
+++ b/templates/plugin-template/rollup.config.widgets.js
@@ -78,6 +78,14 @@ const widgetBundles = widgets.map(({ name, path: widgetPath }) => ({
         'react/jsx-dev-runtime',
         'react-dom/client'
     ],
+    // Treat TypeScript diagnostics from @rollup/plugin-typescript as build errors
+    // instead of warnings, so type issues fail the build.
+    onwarn(warning, defaultHandler) {
+        if (warning.plugin === 'typescript') {
+            throw new Error(warning.message ?? String(warning));
+        }
+        defaultHandler(warning);
+    },
     plugins: [
         typescript({
             tsconfig: './tsconfig.widgets.json',

--- a/templates/plugin-template/src/tool-server/activities/examples/word_count/word_count.ts
+++ b/templates/plugin-template/src/tool-server/activities/examples/word_count/word_count.ts
@@ -18,7 +18,7 @@ export async function wordCount(
     payload: RemoteActivityExecutionPayload,
     _context: ActivityExecutionContext
 ): Promise<WordCountResult> {
-    const { text } = payload.params as WordCountParams;
+    const text = payload.params.text;
     if (!text || typeof text !== 'string') {
         throw new Error('Missing or invalid "text" parameter');
     }

--- a/templates/plugin-template/src/ui/app/layouts/PluginSidebar.tsx
+++ b/templates/plugin-template/src/ui/app/layouts/PluginSidebar.tsx
@@ -35,7 +35,9 @@ function getConversationLabel(
     formatTime: (date: Date | string | number | null | undefined) => string,
 ): string {
     if (conv.topic) return conv.topic;
-    const prompt = conv.input?.data?.user_prompt;
+    const input = typeof conv.input === 'object' && conv.input !== null ? conv.input as { data?: unknown } : undefined;
+    const inputData = typeof input?.data === 'object' && input.data !== null ? input.data as Record<string, unknown> : undefined;
+    const prompt = inputData?.user_prompt;
     if (typeof prompt === 'string' && prompt.trim()) return prompt.trim();
     if (conv.started_at) return formatTime(conv.started_at);
     return t('nav.conversation');

--- a/templates/plugin-template/vite-api-server.ts
+++ b/templates/plugin-template/vite-api-server.ts
@@ -23,6 +23,10 @@ import {
     rawTransformer,
 } from '@vertesia/build-tools';
 
+interface HonoApp {
+    fetch: (request: Request, env?: unknown, executionCtx?: unknown) => Response | Promise<Response>;
+}
+
 export interface ApiServerPluginOptions {
     /**
      * The tool server entry point (TypeScript source).
@@ -101,7 +105,7 @@ function createDevListener(server: ViteDevServer, entry: string) {
 
         try {
             const mod = await server.ssrLoadModule(entry);
-            const app = mod.default;
+            const app = mod.default as HonoApp;
             const requestListener = getRequestListener(app.fetch);
             requestListener(req, res);
         } catch (e) {
@@ -116,7 +120,7 @@ function createDevListener(server: ViteDevServer, entry: string) {
  */
 function createPreviewListener(compiledEntry: string) {
     // Cache the app — no hot reload in preview mode
-    let appPromise: Promise<any> | null = null;
+    let appPromise: Promise<HonoApp> | null = null;
 
     return async (
         req: Parameters<Connect.NextHandleFunction>[0],
@@ -145,6 +149,6 @@ declare namespace Connect {
     type NextHandleFunction = (
         req: import('node:http').IncomingMessage,
         res: import('node:http').ServerResponse,
-        next: (err?: any) => void,
+        next: (err?: unknown) => void,
     ) => void;
 }

--- a/tools/environment-configuration/src/gcp-vertex-ai.ts
+++ b/tools/environment-configuration/src/gcp-vertex-ai.ts
@@ -106,7 +106,7 @@ const getOrCreatePool = async (
   projectId: string,
   poolName: string,
 ) => {
-  let pool;
+  let pool: unknown;
 
   try {
     const { data } = await gcp.request({
@@ -164,7 +164,7 @@ const getOrCreateProvider = async (
   stsUrl?: string,
 ) => {
   // check if provider already exists. if not create it
-  let provider;
+  let provider: unknown;
 
   try {
     const { data } = await gcp.request({


### PR DESCRIPTION
## Summary
- Apply the same `any` → `unknown` migration as llumiverse across @vertesia/common, client, ui packages
- Resolve a11y warnings (56→0): icon-only buttons get `aria-label`, form controls go through `<FormItem>` with `helpText`/`error`, table headers use semantic components, deprecated `Button.alt`/`CopyButton.alt` props removed in favour of `aria-label`
- Add `tsconfig.test.json` + `typecheck:test` script in all packages
- Wire `typecheck:test` into CI
- Fix `useExhaustiveDependencies` and `useHookAtTopLevel` lint errors
- Add `none` size variant to `<Button>` and `onActivateKey` keyboard handler helper for accessible clickable wrappers
- Update llumiverse submodule (lint cleanup, any removal, test typecheck)

## Submodule Changes
- llumiverse: https://github.com/vertesia/llumiverse/pull/408

## Verification
- `pnpm lint` — 0 errors (195 warnings remain, all `useExhaustiveDependencies` advisories)
- `pnpm typecheck:test` — 0 errors across all packages
- `pnpm test` — all tests pass (including vitest-axe a11y regression tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>