### PR TITLE
chore: lint and pin GitHub workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,5 @@ updates:
       github-actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Actions are pinned to commit SHAs; Dependabot updates the SHA + version comment.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/code-sync.yaml
+++ b/.github/workflows/code-sync.yaml
@@ -48,7 +48,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export SOURCE_COMPOSABLEAI_REF="${FROM_BRANCH}"
-          export SOURCE_COMPOSABLEAI_SHA="$(git rev-parse 'origin/${FROM_BRANCH}')"
+          export SOURCE_COMPOSABLEAI_SHA="$(git rev-parse "origin/${FROM_BRANCH}")"
           export SOURCE_COMPOSABLEAI_MSG="$(git log --format="%cd: %s by %an" --date=short -1 $SOURCE_COMPOSABLEAI_SHA)"
 
           export SOURCE_LLUMIVERSE_REF="main"

--- a/.github/workflows/code-sync.yaml
+++ b/.github/workflows/code-sync.yaml
@@ -19,12 +19,14 @@ env:
   FROM_BRANCH: ${{ inputs.from_branch || github.ref_name }}
 
 permissions:
-  contents: write # required for pushing changes to the repository
-  pull-requests: write # required for creating pull requests
+  contents: read
 
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # required for pushing changes to the repository
+      pull-requests: write # required for creating pull requests
     outputs:
       is_merged: ${{ steps.sync.outputs.IS_MERGED }}
       pr_number: ${{ steps.sync.outputs.PR_NUMBER }}
@@ -38,14 +40,15 @@ jobs:
           fetch-depth: 0 # Fetch all because we need to access info from different branches
           fetch-tags: false
           submodules: recursive
+          persist-credentials: false
 
       - name: Code Sync
         id: sync
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          export SOURCE_COMPOSABLEAI_REF="${{ env.FROM_BRANCH }}"
-          export SOURCE_COMPOSABLEAI_SHA="$(git rev-parse 'origin/${{ env.FROM_BRANCH }}')"
+          export SOURCE_COMPOSABLEAI_REF="${FROM_BRANCH}"
+          export SOURCE_COMPOSABLEAI_SHA="$(git rev-parse 'origin/${FROM_BRANCH}')"
           export SOURCE_COMPOSABLEAI_MSG="$(git log --format="%cd: %s by %an" --date=short -1 $SOURCE_COMPOSABLEAI_SHA)"
 
           export SOURCE_LLUMIVERSE_REF="main"
@@ -93,7 +96,7 @@ jobs:
             echo "IS_MERGED=true" >> $GITHUB_OUTPUT
           elif [ $is_sync_result -eq 2 ]; then
             echo "Code sync failed because merge conflicts cannot be resolved automatically."
-            echo "Preparing a PR and asking the author [${{ github.actor }}] to handle the synchronization..."
+            echo "Preparing a PR and asking the author [${GITHUB_ACTOR}] to handle the synchronization..."
 
             git push origin $TEMP_BRANCH
 
@@ -156,6 +159,8 @@ jobs:
       - sync
     if: ${{ needs.sync.outputs.is_merged == 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # required for pushing changes to the repository
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -165,6 +170,7 @@ jobs:
           ref: ${{ needs.sync.outputs.sync_ref }}
           ssh-key: ${{ secrets.DEPLOY_KEY }} # Use deploy key to bypass branch protection rules
           submodules: recursive
+          persist-credentials: false
 
       - name: Push changes to main branch
         run: |
@@ -178,9 +184,11 @@ jobs:
           # note: --ff-only ensures that the merge will only succeed if it can be fast-forwarded. This avoids creating
           # a merge commit and keeps the history clean. If failed, user should trigger the workflow again, or resolving
           # conflicts and then sync manually.
-          git merge --ff-only --no-edit ${{ needs.sync.outputs.sync_ref }}
+          git merge --ff-only --no-edit ${NEEDS_SYNC_OUTPUTS_SYNC_REF}
 
           git push origin main
+        env:
+          NEEDS_SYNC_OUTPUTS_SYNC_REF: ${{ needs.sync.outputs.sync_ref }}
 
   notify:
     runs-on: ubuntu-latest
@@ -200,7 +208,7 @@ jobs:
             -d '{
               "event_type": "developer-notification",
               "client_payload": {
-                "github_login": "${{ github.actor }}",
+                "github_login": "${GITHUB_ACTOR}",
                 "message": "Your changes from `preview` have been synced to `main` in vertesia/composableai. See the <https://github.com/vertesia/composableai/actions/runs/${{ github.run_id }}|Action run>."
               }
             }'
@@ -222,10 +230,12 @@ jobs:
             -d '{
               "event_type": "developer-notification",
               "client_payload": {
-                "github_login": "${{ github.actor }}",
-                "message": "Your changes from `preview` failed to sync to `main` in vertesia/composableai due to merge conflicts. Please resolve this PR: ${{ needs.sync.outputs.pr_url }}"
+                "github_login": "${GITHUB_ACTOR}",
+                "message": "Your changes from `preview` failed to sync to `main` in vertesia/composableai due to merge conflicts. Please resolve this PR: ${NEEDS_SYNC_OUTPUTS_PR_URL}"
               }
             }'
+        env:
+          NEEDS_SYNC_OUTPUTS_PR_URL: ${{ needs.sync.outputs.pr_url }}
 
   cleanup:
     runs-on: ubuntu-latest
@@ -234,6 +244,8 @@ jobs:
       - push
     # Always run cleanup except when there is a conflict PR that needs the branch to stay alive.
     if: ${{ always() && needs.sync.outputs.should_cleanup != 'false' }}
+    permissions:
+      contents: write # required for deleting the temporary branch
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -241,11 +253,14 @@ jobs:
           fetch-depth: 0 # Fetch all because we need to access info from different branches
           fetch-tags: false
           submodules: recursive
+          persist-credentials: false
 
       - name: Cleanup temporary branch
         run: |
           set -x
 
-          TEMP_BRANCH="${{ needs.sync.outputs.sync_ref }}"
+          TEMP_BRANCH="${NEEDS_SYNC_OUTPUTS_SYNC_REF}"
           git branch -D $TEMP_BRANCH || true # Ignore if branch does not exist
           git push origin --delete $TEMP_BRANCH || true # Ignore if branch does not exist
+        env:
+          NEEDS_SYNC_OUTPUTS_SYNC_REF: ${{ needs.sync.outputs.sync_ref }}

--- a/.github/workflows/code-sync.yaml
+++ b/.github/workflows/code-sync.yaml
@@ -33,7 +33,7 @@ jobs:
       sync_ref: ${{ steps.sync.outputs.SYNC_REF }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # Fetch all because we need to access info from different branches
           fetch-tags: false
@@ -158,7 +158,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # Fetch all because we need to access info from different branches
           fetch-tags: false
@@ -236,7 +236,7 @@ jobs:
     if: ${{ always() && needs.sync.outputs.should_cleanup != 'false' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # Fetch all because we need to access info from different branches
           fetch-tags: false

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+          persist-credentials: false
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,11 +11,11 @@ jobs:
     name: Lint codebase
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,16 +10,16 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: "pnpm"
       - name: Install pandoc
-        uses: pandoc/actions/setup@main
+        uses: pandoc/actions/setup@86321b6dd4675f5014c611e05088e10d4939e09e # v1.1.1
       - name: Install native test dependencies
         run: |
           sudo apt-get update
@@ -34,11 +34,11 @@ jobs:
   template-smoke-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: "pnpm"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+          persist-credentials: false
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -37,6 +38,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+          persist-credentials: false
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -68,7 +70,7 @@ jobs:
               "event_type": "update-git-submodule-request",
               "client_payload": {
                 "composableai_sha": "${{ github.sha }}",
-                "branch": "${{ github.ref_name }}",
-                "sender": "${{ github.actor }}"
+                "branch": "${GITHUB_REF_NAME}",
+                "sender": "${GITHUB_ACTOR}"
               }
             }'

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -36,13 +36,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
           ssh-key: ${{ secrets.DEPLOY_KEY }} # Use deploy key to bypass branch protection rules
 
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
@@ -84,9 +84,9 @@ jobs:
     needs: publish
     if: inputs.dry_run == false
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
 

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -27,19 +27,22 @@ on:
         default: true
 
 permissions:
-  id-token: write # Required for OIDC between GitHub and NPM
-  contents: write # Required to push version changes for preview
+  contents: read
 
 jobs:
   publish:
     name: Publish all packages
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for OIDC between GitHub and NPM
+      contents: write # Required to push version changes for preview
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
           ssh-key: ${{ secrets.DEPLOY_KEY }} # Use deploy key to bypass branch protection rules
+          persist-credentials: false
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -58,7 +61,7 @@ jobs:
       - name: Publish all packages
         run: |
           ./.github/bin/publish-all-packages.sh \
-              --ref "${{ github.ref_name }}" \
+              --ref "${GITHUB_REF_NAME}" \
               --release-type "${{ inputs.release_type }}" \
               --bump-type "${{ inputs.bump_type }}" \
               --dry-run "${{ inputs.dry_run }}"
@@ -85,6 +88,8 @@ jobs:
     if: inputs.dry_run == false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -92,9 +97,8 @@ jobs:
 
       - name: Smoke test - Plugin
         run: ./.github/bin/test-template-smoke.sh --release-type "${{
-          inputs.release_type }}" --template "Vertesia Plugin" --branch "${{
-          github.ref_name }}" --wait
+          inputs.release_type }}" --template "Vertesia Plugin" --branch "${GITHUB_REF_NAME}" --wait
       - name: Smoke test - Tool Server (deprecated)
         run: ./.github/bin/test-template-smoke.sh --release-type "${{
           inputs.release_type }}" --template "Vertesia Tool Server (deprecated)"
-          --branch "${{ github.ref_name }}" --wait
+          --branch "${GITHUB_REF_NAME}" --wait

--- a/.github/workflows/update-git-submodule.yaml
+++ b/.github/workflows/update-git-submodule.yaml
@@ -23,12 +23,14 @@ env:
   TARGET_COMPOSABLEAI_BRANCH: ${{ inputs.branch || github.event.client_payload.branch }}
 
 permissions:
-  contents: write # required for pushing changes to the repository, deleting old branches
-  pull-requests: write # required for creating new pull requests and closing old ones
+  contents: read
 
 jobs:
   update-submodule:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write       # required for pushing changes and deleting old branches
+      pull-requests: write  # required for creating new PRs and closing old ones
     steps:
       - name: Validate branch
         run: |

--- a/.github/workflows/update-git-submodule.yaml
+++ b/.github/workflows/update-git-submodule.yaml
@@ -32,11 +32,11 @@ jobs:
     steps:
       - name: Validate branch
         run: |
-          if [[ "${{ env.TARGET_COMPOSABLEAI_BRANCH }}" != "main" && "${{ env.TARGET_COMPOSABLEAI_BRANCH }}" != "preview" ]]; then
-            echo "::error::Invalid branch '${{ env.TARGET_COMPOSABLEAI_BRANCH }}'. Only 'main' and 'preview' branches are supported."
+          if [[ "${TARGET_COMPOSABLEAI_BRANCH}" != "main" && "${TARGET_COMPOSABLEAI_BRANCH}" != "preview" ]]; then
+            echo "::error::Invalid branch '${TARGET_COMPOSABLEAI_BRANCH}'. Only 'main' and 'preview' branches are supported."
             exit 1
           fi
-          echo "Branch '${{ env.TARGET_COMPOSABLEAI_BRANCH }}' is valid."
+          echo "Branch '${TARGET_COMPOSABLEAI_BRANCH}' is valid."
 
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -44,6 +44,7 @@ jobs:
           submodules: recursive
           fetch-depth: 0 # Fetch all history to ensure we can access the specified commit
           ref: ${{ env.TARGET_COMPOSABLEAI_BRANCH }}
+          persist-credentials: false
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -56,7 +57,7 @@ jobs:
         run: |
           current_llumiverse_sha="$(git ls-tree --format='%(objectname)' HEAD llumiverse)"
 
-          if [ "$current_llumiverse_sha" = "${{ env.TARGET_LLUMIVERSE_SHA }}" ]; then
+          if [ "$current_llumiverse_sha" = "${TARGET_LLUMIVERSE_SHA}" ]; then
             echo "No update needed. Submodule 'llumiverse' is already at target SHA."
             echo "skip=true" >> $GITHUB_OUTPUT
           else
@@ -69,10 +70,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "Fetching pull requests with labels: [branch:${{ env.TARGET_COMPOSABLEAI_BRANCH }}] and [workflow:update-llumiverse]..."
+          echo "Fetching pull requests with labels: [branch:${TARGET_COMPOSABLEAI_BRANCH}] and [workflow:update-llumiverse]..."
           pr_list=$(gh pr list \
             --repo vertesia/composableai \
-            --label branch:${{ env.TARGET_COMPOSABLEAI_BRANCH }} \
+            --label branch:${TARGET_COMPOSABLEAI_BRANCH} \
             --label workflow:update-llumiverse \
             --state open \
             --json number,title \
@@ -172,8 +173,8 @@ jobs:
           new_pr_url=$(gh pr create \
               --title "chore: update llumiverse to ${TARGET_LLUMIVERSE_SHA::7}" \
               --body "${pr_body}" \
-              --base ${{ env.TARGET_COMPOSABLEAI_BRANCH }} \
-              --label "branch:${{ env.TARGET_COMPOSABLEAI_BRANCH }}" \
+              --base ${TARGET_COMPOSABLEAI_BRANCH} \
+              --label "branch:${TARGET_COMPOSABLEAI_BRANCH}" \
               --label "workflow:update-llumiverse")
           new_pr_number=$(echo "$new_pr_url" | grep -oP '(?<=pull/)\d+')
 
@@ -190,9 +191,11 @@ jobs:
         if: ${{ steps.precheck.outputs.skip != 'true' && steps.update-submodule.outputs.author_login }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STEPS_UPDATE_SUBMODULE_OUTPUTS_NEW_PR_NUMBER: ${{ steps.update-submodule.outputs.new_pr_number }}
+          STEPS_UPDATE_SUBMODULE_OUTPUTS_AUTHOR_LOGIN: ${{ steps.update-submodule.outputs.author_login }}
         run: |
-          gh pr edit "${{ steps.update-submodule.outputs.new_pr_number }}" \
-            --add-assignee "${{ steps.update-submodule.outputs.author_login }}"
+          gh pr edit "${STEPS_UPDATE_SUBMODULE_OUTPUTS_NEW_PR_NUMBER}" \
+            --add-assignee "${STEPS_UPDATE_SUBMODULE_OUTPUTS_AUTHOR_LOGIN}"
 
       - name: Notify studio for Slack notification
         # Dispatch to the private studio repo so it can look up the developer's
@@ -209,7 +212,10 @@ jobs:
             -d '{
               "event_type": "composableai-pr-notification",
               "client_payload": {
-                "github_login": "${{ steps.update-submodule.outputs.author_login }}",
-                "message": "Please review this PR which brings your llumiverse changes to composableai: ${{ steps.update-submodule.outputs.new_pr_url }}"
+                "github_login": "${STEPS_UPDATE_SUBMODULE_OUTPUTS_AUTHOR_LOGIN}",
+                "message": "Please review this PR which brings your llumiverse changes to composableai: ${STEPS_UPDATE_SUBMODULE_OUTPUTS_NEW_PR_URL}"
               }
             }'
+        env:
+          STEPS_UPDATE_SUBMODULE_OUTPUTS_AUTHOR_LOGIN: ${{ steps.update-submodule.outputs.author_login }}
+          STEPS_UPDATE_SUBMODULE_OUTPUTS_NEW_PR_URL: ${{ steps.update-submodule.outputs.new_pr_url }}

--- a/.github/workflows/update-git-submodule.yaml
+++ b/.github/workflows/update-git-submodule.yaml
@@ -39,14 +39,14 @@ jobs:
           echo "Branch '${{ env.TARGET_COMPOSABLEAI_BRANCH }}' is valid."
 
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
           fetch-depth: 0 # Fetch all history to ensure we can access the specified commit
           ref: ${{ env.TARGET_COMPOSABLEAI_BRANCH }}
 
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -20,12 +20,13 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          submodules: recursive
           persist-credentials: false
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Run zizmor
-        run: uvx zizmor@1.24.1 --format=sarif . > results.sarif
+        run: uvx zizmor@1.24.1 --persona=auditor --format=sarif .github llumiverse/.github > results.sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Run zizmor
-        run: uvx zizmor@1.24.1 --persona=auditor --format=sarif .github llumiverse/.github > results.sarif
+        run: uvx zizmor@1.24.1 --no-exit-codes --persona=auditor --format=sarif .github llumiverse/.github > results.sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Pin composableai GitHub Actions to immutable commit SHAs and add Dependabot coverage for GitHub Actions updates.
- Scope workflow permissions in code-sync and publish workflows so write tokens are only granted to the jobs that need them.
- Simplify the pre-commit hook to run the repository lint command directly.
- Update the llumiverse submodule to include its workflow pinning and lint fixes.

## Submodule Changes
- llumiverse: https://github.com/vertesia/llumiverse/pull/410

## Test Plan
- [x] `zizmor --no-progress --format json .github playwright-tests/.github composableai/.github composableai/llumiverse/.github`
- [x] `git diff --check` from `composableai`
- [ ] Package build/tests not run; changes are limited to workflow metadata, Dependabot configuration, the pre-commit hook, and the llumiverse submodule pointer.
