### PR TITLE
Fix React hook dependency lint

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -88,7 +88,7 @@
       "linter": {
         "rules": {
           "correctness": {
-            "useExhaustiveDependencies": "warn",
+            "useExhaustiveDependencies": "error",
             "useHookAtTopLevel": "error"
           }
         }

--- a/packages/react/src/useInteractionStreaming.ts
+++ b/packages/react/src/useInteractionStreaming.ts
@@ -23,7 +23,7 @@ export function useInteractionStreaming<TProps>(interaction: InteractionBase<TPr
         }).finally(() => {
             chunks = []
         });
-    }, []);
+    }, [interaction.execute, isRunning]);
 
     return { text, isRunning, execute }
 }

--- a/packages/ui/src/core/components/ComboBox.tsx
+++ b/packages/ui/src/core/components/ComboBox.tsx
@@ -126,12 +126,12 @@ export function ComboBox<T>({ menuAlign = "fill", menuGap, focusOnMount, onSelec
         if (inputRef.current) {
             if (focusOnMount) inputRef.current.focus();
         }
-    }, [inputRef.current]);
+    }, [focusOnMount]);
     // the onSelect callback may change so we need to refresh it.
     useEffect(() => {
         ctrl.onSelect = onSelect
         ctrl.popupCtrl = popupCtrl.current;
-    }, [onSelect, popupCtrl.current]);
+    }, [ctrl, onSelect]);
     useEffect(() => {
         if (api && ctrl && inputRef.current) {
             api.current = {
@@ -147,7 +147,7 @@ export function ComboBox<T>({ menuAlign = "fill", menuGap, focusOnMount, onSelec
                 api.current = null;
             }
         }
-    }, [api, ctrl, inputRef.current]);
+    }, [api, ctrl]);
 
     const showMenu = ctrl.isMenuOpen && (ctrl.filteredItems.length > 0 || !!noMatchMessage);
 
@@ -275,7 +275,7 @@ export function useComboboxCtrl<ItemT>(props: ComboboxControllerProps<ItemT>): C
     const [ctrl, setCtrl] = useState<ComboboxController<ItemT>>(new ComboboxController(props));
     useEffect(() => {
         ctrl?.withState(setCtrl);
-    }, []);
+    }, [ctrl]);
     return ctrl;
 }
 

--- a/packages/ui/src/core/components/Portal.tsx
+++ b/packages/ui/src/core/components/Portal.tsx
@@ -22,7 +22,7 @@ export function Portal({ children }: PortalProps) {
             }
             setPortalEl(portalEl);
         }
-    }, [tempNode.current]);
+    }, []);
 
     if (portalEl) {
         return createPortal(children, portalEl);

--- a/packages/ui/src/core/components/TagsInput.tsx
+++ b/packages/ui/src/core/components/TagsInput.tsx
@@ -80,11 +80,6 @@ function TagsInputContent({
     // Total number of items (filtered options + create option if shown)
     const totalItems = filteredOptions.length + (showCreateOption ? 1 : 0);
 
-    // Reset highlighted index when filtered options change
-    useEffect(() => {
-        setHighlightedIndex(0);
-    }, [searchTerm, showCreateOption]);
-
     // Clear pending delete when user starts typing
     useEffect(() => {
         if (searchTerm !== '') {
@@ -94,7 +89,7 @@ function TagsInputContent({
 
     // Scroll highlighted item into view
     useEffect(() => {
-        if (isOpen && highlightedItemRef.current && dropdownRef.current) {
+        if (isOpen && highlightedIndex >= 0 && highlightedItemRef.current && dropdownRef.current) {
             highlightedItemRef.current.scrollIntoView({
                 block: 'nearest',
                 behavior: 'smooth'
@@ -294,7 +289,10 @@ function TagsInputContent({
                         ref={inputRef}
                         type="text"
                         value={searchTerm}
-                        onChange={(e) => setSearchTerm(e.target.value)}
+                        onChange={(e) => {
+                            setSearchTerm(e.target.value);
+                            setHighlightedIndex(0);
+                        }}
                         onKeyDown={handleKeyDown}
                         onClick={handleInputClick}
                         onFocus={handleInputFocus}

--- a/packages/ui/src/core/components/popup/Popup.tsx
+++ b/packages/ui/src/core/components/popup/Popup.tsx
@@ -26,26 +26,35 @@ interface DOMPopupProps extends Omit<PopupControllerOptions, 'anchor' | 'popup' 
     children: ReactNode | ReactNode[];
     ctrlRef?: MutableRefObject<PopupController | undefined>;
 }
-export function DOMPopup({ ctrlRef, id, constraints, isOpen, children, className, onClose, zIndex, position, ...props }: DOMPopupProps) {
+export function DOMPopup({ ctrlRef, id, constraints, isOpen, children, className, onClose, onOpen, zIndex, position, anchor, root, closeOnClick, closeOnEsc, blockPageScroll }: DOMPopupProps) {
     const popupRef = useRef<HTMLDivElement>(null);
     const [ctrl, setCtrl] = useState<PopupController | undefined>();
+    const onCloseRef = useRef(onClose);
+    const onOpenRef = useRef(onOpen);
+    onCloseRef.current = onClose;
+    onOpenRef.current = onOpen;
     useEffect(() => {
-        if (!props.anchor) throw new Error("Anchor element is required");
+        if (!anchor) throw new Error("Anchor element is required");
         const _ctrl = new PopupController({
-            ...props,
-            onClose
+            anchor,
+            root,
+            closeOnClick,
+            closeOnEsc,
+            blockPageScroll,
+            onClose: () => onCloseRef.current?.(),
+            onOpen: () => onOpenRef.current?.()
         });
         setCtrl(_ctrl);
         return () => {
             _ctrl.tryClose();
         }
-    }, []);
+    }, [anchor, blockPageScroll, closeOnClick, closeOnEsc, root]);
 
     useEffect(() => {
         if (ctrlRef) {
             ctrlRef.current = ctrl;
         }
-    }, [ctrl]);
+    }, [ctrl, ctrlRef]);
 
     // effect to open / close the popup
     useEffect(() => {
@@ -62,7 +71,7 @@ export function DOMPopup({ ctrlRef, id, constraints, isOpen, children, className
             // and the popupRef was destroyed by the isOpen && below
             ctrl.close();
         }
-    }, [isOpen, ctrl, popupRef.current]);
+    }, [constraints, isOpen, ctrl]);
 
     return (
         <PopupContext.Provider value={ctrl}>

--- a/packages/ui/src/core/components/shadcn/button.tsx
+++ b/packages/ui/src/core/components/shadcn/button.tsx
@@ -21,7 +21,7 @@ function useDeprecationWarning(propName: string, isUsed: boolean, message: strin
       warnedDeprecatedProps.add(propName)
       console.warn(`[@vertesia/ui] ${propName} is deprecated: ${message}`)
     }
-  }, [isUsed])
+  }, [isUsed, message, propName])
 }
 
 const buttonVariants = cva(

--- a/packages/ui/src/core/components/shadcn/filters/filterBar.tsx
+++ b/packages/ui/src/core/components/shadcn/filters/filterBar.tsx
@@ -41,6 +41,7 @@ interface FilterProviderProps {
 const FilterProvider = ({ filters, setFilters, filterGroups, children, inModal }: FilterProviderProps) => {
   const url = new URL(window.location.href);
   const searchParams = url.searchParams;
+  const searchParamsString = searchParams.toString();
   const [initialFiltersParam] = React.useState(() => new URLSearchParams(window.location.search).get('filters'));
   const processedUrlFilters = React.useRef<Set<string>>(new Set());
   const hasRestoredFromUrl = React.useRef(inModal || !initialFiltersParam);
@@ -49,7 +50,7 @@ const FilterProvider = ({ filters, setFilters, filterGroups, children, inModal }
     if (inModal) return;
     if (!hasRestoredFromUrl.current) return;
     try {
-      const params = new URLSearchParams(searchParams.toString());
+      const params = new URLSearchParams(searchParamsString);
       if (filters.length > 0) {
         const filterString = filters.map(filter => {
           let values: string;
@@ -85,7 +86,7 @@ const FilterProvider = ({ filters, setFilters, filterGroups, children, inModal }
     } catch (error) {
       console.error("Failed to update URL with filters:", error);
     }
-  }, [filters]);
+  }, [filters, inModal, searchParamsString]);
 
   useEffect(() => {
     if (inModal || !initialFiltersParam || filterGroups.length === 0) return;
@@ -159,7 +160,7 @@ const FilterProvider = ({ filters, setFilters, filterGroups, children, inModal }
     } catch (_error) {
       // ignore parse errors
     }
-  }, [filterGroups, initialFiltersParam]);
+  }, [filterGroups, inModal, initialFiltersParam, setFilters]);
 
   return (
     <FilterContext.Provider value={{ filters, setFilters, filterGroups }}>

--- a/packages/ui/src/core/components/shadcn/tabs.tsx
+++ b/packages/ui/src/core/components/shadcn/tabs.tsx
@@ -93,7 +93,7 @@ const Tabs = ({
     if (currentValue && currentValue !== value) {
       setValue(currentValue);
     }
-  }, [current]);
+  }, [current, value]);
 
   // Listen to hash changes only when there's no current prop being controlled externally
   React.useEffect(() => {
@@ -119,7 +119,7 @@ const Tabs = ({
     return () => window.removeEventListener('hashchange', handleHashChange);
   }, [current, visibleTabs, defaultValue]);
 
-  const handleValueChange = (newValue: string) => {
+  const handleValueChange = React.useCallback((newValue: string) => {
     setValue(newValue);
 
     // Update the URL hash when tab changes (only if updateHash is true and not controlled by parent)
@@ -133,7 +133,7 @@ const Tabs = ({
     if (onTabChange) {
       onTabChange(newValue);
     }
-  };
+  }, [current, onTabChange, updateHash]);
 
   const setTab = React.useCallback((tabName: string) => {
     handleValueChange(tabName);

--- a/packages/ui/src/core/components/shadcn/textarea.tsx
+++ b/packages/ui/src/core/components/shadcn/textarea.tsx
@@ -38,7 +38,7 @@ function Textarea({ className, minLines, maxLines, value, ...props }: TextareaPr
 
   useLayoutEffect(() => {
     if (growing) resize()
-  }, [value, growing, resize])
+  })
 
   return (
     <textarea

--- a/packages/ui/src/core/components/toast/NotificationPanel.tsx
+++ b/packages/ui/src/core/components/toast/NotificationPanel.tsx
@@ -1,6 +1,6 @@
 import { AnimatePresence, motion } from "framer-motion"
 import { CircleCheck, AlertTriangle, Info, CircleX, X } from "lucide-react"
-import { useEffect, useState, useRef } from "react"
+import { useCallback, useEffect, useState, useRef } from "react"
 import { ToastProps } from "./ToastProps.js"
 
 const icons = {
@@ -25,26 +25,24 @@ export function NotificationPanel({ data, onClose }: NotificationPanelProps) {
     const [show, setShow] = useState(true)
     const timeoutRef = useRef<NodeJS.Timeout | null>(null)
 
-    const resetTimeout = () => {
-        if (timeoutRef.current) {
-            globalThis.clearTimeout(timeoutRef.current)
-        }
-        if (data.duration) {
-            timeoutRef.current = setTimeout(() => setShow(false), data.duration)
-        }
-    }
-
-    const clearCurrentTimeout = () => {
+    const clearCurrentTimeout = useCallback(() => {
         if (timeoutRef.current) {
             globalThis.clearTimeout(timeoutRef.current)
             timeoutRef.current = null
         }
-    }
+    }, [])
+
+    const resetTimeout = useCallback(() => {
+        clearCurrentTimeout()
+        if (data.duration) {
+            timeoutRef.current = setTimeout(() => setShow(false), data.duration)
+        }
+    }, [clearCurrentTimeout, data.duration])
 
     useEffect(() => {
         resetTimeout()
         return clearCurrentTimeout
-    }, [data.duration])
+    }, [clearCurrentTimeout, resetTimeout])
 
     const Icon = icons[data.status] || Info;
     const color = colors[data.status] || 'text-info';

--- a/packages/ui/src/core/hooks/useClickOutside.tsx
+++ b/packages/ui/src/core/hooks/useClickOutside.tsx
@@ -18,12 +18,13 @@ export function useClickOutside<T extends HTMLElement>(callback: (e: MouseEvent)
         }
         // add te listener just after the render to avoid the callback to be called on the current click
         // if you are in a click context
-        window.setTimeout(() => {
+        const timeoutId = window.setTimeout(() => {
             document.addEventListener('click', handleClick);
         }, 0);
         return () => {
+            window.clearTimeout(timeoutId);
             document.removeEventListener('click', handleClick);
         }
-    }, [])
+    }, [callback, skipFn])
     return ref;
 }

--- a/packages/ui/src/core/hooks/useDarkMode.ts
+++ b/packages/ui/src/core/hooks/useDarkMode.ts
@@ -7,5 +7,5 @@ export function useDarkMode(cb: (isDarkMode: boolean) => unknown) {
         mediaQuery.addEventListener('change', _cb);
         cb(mediaQuery.matches);
         return () => mediaQuery.removeEventListener('change', _cb);
-    }, []);
+    }, [cb]);
 }

--- a/packages/ui/src/core/hooks/useEventSource.ts
+++ b/packages/ui/src/core/hooks/useEventSource.ts
@@ -26,10 +26,20 @@ export function useEventSource<T>(url: string | (() => Promise<string>),
     onMessage: (content: string) => void,
     onCompleted: (payload: T) => void) {
     useEffect(() => {
+        let stop: (() => void) | undefined;
+        let cancelled = false;
         if (typeof url === 'function') {
-            url().then(url => startSse(url, onMessage, onCompleted));
+            void url().then(url => {
+                if (!cancelled) {
+                    stop = startSse(url, onMessage, onCompleted);
+                }
+            });
         } else {
-            startSse(url, onMessage, onCompleted);
+            stop = startSse(url, onMessage, onCompleted);
         }
-    }, [url])
+        return () => {
+            cancelled = true;
+            stop?.();
+        }
+    }, [onCompleted, onMessage, url])
 }

--- a/packages/ui/src/core/hooks/useFetch.ts
+++ b/packages/ui/src/core/hooks/useFetch.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export interface FetchOpts<T> {
     start?: () => void,
@@ -22,27 +22,33 @@ export function useFetch<T = unknown>(fetcher: () => Promise<T>, opts?: FetchOpt
     const [error, setError] = useState<Error | undefined>(undefined);
     const [isLoading, setIsLoading] = useState(false);
     const [data, setData] = useState<T | undefined>(options.defaultValue);
-    const fetch = () => {
-        options.start?.();
+    const fetcherRef = useRef(fetcher);
+    fetcherRef.current = fetcher;
+    const optionsRef = useRef(options);
+    optionsRef.current = options;
+    const fetch = useCallback(() => {
+        const currentOptions = optionsRef.current;
+        currentOptions.start?.();
         setIsLoading(true);
-        return fetcher().then((result: T) => {
+        return fetcherRef.current().then((result: T) => {
             setData(result);
-            options.onSuccess?.(result);
+            currentOptions.onSuccess?.(result);
         }).catch(error => {
             const err = toError(error);
             setError(err);
-            options.onError?.(err);
+            currentOptions.onError?.(err);
         }).finally(() => {
             setIsLoading(false);
-            options.end?.();
+            currentOptions.end?.();
         });
-    }
+    }, [])
     useEffect(() => {
-        if (!options.condition || options.condition()) {
+        const currentOptions = optionsRef.current;
+        if (!currentOptions.condition || currentOptions.condition()) {
             fetch();
         }
 
-    }, options.deps);
+    }, [fetch, ...(options.deps ?? [])]);
     return { data, isLoading, error, setData, refetch: fetch };
 }
 

--- a/packages/ui/src/core/hooks/useIntersectionObserver.tsx
+++ b/packages/ui/src/core/hooks/useIntersectionObserver.tsx
@@ -1,4 +1,4 @@
-import { RefObject, useEffect } from "react";
+import { RefObject, useEffect, useRef } from "react";
 
 /**
  * if leave option is true then callback will be called when the target leaves the viewport
@@ -8,33 +8,39 @@ import { RefObject, useEffect } from "react";
  * @param opts
  */
 export function useIntersectionObserver(target: RefObject<HTMLElement | null | undefined>, cb: (entry: IntersectionObserverEntry) => void, opts: { leave?: boolean, threshold?: number, deps?: unknown[] } = {}) {
+    const cbRef = useRef(cb);
+    cbRef.current = cb;
+    const optsRef = useRef(opts);
+    optsRef.current = opts;
+    const threshold = opts.threshold || 1;
 
     useEffect(() => {
+        const element = target.current;
         const observer = new IntersectionObserver(
             entries => {
                 const isEntering = entries[0].isIntersecting;
-                if (opts.leave) {
+                if (optsRef.current.leave) {
                     if (!isEntering) {
-                        cb(entries[0]);
+                        cbRef.current(entries[0]);
                     }
                 } else {
                     if (isEntering) {
-                        cb(entries[0]);
+                        cbRef.current(entries[0]);
                     }
                 }
             },
-            { threshold: opts.threshold || 1 }
+            { threshold }
         );
 
-        if (target.current) {
-            observer.observe(target.current);
+        if (element) {
+            observer.observe(element);
         }
 
         return () => {
-            if (target.current) {
-                observer.unobserve(target.current);
+            if (element) {
+                observer.unobserve(element);
             }
         };
-    }, opts.deps ? opts.deps.concat(target) : [target]);
+    }, [target, threshold]);
 
 }

--- a/packages/ui/src/core/hooks/useScrollableSearch.tsx
+++ b/packages/ui/src/core/hooks/useScrollableSearch.tsx
@@ -149,7 +149,7 @@ export function useScrollableSearch<ResultT, PayloadT, PageT = number>(opts: Scr
                 setIsSearching(false);
             }
         });
-    }, [...dependencies, lastPayload, page]);
+    }, [...dependencies, lastPayload, opts.search, page, pageSize]);
 
     // Intersection observer for infinite scrolling
     useIntersectionObserver(opts.nextPageTrigger, () => {

--- a/packages/ui/src/features/activity-doc/ActivityDoc.tsx
+++ b/packages/ui/src/features/activity-doc/ActivityDoc.tsx
@@ -100,7 +100,7 @@ function PropertyDetails({ property, className }: { className?: string, property
         } else {
             return null;
         }
-    }, [property.type.innerType]);
+    }, [property.type]);
     return (
         <div className={clsx("py-2", className)}>
             <PropertySignature property={property} />

--- a/packages/ui/src/features/agent/chat/AgentRightPanel.tsx
+++ b/packages/ui/src/features/agent/chat/AgentRightPanel.tsx
@@ -190,7 +190,7 @@ function WorkstreamsTab({ workstreams, messages, runId }: WorkstreamsTabProps) {
     const copyRunId = useCallback((runId: string) => {
         navigator.clipboard.writeText(runId);
         toast({ status: 'success', title: t('agent.runIdCopied'), duration: 2000 });
-    }, [toast]);
+    }, [t, toast]);
 
     const downloadConversation = useCallback(async (runId: string) => {
         try {
@@ -199,7 +199,7 @@ function WorkstreamsTab({ workstreams, messages, runId }: WorkstreamsTabProps) {
         } catch {
             toast({ status: 'error', title: t('agent.failedToDownload') });
         }
-    }, [client, toast]);
+    }, [client, t, toast]);
 
     if (workstreams.length === 0) {
         return (

--- a/packages/ui/src/features/agent/chat/DocumentPanel.tsx
+++ b/packages/ui/src/features/agent/chat/DocumentPanel.tsx
@@ -55,10 +55,11 @@ function DocumentPanelComponent({
         } finally {
             setIsLoading(false);
         }
-    }, [client, onUpdateDocumentTitle]);
+    }, [client, onUpdateDocumentTitle, t]);
 
     // Fetch content when active document changes or refreshKey bumps
     useEffect(() => {
+        void refreshKey;
         if (activeDocumentId && isOpen) {
             fetchContent(activeDocumentId);
         }

--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
@@ -499,6 +499,7 @@ function StartWorkflowView({
     }, []);
 
     useEffect(() => {
+        void inputValue;
         adjustTextareaHeight();
     }, [inputValue, adjustTextareaHeight]);
 
@@ -1006,7 +1007,7 @@ const handleCloseRightPanel = useCallback(() => {
                 {children}
             </a>
         ),
-        [openDocInPanel, setRightPanelTab]
+        [openDocInPanel]
     );
 
     const effectiveStoreLinkComponent = StoreLinkComponent ?? internalStoreLinkComponent;
@@ -1186,7 +1187,7 @@ const handleCloseRightPanel = useCallback(() => {
             .finally(() => {
                 setIsSending(false);
             });
-    }, [agentRunId, client, toast, getAttachedDocs, getMessageContext, onAttachmentsSent, addOptimisticMessage, removeOptimisticMessages]);
+    }, [agentRunId, client, toast, getAttachedDocs, getMessageContext, onAttachmentsSent, addOptimisticMessage, removeOptimisticMessages, t]);
 
     // Drag and drop handlers for full-panel file upload
     const handleDragEnter = useCallback((e: React.DragEvent) => {
@@ -1250,7 +1251,7 @@ const handleCloseRightPanel = useCallback(() => {
         } finally {
             setIsStopping(false);
         }
-    }, [isStopping, client, agentRunId, toast]);
+    }, [isStopping, client, agentRunId, toast, t]);
 
     // Expose stop handler to external callers via ref
     useEffect(() => {

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/AllMessagesMixed.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/AllMessagesMixed.tsx
@@ -265,6 +265,9 @@ function AllMessagesMixedComponent({
     // Throttled to max 10 scrolls/sec to prevent layout thrashing
     // Skipped when the user has manually scrolled up to read earlier content
     useEffect(() => {
+        void messages.length;
+        void streamingMessages.size;
+        void streamingContentBucket;
         // Respect user's scroll position — don't yank them back to the bottom
         if (userScrolledUpRef.current) return;
 

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageInput.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageInput.tsx
@@ -266,6 +266,7 @@ export default function MessageInput({
     }, []);
 
     useEffect(() => {
+        void value;
         adjustTextareaHeight();
     }, [value, adjustTextareaHeight]);
 

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageItem.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageItem.tsx
@@ -391,12 +391,10 @@ function MessageItemComponent({
         { displayName: string; artifactPath: string; url: string; isImage: boolean }[]
     >([]);
 
-    // Create stable key from message for dependency tracking
     const runId = message.workflow_run_id;
     const details = message.details;
     // Check both outputFiles (from execute_shell) and files (from tool results like dashboard tools)
     const outputFiles = details?.outputFiles ?? details?.files;
-    const outputFilesKey = Array.isArray(outputFiles) ? outputFiles.join(",") : "";
 
     useEffect(() => {
         const loadArtifacts = async () => {
@@ -461,7 +459,7 @@ function MessageItemComponent({
         };
 
         loadArtifacts();
-    }, [runId, outputFilesKey]);
+    }, [runId, outputFiles]);
 
     const workstreamId = getWorkstreamId(message);
     const { Icon } = resolvedStyle;

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/MessagesContainer.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/MessagesContainer.tsx
@@ -25,6 +25,7 @@ export default function MessagesContainer({
 
     // Auto-scroll to bottom when messages change
     useEffect(() => {
+        void messages;
         if (bottomRef.current) {
             bottomRef.current.scrollIntoView({ behavior: "smooth" });
         }

--- a/packages/ui/src/features/agent/chat/SkillWidgetProvider.tsx
+++ b/packages/ui/src/features/agent/chat/SkillWidgetProvider.tsx
@@ -158,7 +158,7 @@ export function SkillWidgetProvider({ children }: SkillWidgetProviderProperties)
                 ...widgets,
             })
         })
-    }, []);
+    }, [client]);
 
 
     return (

--- a/packages/ui/src/features/agent/chat/SlidingThinkingIndicator.tsx
+++ b/packages/ui/src/features/agent/chat/SlidingThinkingIndicator.tsx
@@ -1,7 +1,7 @@
 import { AgentMessage, AgentMessageType } from "@vertesia/common";
 import { Button, cn } from "@vertesia/ui/core";
 import { EyeIcon, EyeOffIcon } from "lucide-react";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useUITranslation } from '@vertesia/ui/i18n';
 import { AnimatedThinkingDots, PulsatingCircle, PulsingMessageLoader } from "./AnimatedThinkingDots";
 import MessageItem from "./ModernAgentOutput/MessageItem";
@@ -73,12 +73,12 @@ export function SlidingThinkingIndicator({
     }, []);
 
     // Filter for thinking-type messages
-    const thinkingMessages = messages.filter(
+    const thinkingMessages = useMemo(() => messages.filter(
         (msg) =>
             msg.type === AgentMessageType.THOUGHT ||
             msg.type === AgentMessageType.UPDATE ||
             msg.type === AgentMessageType.PLAN,
-    );
+    ), [messages]);
 
     // Track recent messages for cascading display
     const [recentMessages, setRecentMessages] = useState<AgentMessage[]>([]);
@@ -207,7 +207,7 @@ export function SlidingThinkingIndicator({
                 clearTimeout(timeoutRef.current);
             }
         };
-    }, [messages, isCompleted, showDetails, prevPermanentCount]);
+    }, [messages, thinkingMessages, isCompleted, showDetails, prevPermanentCount, recentMessages.length, visibleMessage]);
 
     // Choose the color based on message type (using valid color values)
     const getThinkingColor = (message: AgentMessage | null): "blue" | "purple" | "teal" | "green" => {

--- a/packages/ui/src/features/agent/chat/VegaLiteChart.tsx
+++ b/packages/ui/src/features/agent/chat/VegaLiteChart.tsx
@@ -960,6 +960,7 @@ export const VegaLiteChart = memo(function VegaLiteChart({ spec, artifactRunId }
 
     // Clear error when spec changes
     useEffect(() => {
+        void vegaSpec;
         setError(null);
     }, [vegaSpec]);
 

--- a/packages/ui/src/features/agent/chat/hooks/useAgentPlans.ts
+++ b/packages/ui/src/features/agent/chat/hooks/useAgentPlans.ts
@@ -47,7 +47,21 @@ export function useAgentPlans(
             lastProcessedIndex.current = -1;
             knownPlanTimestamps.current.clear();
         }
-    }, [messages.length === 0, isModal]);
+    }, [messages.length, isModal]);
+
+    // Helper to determine showInput from the latest message
+    const updateShowInput = useCallback((msgs: AgentMessage[]) => {
+        const lastMessage = msgs[msgs.length - 1];
+        if (!lastMessage) return;
+
+        if (lastMessage.type === AgentMessageType.TERMINATED) {
+            setShowInput(false);
+        } else if (interactive) {
+            setShowInput(true);
+        } else {
+            setShowInput(lastMessage.type === AgentMessageType.REQUEST_INPUT);
+        }
+    }, [interactive]);
 
     // Process new messages incrementally
     useEffect(() => {
@@ -141,7 +155,7 @@ export function useAgentPlans(
         }
 
         updateShowInput(messages);
-    }, [messages, interactive]);
+    }, [messages, updateShowInput]);
 
     // Auto-show plan panel for the first plan (once only)
     useEffect(() => {
@@ -157,20 +171,6 @@ export function useAgentPlans(
             return () => clearTimeout(notificationTimeout);
         }
     }, [plans.length, showSlidingPanel]);
-
-    // Helper to determine showInput from the latest message
-    const updateShowInput = useCallback((msgs: AgentMessage[]) => {
-        const lastMessage = msgs[msgs.length - 1];
-        if (!lastMessage) return;
-
-        if (lastMessage.type === AgentMessageType.TERMINATED) {
-            setShowInput(false);
-        } else if (interactive) {
-            setShowInput(true);
-        } else {
-            setShowInput(lastMessage.type === AgentMessageType.REQUEST_INPUT);
-        }
-    }, [interactive]);
 
     return {
         plans,

--- a/packages/ui/src/features/agent/chat/hooks/useArtifacts.ts
+++ b/packages/ui/src/features/agent/chat/hooks/useArtifacts.ts
@@ -138,6 +138,8 @@ export function useArtifacts(
     }, [client, runId]);
 
     useEffect(() => {
+        void refreshKey;
+        void manualRefreshKey;
         fetchArtifacts();
     }, [fetchArtifacts, refreshKey, manualRefreshKey]);
 

--- a/packages/ui/src/features/agent/chat/hooks/useDocumentPanel.ts
+++ b/packages/ui/src/features/agent/chat/hooks/useDocumentPanel.ts
@@ -77,7 +77,7 @@ export function useDocumentPanel(messages: AgentMessage[]): UseDocumentPanelResu
             setDocRefreshKey(0);
             lastProcessedIndex.current = -1;
         }
-    }, [messages.length === 0]);
+    }, [messages.length]);
 
     // Process new messages incrementally for document events
     useEffect(() => {

--- a/packages/ui/src/features/agent/chat/hooks/useFileProcessing.ts
+++ b/packages/ui/src/features/agent/chat/hooks/useFileProcessing.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { VertesiaClient } from '@vertesia/client';
 import {
     ConversationFile,
@@ -35,10 +35,14 @@ export function useFileProcessing(
     const t = i18nInstance.getFixedT(null, NAMESPACE);
     // Local optimistic file state (uploads initiated from the UI)
     const [localFiles, setLocalFiles] = useState<Map<string, ConversationFile>>(new Map());
+    const previousAgentRunId = useRef(agentRunId);
 
     // Reset when agentRunId changes
     useEffect(() => {
-        setLocalFiles(new Map());
+        if (previousAgentRunId.current !== agentRunId) {
+            previousAgentRunId.current = agentRunId;
+            setLocalFiles(new Map());
+        }
     }, [agentRunId]);
 
     // Merge local + server state (server takes precedence for same IDs)
@@ -121,7 +125,7 @@ export function useFileProcessing(
                 });
             }
         }
-    }, [client, agentRunId, toast]);
+    }, [client, agentRunId, toast, t]);
 
     return { processingFiles, hasProcessingFiles, handleFileUpload };
 }

--- a/packages/ui/src/features/facets/utils/StringListFacet.tsx
+++ b/packages/ui/src/features/facets/utils/StringListFacet.tsx
@@ -15,7 +15,7 @@ export function StringListFacet({ search, name, placeholder, className }: String
 
     useEffect(() => {
         search.setFilterValue(name, tags);
-    }, [tags]);
+    }, [name, search, tags]);
 
     return (
         <InputList className={className} value={tags} onChange={setTags} placeholder={placeholder} />

--- a/packages/ui/src/features/magic-pdf/MagicPdfProvider.tsx
+++ b/packages/ui/src/features/magic-pdf/MagicPdfProvider.tsx
@@ -251,7 +251,7 @@ export function MagicPdfProvider({ children, object }: MagicPdfProviderProps) {
             // For XML processor, no pre-loading needed - images load on demand
             setInfo(prev => ({ ...prev, pdfUrlLoading: false }));
         }
-    }, [object.id, client, isMarkdownProcessor, page_count]);
+    }, [client, isMarkdownProcessor, object.metadata, object.content?.type, object.content?.source]);
 
     return (
         <MagicPdfContext.Provider value={info}>

--- a/packages/ui/src/features/media-viewer/AudioPanel.tsx
+++ b/packages/ui/src/features/media-viewer/AudioPanel.tsx
@@ -78,7 +78,7 @@ export function AudioPanel({ url, source, object, className }: AudioPanelProps) 
         } else {
             setIsLoading(false);
         }
-    }, [url, source, object?.id, object?.content?.type, object?.content?.source, object?.metadata, audioRendition, isOriginalWebSupported, client]);
+    }, [url, source, object, audioRendition, isOriginalWebSupported, client]);
 
     if (showsObjectFallbackEmpty) {
         return (

--- a/packages/ui/src/features/media-viewer/ImagePanel.tsx
+++ b/packages/ui/src/features/media-viewer/ImagePanel.tsx
@@ -78,7 +78,7 @@ export function ImagePanel({ url, source, object, className }: ImagePanelProps) 
         } else {
             setIsLoading(false);
         }
-    }, [url, source, object?.id, object?.content?.type, object?.content?.source, object?.metadata, client]);
+    }, [url, source, object, client]);
 
     if (isLoading) {
         return (

--- a/packages/ui/src/features/media-viewer/VideoPanel.tsx
+++ b/packages/ui/src/features/media-viewer/VideoPanel.tsx
@@ -82,7 +82,7 @@ export function VideoPanel({ url, source, object, className }: VideoPanelProps) 
         } else {
             setIsLoading(false);
         }
-    }, [url, source, object?.id, object?.content?.type, object?.content?.source, object?.metadata, webRendition, isOriginalWebSupported, client]);
+    }, [url, source, object, webRendition, isOriginalWebSupported, client]);
 
     useEffect(() => {
         if (!poster?.content?.source) return;

--- a/packages/ui/src/features/pdf-viewer/PdfPageSlider.tsx
+++ b/packages/ui/src/features/pdf-viewer/PdfPageSlider.tsx
@@ -94,10 +94,10 @@ export function PdfPageSlider({
     }, [compact]);
 
     // Legacy function for resize preservation - kept for backwards compatibility
-    const getItemHeight = (width: number | undefined, ratio: number) => {
+    const getItemHeight = useCallback((width: number | undefined, ratio: number) => {
         const placeholderHeight = width ? Math.round(width / ratio) : 200;
         return calculateItemHeight(placeholderHeight);
-    };
+    }, [calculateItemHeight]);
 
     // Single ResizeObserver at parent level to measure thumbnail width
     // Debounced to avoid excessive re-renders during resize
@@ -161,7 +161,7 @@ export function PdfPageSlider({
             if (debounceTimer) clearTimeout(debounceTimer);
             resizeObserver.disconnect();
         };
-    }, [aspectRatio]);
+    }, [aspectRatio, getItemHeight]);
 
     // Track whether we're programmatically scrolling to avoid feedback loops
     const isProgrammaticScrollRef = useRef(false);

--- a/packages/ui/src/features/store/collections/SharedPropsEditor.tsx
+++ b/packages/ui/src/features/store/collections/SharedPropsEditor.tsx
@@ -19,7 +19,7 @@ export function SharedPropsEditor({ collection }: SharedPropsEditorProps) {
         if (collection.type?.id) {
             client.store.types.retrieve(collection.type.id).then(setColType);
         }
-    }, [collection.type?.id]);
+    }, [client.store.types.retrieve, collection.type?.id]);
 
     const options: string[] = colType ? Object.keys(colType.object_schema?.properties || {}) : [];
 

--- a/packages/ui/src/features/store/objects/DocumentPreviewPanel.tsx
+++ b/packages/ui/src/features/store/objects/DocumentPreviewPanel.tsx
@@ -15,7 +15,7 @@ import {
   Maximize2,
   X,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useUITranslation } from '@vertesia/ui/i18n';
 
 interface DocumentPreviewPanelProps {
@@ -39,6 +39,45 @@ export function DocumentPreviewPanel({
   const [currentTab, setCurrentTab] = useState("preview");
   const { t } = useUITranslation();
   const toast = useToast();
+
+  const loadObjectText = useCallback(async (id: string) => {
+    setLoadingText(true);
+    try {
+      const result = await store.objects.getObjectText(id);
+      setText(result.text);
+    } catch (error) {
+      console.error("Error loading text:", error);
+    } finally {
+      setLoadingText(false);
+    }
+  }, [store.objects]);
+
+  const loadImageUrl = useCallback(async (obj: ContentObject) => {
+    if (!obj.content?.source) {
+      return;
+    }
+
+    try {
+      // Try to get a rendition first
+      const rendition = await client.objects.getRendition(obj.id, {
+        format: ImageRenditionFormat.jpeg,
+        generate_if_missing: false,
+      });
+
+      // Don't use rendition object to avoid type issues
+      if (rendition.status === "found") {
+        console.log("Found rendition");
+      }
+
+      // Get download URL
+      const downloadUrlResult = await client.files.getDownloadUrl(
+        obj.content.source,
+      );
+      setImageUrl(downloadUrlResult.url);
+    } catch (error) {
+      console.error("Error loading image:", error);
+    }
+  }, [client.files, client.objects]);
 
   useEffect(() => {
     if (objectId && isOpen) {
@@ -84,46 +123,7 @@ export function DocumentPreviewPanel({
       setText(undefined);
       setImageUrl(undefined);
     }
-  }, [objectId, isOpen, store.objects]);
-
-  const loadObjectText = async (id: string) => {
-    setLoadingText(true);
-    try {
-      const result = await store.objects.getObjectText(id);
-      setText(result.text);
-    } catch (error) {
-      console.error("Error loading text:", error);
-    } finally {
-      setLoadingText(false);
-    }
-  };
-
-  const loadImageUrl = async (obj: ContentObject) => {
-    if (!obj.content?.source) {
-      return;
-    }
-
-    try {
-      // Try to get a rendition first
-      const rendition = await client.objects.getRendition(obj.id, {
-        format: ImageRenditionFormat.jpeg,
-        generate_if_missing: false,
-      });
-
-      // Don't use rendition object to avoid type issues
-      if (rendition.status === "found") {
-        console.log("Found rendition");
-      }
-
-      // Get download URL
-      const downloadUrlResult = await client.files.getDownloadUrl(
-        obj.content.source,
-      );
-      setImageUrl(downloadUrlResult.url);
-    } catch (error) {
-      console.error("Error loading image:", error);
-    }
-  };
+  }, [objectId, isOpen, store.objects, loadObjectText, loadImageUrl, t, toast]);
 
   const handleViewFullDocument = () => {
     if (object) {

--- a/packages/ui/src/features/store/objects/DocumentSearchResults.tsx
+++ b/packages/ui/src/features/store/objects/DocumentSearchResults.tsx
@@ -14,7 +14,7 @@ import { useUserSession } from '@vertesia/ui/session';
 import { TypeRegistry } from '../types/TypeRegistry.js';
 import { useTypeRegistry } from '../types/TypeRegistryProvider.js';
 import { Download, ExternalLink, RefreshCw } from 'lucide-react';
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useDocumentFilterGroups, useDocumentFilterHandler } from "../../facets/DocumentsFacetsNav";
 import { ContentDispositionButton } from './components/ContentDispositionButton';
 import { ContentOverview } from './components/ContentOverview';
@@ -54,7 +54,7 @@ export function DocumentSearchResultsWithDropZone({ onUploadDone = async () => {
     const { t } = useUITranslation();
 
     // Create a wrapper around the onUploadDone callback that also refreshes the search
-    const handleUploadDone = async (objectIds: string[]) => {
+    const handleUploadDone = useCallback(async (objectIds: string[]) => {
         // First, call the original callback
         await onUploadDone(objectIds);
 
@@ -73,17 +73,17 @@ export function DocumentSearchResultsWithDropZone({ onUploadDone = async () => {
                 console.error('Failed to refresh search results:', err);
             });
         }, 1000); // 1-second delay for backend processing
-    };
+    }, [onUploadDone, search, t, toast]);
 
     // Use the enhanced standard upload handler with smart processing
     const uploadHandler = useDocumentUploadHandler(handleUploadDone);
 
     // Wrap the uploadHandler to ensure the collectionId is passed
-    const wrappedUploadHandler = (files: File[], type: string | null) => {
+    const wrappedUploadHandler = useCallback((files: File[], type: string | null) => {
         // Get the collection ID from the search context
         const collectionId = search.collectionId;
         return uploadHandler(files, type, collectionId);
-    };
+    }, [search, uploadHandler]);
 
     return <DocumentSearchResults layout={layout} onUpload={wrappedUploadHandler} />;
 }
@@ -134,7 +134,7 @@ export function DocumentSearchResults({ layout, onUpload, allowFilter = true, al
                 search._updateRunningState(false);
             });
         }
-    }, []);
+    }, [isReady, objects.length, search]);
 
     useEffect(() => {
         if (objects.length < loaded) {

--- a/packages/ui/src/features/store/objects/DocumentSearchResults.tsx
+++ b/packages/ui/src/features/store/objects/DocumentSearchResults.tsx
@@ -61,7 +61,10 @@ export function DocumentSearchResultsWithDropZone({ onUploadDone = async () => {
         // Use a timeout to let the backend catch up, then refresh the search results
         setTimeout(() => {
             console.log('Delayed refresh after upload to ensure backend consistency');
-            search.search().then(() => {
+            void search.search().then((refreshed) => {
+                if (!refreshed) {
+                    return;
+                }
                 // Notify the user that the list has been refreshed
                 toast({
                     title: t('store.documentListRefreshed'),
@@ -121,20 +124,45 @@ export function DocumentSearchResults({ layout, onUpload, allowFilter = true, al
     const loadMoreRef = useRef<HTMLDivElement>(null);
     const scrollRef = useRef<HTMLDivElement>(null);
 
+    const settleSearch = useCallback((promise: Promise<unknown>, errorMessage: string) => {
+        setIsReady(false);
+        void promise
+            .catch((err: unknown) => {
+                console.error(errorMessage, err);
+            })
+            .finally(() => {
+                setIsReady(true);
+            });
+    }, []);
+
     // Trigger initial search when component mounts
     useEffect(() => {
-        if (!isReady && objects.length === 0) {
-            setLoaded(0);
-            // Manually set loading state to show spinner during initial load
-            search._updateRunningState(true);
-            search.search().then(() => {
-                setIsReady(true);
-            }).catch(err => {
-                console.error('Initial search failed:', err);
-                search._updateRunningState(false);
-            });
+        let cancelled = false;
+        if (search.initialized) {
+            setIsReady(true);
+            return () => {
+                cancelled = true;
+            };
         }
-    }, [isReady, objects.length, search]);
+
+        setIsReady(false);
+        setLoaded(0);
+        void search.search()
+            .catch((err: unknown) => {
+                if (!cancelled) {
+                    console.error('Initial search failed:', err);
+                }
+            })
+            .finally(() => {
+                if (!cancelled) {
+                    setIsReady(true);
+                }
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [search]);
 
     useEffect(() => {
         if (objects.length < loaded) {
@@ -145,10 +173,14 @@ export function DocumentSearchResults({ layout, onUpload, allowFilter = true, al
     useIntersectionObserver(loadMoreRef, () => {
         if (isReady && objects.length > 0 && objects.length != loaded) {
             setIsReady(false);
-            search.loadMore().finally(() => {
-                setLoaded(objects.length)
-                setIsReady(true);
-            });
+            void search.loadMore()
+                .catch((err: unknown) => {
+                    console.error('Failed to load more search results:', err);
+                })
+                .finally(() => {
+                    setLoaded(objects.length)
+                    setIsReady(true);
+                });
         }
     }, { deps: [isReady, objects.length] });
 
@@ -176,21 +208,21 @@ export function DocumentSearchResults({ layout, onUpload, allowFilter = true, al
                 ];
                 setActualLayout(layout);
             }
-            search.search().then(() => setIsReady(true));
+            settleSearch(search.search(), 'Vector search failed:');
         } else if (query && query.full_text) {
             search.query.full_text = query.full_text;
             if (query.limit !== undefined) {
                 search.limit = query.limit;
                 search.query.limit = query.limit;
             }
-            search.search().then(() => setIsReady(true));
+            settleSearch(search.search(), 'Text search failed:');
         } else if (query === undefined) {
             // Only clear search if this is a user-initiated clear (not initialization)
             // The VectorSearchWidget calls onChange(undefined) during initialization
             if (isReady) {
                 delete search.query.vector;
                 delete search.query.full_text;
-                search.search().then(() => setIsReady(true));
+                settleSearch(search.search(), 'Search reset failed:');
             }
         }
     };
@@ -199,7 +231,7 @@ export function DocumentSearchResults({ layout, onUpload, allowFilter = true, al
     const facetSearch = useDocumentSearch();
 
     const handleRefetch = () => {
-        search.search().then(() => setIsReady(true));
+        settleSearch(search.search(), 'Search refresh failed:');
     };
 
     // Use DocumentsFacetsNav hooks for cleaner organization
@@ -356,7 +388,7 @@ function Toolsbar(props: ToolsbarProps) {
                 )
             }
             <div className="flex gap-1 items-center">
-                <Button variant="outline" onClick={handleRefetch} alt={t('store.refresh')}><RefreshCw size={16} /></Button>
+                <Button variant="outline" onClick={handleRefetch} aria-label={t('store.refresh')}><RefreshCw size={16} /></Button>
                 <ContentDispositionButton onUpdate={setIsGridView} />
             </div>
         </div>

--- a/packages/ui/src/features/store/objects/DocumentSearchResults.tsx
+++ b/packages/ui/src/features/store/objects/DocumentSearchResults.tsx
@@ -7,7 +7,7 @@ import {
     FilterBtn,
     FilterClear,
     FilterProvider,
-    SidePanel, Spinner, useIntersectionObserver, useToast
+    SidePanel, Spinner, useIntersectionObserver, useToast, VTooltip
 } from '@vertesia/ui/core';
 import { useNavigate } from "@vertesia/ui/router";
 import { useUserSession } from '@vertesia/ui/session';
@@ -388,7 +388,11 @@ function Toolsbar(props: ToolsbarProps) {
                 )
             }
             <div className="flex gap-1 items-center">
-                <Button variant="outline" onClick={handleRefetch} aria-label={t('store.refresh')}><RefreshCw size={16} /></Button>
+                <VTooltip description={t('store.refresh')} asChild size="xs" placement="top">
+                    <Button variant="outline" onClick={handleRefetch} aria-label={t('store.refresh')}>
+                        <RefreshCw size={16} />
+                    </Button>
+                </VTooltip>
                 <ContentDispositionButton onUpdate={setIsGridView} />
             </div>
         </div>

--- a/packages/ui/src/features/store/objects/DocumentSelectionProvider.tsx
+++ b/packages/ui/src/features/store/objects/DocumentSelectionProvider.tsx
@@ -92,7 +92,7 @@ export function DocumentSelectionProvider({ value, collectionId, children }: Doc
     useEffect(() => {
         const selection = new DocumentSelection(value, collectionId, {}, setSelection);
         setSelection(selection);
-    }, [value]);
+    }, [collectionId, value]);
     return selection && (
         <DocumentSelectionContext.Provider value={selection}>{children}</DocumentSelectionContext.Provider>
     )

--- a/packages/ui/src/features/store/objects/components/DocumentIcon.tsx
+++ b/packages/ui/src/features/store/objects/components/DocumentIcon.tsx
@@ -67,7 +67,7 @@ export function DocumentIcon({ selection, document, onSelectionChange, onRowClic
         }
 
         retrieveRendition(client, document, setRenditionUrl, setRenditionAlt, setRenditionStatus)
-    }, [document])
+    }, [client, document])
 
     const isHighlighted = highlightRow?.(document);
 

--- a/packages/ui/src/features/store/objects/components/DocumentInput.tsx
+++ b/packages/ui/src/features/store/objects/components/DocumentInput.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { ChangeEvent, useEffect, useState } from 'react';
+import { ChangeEvent, useCallback, useEffect, useState } from 'react';
 
 import { useUserSession } from '@vertesia/ui/session';
 import { ContentObjectItem } from '@vertesia/common';
@@ -28,11 +28,11 @@ export function DocumentInput({ object }: DocumentInputProps) {
         object.value = value;
     };
 
-    const clearValue = () => {
+    const clearValue = useCallback(() => {
         setValue('');
         object.value = '';
         setDoc(undefined);
-    };
+    }, [object]);
 
     const onSelect = (value?: ContentObjectItem) => {
         if (value) {
@@ -59,7 +59,7 @@ export function DocumentInput({ object }: DocumentInputProps) {
         }).catch(() => {
             clearValue();
         });
-    }, [actualValue]);
+    }, [actualValue, client.objects.retrieve, clearValue, doc]);
 
     return (
         <div>

--- a/packages/ui/src/features/store/objects/components/PropertiesEditorModal.tsx
+++ b/packages/ui/src/features/store/objects/components/PropertiesEditorModal.tsx
@@ -1,5 +1,5 @@
 import { useUserSession } from '@vertesia/ui/session';
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import { useUITranslation } from '@vertesia/ui/i18n';
 import {
     Button,
@@ -42,6 +42,18 @@ export function PropertiesEditorModal({ isOpen, onClose, object, refetch }: Prop
     //TODO  state not used
     const [_newVersionId, setNewVersionId] = useState<string | null>(null);
 
+    // Fetch JSON schema for the object type
+    const fetchJsonSchema = useCallback(async (typeId: string) => {
+        try {
+            const typeDetails = await store.types.retrieve(typeId);
+            if (typeDetails.object_schema) {
+                setJsonSchema(typeDetails.object_schema);
+            }
+        } catch (error) {
+            console.error('Failed to fetch JSON schema:', error);
+        }
+    }, [store.types]);
+
     // Initialize editor content when modal opens
     useEffect(() => {
         if (isOpen) {
@@ -52,19 +64,7 @@ export function PropertiesEditorModal({ isOpen, onClose, object, refetch }: Prop
                 fetchJsonSchema(object.type.id);
             }
         }
-    }, [isOpen, object]);
-
-    // Fetch JSON schema for the object type
-    async function fetchJsonSchema(typeId: string) {
-        try {
-            const typeDetails = await store.types.retrieve(typeId);
-            if (typeDetails.object_schema) {
-                setJsonSchema(typeDetails.object_schema);
-            }
-        } catch (error) {
-            console.error('Failed to fetch JSON schema:', error);
-        }
-    }
+    }, [isOpen, object, fetchJsonSchema]);
 
     // Configure Monaco editor with JSON schema validation
     const beforeMount = (monaco: typeof import('monaco-editor')) => {

--- a/packages/ui/src/features/store/objects/components/SaveVersionConfirmModal.tsx
+++ b/packages/ui/src/features/store/objects/components/SaveVersionConfirmModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import {
     Button,
     Modal,
@@ -36,7 +36,7 @@ class SaveOptionAdapter extends RadioGroupAdapter<SaveOptionType> {
 
 export function SaveVersionConfirmModal({ isOpen, onClose, onConfirm, isLoading, uploadedFileName }: SaveVersionConfirmModalProps) {
     const { t } = useUITranslation();
-    const saveOptions: SaveOptionType[] = [
+    const saveOptions: SaveOptionType[] = useMemo(() => [
         {
             id: "update",
             label: t('modal.saveVersion.updateCurrent'),
@@ -51,7 +51,7 @@ export function SaveVersionConfirmModal({ isOpen, onClose, onConfirm, isLoading,
                 ? t('modal.saveVersion.createWithFileDescription')
                 : t('modal.saveVersion.createDescription')
         }
-    ];
+    ], [t, uploadedFileName]);
 
     // Default to "create new version" when replacing a file, "update current version" when editing properties
     const defaultOption = uploadedFileName ? saveOptions[1] : saveOptions[0];
@@ -65,7 +65,7 @@ export function SaveVersionConfirmModal({ isOpen, onClose, onConfirm, isLoading,
             setSelectedOption(defaultOption);
             setVersionLabel('');
         }
-    }, [isOpen, uploadedFileName]);
+    }, [defaultOption, isOpen]);
 
     const createVersion = selectedOption?.id === "new-version";
 

--- a/packages/ui/src/features/store/objects/components/SelectDocument.tsx
+++ b/packages/ui/src/features/store/objects/components/SelectDocument.tsx
@@ -71,7 +71,7 @@ function SelectDocumentImpl({ onRowClick, selectedIds }: Readonly<SelectDocument
             .finally(() => {
                 setIsReady(true);
             });
-    }, []);
+    }, [search]);
 
     const facets = useWatchDocumentSearchFacets();
     const facetSearch = useDocumentSearch();

--- a/packages/ui/src/features/store/objects/components/VectorSearchWidget.test.tsx
+++ b/packages/ui/src/features/store/objects/components/VectorSearchWidget.test.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../__tests__/test-utils.js';
+import { VectorSearchWidget } from './VectorSearchWidget';
+
+vi.mock('@vertesia/ui/session', () => ({
+    useUserSession: () => ({
+        client: {
+            projects: {
+                retrieve: vi.fn(),
+            },
+        },
+        project: undefined,
+    }),
+}));
+
+describe('VectorSearchWidget', () => {
+    it('does not clear search on empty initial render or parent rerender', async () => {
+        const initialOnChange = vi.fn();
+        const nextOnChange = vi.fn();
+        const { getByRole, rerender } = renderWithProviders(
+            <VectorSearchWidget onChange={initialOnChange} refresh={0} />,
+        );
+
+        rerender(<VectorSearchWidget onChange={nextOnChange} refresh={0} />);
+
+        expect(initialOnChange).not.toHaveBeenCalled();
+        expect(nextOnChange).not.toHaveBeenCalled();
+
+        fireEvent.change(getByRole('textbox'), { target: { value: 'tokyo tower' } });
+
+        expect(nextOnChange).not.toHaveBeenCalled();
+
+        fireEvent.change(getByRole('textbox'), { target: { value: '' } });
+
+        await waitFor(() => {
+            expect(nextOnChange).toHaveBeenCalledTimes(1);
+        });
+        expect(nextOnChange).toHaveBeenCalledWith(undefined);
+    });
+});

--- a/packages/ui/src/features/store/objects/components/VectorSearchWidget.tsx
+++ b/packages/ui/src/features/store/objects/components/VectorSearchWidget.tsx
@@ -29,6 +29,7 @@ export function VectorSearchWidget({ onChange, isLoading, refresh, searchTypes }
     const isReady = !!project && (!!config?.embeddings.text || !!config?.embeddings.image);
     const [status, setStatus] = useState<string | undefined>(undefined);
     const refreshRef = useRef(refresh);
+    const previousSearchTextRef = useRef<string | undefined>(undefined);
 
     const [showSettings, setShowSettings] = useState(false);
     // Default to all types, or use prop if provided
@@ -75,7 +76,10 @@ export function VectorSearchWidget({ onChange, isLoading, refresh, searchTypes }
     }, [status, toast]);
 
     useEffect(() => {
-        if (!searchText || searchText.length === 0) {
+        const previousSearchText = previousSearchTextRef.current;
+        previousSearchTextRef.current = searchText;
+
+        if (previousSearchText && (!searchText || searchText.length === 0)) {
             onChange(undefined);
         }
     }, [onChange, searchText]);

--- a/packages/ui/src/features/store/objects/components/VectorSearchWidget.tsx
+++ b/packages/ui/src/features/store/objects/components/VectorSearchWidget.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { ComplexSearchQuery, ProjectConfiguration, SearchTypes, SupportedEmbeddingTypes } from '@vertesia/common';
 import { Button, Checkbox, Input, Label, Modal, ModalBody, ModalFooter, ModalTitle, NumberInput, useToast } from '@vertesia/ui/core';
@@ -28,6 +28,7 @@ export function VectorSearchWidget({ onChange, isLoading, refresh, searchTypes }
     const [config, setConfig] = useState<ProjectConfiguration | undefined>(undefined);
     const isReady = !!project && (!!config?.embeddings.text || !!config?.embeddings.image);
     const [status, setStatus] = useState<string | undefined>(undefined);
+    const refreshRef = useRef(refresh);
 
     const [showSettings, setShowSettings] = useState(false);
     // Default to all types, or use prop if provided
@@ -53,28 +54,31 @@ export function VectorSearchWidget({ onChange, isLoading, refresh, searchTypes }
     });
 
     useEffect(() => {
-        setSearchText(undefined);
-        setStatus(undefined);
-    }, [refresh]);
+        if (refreshRef.current !== refresh) {
+            refreshRef.current = refresh;
+            setSearchText(undefined);
+            setStatus(undefined);
+        }
+    });
 
     useEffect(() => {
         if (!project) return;
         client.projects.retrieve(project.id).then((project) => {
             setConfig(project.configuration);
         })
-    }, [project]);
+    }, [client.projects.retrieve, project]);
 
     useEffect(() => {
         if (status) {
             toast({ title: status, status: 'success', duration: 2000 });
         }
-    }, [status]);
+    }, [status, toast]);
 
     useEffect(() => {
         if (!searchText || searchText.length === 0) {
             onChange(undefined);
         }
-    }, [searchText]);
+    }, [onChange, searchText]);
 
     const fireSearch = () => {
         if (!isReady || !searchText) return;

--- a/packages/ui/src/features/store/objects/components/useContentPanelHooks.ts
+++ b/packages/ui/src/features/store/objects/components/useContentPanelHooks.ts
@@ -66,7 +66,7 @@ export function useObjectText(objectId: string, initialText?: string, loadOnMoun
         if (loadOnMount && !initialText) {
             loadText();
         }
-    }, [objectId, initialText, loadOnMount, loadText]);
+    }, [initialText, loadOnMount, loadText]);
 
     return {
         fullText,
@@ -211,7 +211,7 @@ export function useOfficePdfConversion(objectId: string, enabled: boolean) {
         };
 
         await pollForPdf(true);
-    }, [objectId, enabled, isConverting, client]);
+    }, [objectId, enabled, isConverting, client, t]);
 
     return {
         pdfUrl,

--- a/packages/ui/src/features/store/objects/components/useDownloadFile.ts
+++ b/packages/ui/src/features/store/objects/components/useDownloadFile.ts
@@ -70,7 +70,7 @@ export function useDownloadFile({ client, toast }: UseDownloadFileOptions): UseD
         } finally {
             setIsDownloading(false);
         }
-    }, [client, toast]);
+    }, [client, toast, t]);
 
     /**
      * Download a file from a direct URL (already signed or public).
@@ -142,7 +142,7 @@ export function useDownloadFile({ client, toast }: UseDownloadFileOptions): UseD
         } finally {
             setIsDownloading(false);
         }
-    }, [handleRenderResult, toast]);
+    }, [handleRenderResult, toast, t]);
 
     /**
      * Render markdown content and download the result.
@@ -179,7 +179,7 @@ export function useDownloadFile({ client, toast }: UseDownloadFileOptions): UseD
         } finally {
             setIsDownloading(false);
         }
-    }, [handleRenderResult, toast]);
+    }, [handleRenderResult, toast, t]);
 
     return {
         downloadFromContentSource,

--- a/packages/ui/src/features/store/objects/layout/documentLayout.tsx
+++ b/packages/ui/src/features/store/objects/layout/documentLayout.tsx
@@ -38,7 +38,6 @@ export function DocumentTableView({ objects, selection, isLoading, columns, onRo
                     objects?.map((obj: ContentObjectItem) => {
                         const isHighlighted = highlightRow?.(obj);
                         return (
-                            // biome-ignore lint/a11y/useKeyWithClickEvents: clickable table row; <tr> doesn't accept role="button" semantically — keyboard nav handled at table level via arrow keys.
                             <tr key={obj.id} className={`cursor-pointer hover:bg-muted group ${selectedObject?.id === obj.id ? 'bg-muted' : ''} ${isHighlighted ? 'bg-blue-50 dark:bg-blue-900/20' : ''}`} onClick={() => {
                                 onRowClick?.(obj)
                             }}>

--- a/packages/ui/src/features/store/objects/search/DocumentSearchContext.test.ts
+++ b/packages/ui/src/features/store/objects/search/DocumentSearchContext.test.ts
@@ -1,0 +1,49 @@
+import type { ZenoClient } from '@vertesia/client';
+import type { ContentObjectItem } from '@vertesia/common';
+import { describe, expect, it, vi } from 'vitest';
+import { DocumentSearch } from './DocumentSearchContext';
+
+function createClient(searchImpl: () => Promise<unknown>): ZenoClient {
+    return {
+        objects: {
+            search: vi.fn(searchImpl),
+        },
+    } as unknown as ZenoClient;
+}
+
+describe('DocumentSearch', () => {
+    it('settles loading state and preserves current objects when search fails', async () => {
+        const error = new Error('search failed');
+        const currentObject = { id: 'object-1', name: 'Existing object' } as ContentObjectItem;
+        const search = new DocumentSearch(createClient(() => Promise.reject(error)));
+        search.result.value = {
+            objects: [currentObject],
+            isLoading: false,
+            hasMore: true,
+        };
+
+        await expect(search.search()).resolves.toBe(false);
+
+        expect(search.initialized).toBe(true);
+        expect(search.result.value).toMatchObject({
+            error,
+            isLoading: false,
+            objects: [currentObject],
+            hasMore: false,
+        });
+    });
+
+    it('handles a missing index as an empty initialized search', async () => {
+        const error = Object.assign(new Error('index missing'), { status: 404 });
+        const search = new DocumentSearch(createClient(() => Promise.reject(error)));
+
+        await expect(search.search()).resolves.toBe(false);
+
+        expect(search.initialized).toBe(true);
+        expect(search.result.value).toEqual({
+            isLoading: false,
+            objects: [],
+            hasMore: false,
+        });
+    });
+});

--- a/packages/ui/src/features/store/objects/search/DocumentSearchContext.ts
+++ b/packages/ui/src/features/store/objects/search/DocumentSearchContext.ts
@@ -18,6 +18,7 @@ export class DocumentSearch implements SearchInterface {
     collectionId?: string;
     facets = new SharedState<ComputedFacetResponse>({});
     result = new SharedState<DocumentSearchResult>({ objects: [], isLoading: false });
+    initialized = false;
 
     facetSpecs: FacetSpec[] = [];
     query: ComplexSearchQuery = {};
@@ -88,6 +89,7 @@ export class DocumentSearch implements SearchInterface {
     }
 
     reset(isLoading = false) {
+        this.initialized = false;
         this.result.value = {
             objects: [],
             isLoading,
@@ -133,9 +135,13 @@ export class DocumentSearch implements SearchInterface {
         });
     }
 
-    _search(loadMore = false, noFacets = false) {
-        if (this.isRunning && loadMore) { // avoid searching when a search is pending, but allow initial search
-            return Promise.resolve(false);
+    async _search(loadMore = false, noFacets = false): Promise<boolean> {
+        if (this.isRunning && loadMore) {
+            return false;
+        }
+        const previous = this.result.value;
+        if (!loadMore) {
+            this.initialized = true;
         }
         this.result.value = {
             isLoading: true,
@@ -144,7 +150,8 @@ export class DocumentSearch implements SearchInterface {
         }
         const limit = this.limit;
         const offset = loadMore ? this.objects.length : 0;
-        return this._searchRequest(this.query, limit, offset, !noFacets).then(async (res) => {
+        try {
+            const res = await this._searchRequest(this.query, limit, offset, !noFacets);
             // Handle the new format with results and facets
             const results = res.results || [];
             const facets = res.facets || {};
@@ -161,25 +168,25 @@ export class DocumentSearch implements SearchInterface {
             }
 
             return true;
-        }).catch((err) => {
+        } catch (err: unknown) {
             // index_not_found_exception means the data store has no index yet — treat as empty
-            if (err?.status === 404) {
+            if (typeof err === 'object' && err !== null && 'status' in err && err.status === 404) {
                 this.result.value = { isLoading: false, objects: [], hasMore: false };
                 return false;
             }
+            const error = err instanceof Error ? err : new Error(String(err));
             this.result.value = {
-                error: err,
+                error,
                 isLoading: false,
-                objects: this.objects,
-                hasMore: this.result.value.hasMore
+                objects: previous.objects,
+                hasMore: false
             }
-            throw err;
-        })
+            return false;
+        }
     }
 
     search(noFacets = false) {
-        // Allow initial search even if isLoading is true (for initial page load)
-        if (this.isRunning && this.objects.length > 0) {
+        if (this.isRunning) {
             return Promise.resolve(false);
         }
         return this._search(false, noFacets);

--- a/packages/ui/src/features/store/objects/search/DocumentSearchProvider.tsx
+++ b/packages/ui/src/features/store/objects/search/DocumentSearchProvider.tsx
@@ -45,7 +45,7 @@ export function DocumentSearchProvider({ children, limit, parent, typeId, facets
             search.query.all_revisions = true;
         }
         return search;
-    }, [typeId, limit, collectionId]);
+    }, [collectionId, facets, limit, name, parent, store, typeId]);
 
     return (
         <SearchContext.Provider value={search}>{children}</SearchContext.Provider>

--- a/packages/ui/src/features/store/objects/selection/ObjectsActionContext.tsx
+++ b/packages/ui/src/features/store/objects/selection/ObjectsActionContext.tsx
@@ -60,7 +60,7 @@ export function ObjectsActionContextProvider({ children, type }: ObjectsActionCo
         context.allActions = DEFAULT_ACTIONS;
         context.wfRules = rules!;
         return context;
-    }, [selection, rules, type]);
+    }, [client, search, selection, rules, toast, type]);
 
     if (error) {
         return <ErrorBox title={t('store.failedToFetchWorkflows')}>{errorMessage(error)}</ErrorBox>

--- a/packages/ui/src/features/store/objects/selection/actions/DeleteObjectsAction.tsx
+++ b/packages/ui/src/features/store/objects/selection/actions/DeleteObjectsAction.tsx
@@ -66,7 +66,7 @@ export function DeleteObjectsActionComponent({ action, objectIds, children }: Ac
                 duration: 5000
             });
         });
-    }, [objectIds]);
+    }, [client.store.objects.delete, ctx.params?.selection?.removeAll, navigate, objectIds, search, search.facets, search.resetFacets, search.search, t, toast]);
 
     return (
         <ConfirmAction action={action} callback={callback}>

--- a/packages/ui/src/features/store/objects/selection/actions/RemoveFromCollectionAction.tsx
+++ b/packages/ui/src/features/store/objects/selection/actions/RemoveFromCollectionAction.tsx
@@ -60,7 +60,7 @@ export function RemoveFromCollectionActionComponent({ action, objectIds, collect
                 duration: 5000
             });
         });
-    }, [objectIds, collectionId]);
+    }, [client.store.collections.deleteMembers, collectionId, ctx.params?.selection?.removeAll, objectIds, search, search.search, t, toast]);
 
     return (
         <ConfirmAction action={action} callback={callback}>

--- a/packages/ui/src/features/store/objects/upload/DocumentUploadModal.tsx
+++ b/packages/ui/src/features/store/objects/upload/DocumentUploadModal.tsx
@@ -4,7 +4,7 @@ import { useUserSession } from "@vertesia/ui/session";
 import { useTypeRegistry } from "../../types/TypeRegistryProvider.js";
 import { DropZone, UploadSummary } from '@vertesia/ui/widgets';
 import { AlertCircleIcon, CheckCircleIcon, FileIcon, FolderIcon, Info, UploadIcon, XCircleIcon } from "lucide-react";
-import { ReactNode, useEffect, useMemo, useState } from "react";
+import { ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import { useUITranslation } from '@vertesia/ui/i18n';
 import { FileUploadAction, FileWithMetadata, useSmartFileUploadProcessing } from "./useSmartFileUploadProcessing";
 import { DocumentUploadResult } from "./useUploadHandler";
@@ -94,7 +94,7 @@ export function DocumentUploadModal({
     useEffect(() => {
         if (!collectionId) return;
         client.store.collections.retrieve(collectionId).then(setCollectionData);
-    }, [collectionId]);
+    }, [client.store.collections.retrieve, collectionId]);
 
     // Update title and description based on current state
     useEffect(() => {
@@ -158,66 +158,8 @@ export function DocumentUploadModal({
         return typeRegistry?.types || [];
     }, [typeRegistry?.types]);
 
-    // Reset state when modal opens/closes
-    useEffect(() => {
-        if (isOpen) {
-            // Always reset state first
-            setProcessedFiles([]);
-            setProcessingDone(false);
-            setSelectedType(null);
-            setFileStatuses([]);
-            setIsUploading(false);
-            setUploadComplete(false);
-            setOverallProgress(0);
-            setProcessingStats({ toCreate: 0, toUpdate: 0, toSkip: 0 });
-            setResult(null);
-            setTitle(resolvedTitle);
-            setDescription("");
-
-            // Set initial files if provided
-            if (initialFiles && initialFiles.length > 0) {
-                setFiles(initialFiles);
-                processFiles(initialFiles);
-            } else {
-                setFiles([]);
-            }
-
-            // Create a new key to ensure the modal is fresh
-            setModalKey(Date.now());
-        }
-    }, [isOpen, initialFiles]);
-
-    // Complete cleanup when modal closes
-    const handleClose = () => {
-        // Reset all state to initial values to prevent memory leaks
-        setFiles([]);
-        setProcessedFiles([]);
-        setProcessingDone(false);
-        setSelectedType(null);
-        setFileStatuses([]);
-        setIsUploading(false);
-        setUploadComplete(false);
-        setOverallProgress(0);
-        setProcessingStats({ toCreate: 0, toUpdate: 0, toSkip: 0 });
-        setResult(null);
-        setTitle(resolvedTitle);
-        setDescription("");
-        setModalKey(Date.now());
-
-        // Call the provided onClose function
-        onClose();
-    };
-
-    // Handle file drop/selection
-    const handleFileSelect = (newFiles: File[]) => {
-        if (newFiles && newFiles.length > 0) {
-            setFiles(newFiles);
-            processFiles(newFiles);
-        }
-    };
-
     // Process files to determine create/update/skip status
-    const processFiles = async (filesToProcess: File[]) => {
+    const processFiles = useCallback(async (filesToProcess: File[]) => {
         if (!filesToProcess.length) return;
 
         try {
@@ -257,6 +199,64 @@ export function DocumentUploadModal({
                 status: "error",
                 duration: 5000,
             });
+        }
+    }, [checkDocumentProcessing, collectionId, selectedFolder, t, toast]);
+
+    // Reset state when modal opens/closes
+    useEffect(() => {
+        if (isOpen) {
+            // Always reset state first
+            setProcessedFiles([]);
+            setProcessingDone(false);
+            setSelectedType(null);
+            setFileStatuses([]);
+            setIsUploading(false);
+            setUploadComplete(false);
+            setOverallProgress(0);
+            setProcessingStats({ toCreate: 0, toUpdate: 0, toSkip: 0 });
+            setResult(null);
+            setTitle(resolvedTitle);
+            setDescription("");
+
+            // Set initial files if provided
+            if (initialFiles && initialFiles.length > 0) {
+                setFiles(initialFiles);
+                processFiles(initialFiles);
+            } else {
+                setFiles([]);
+            }
+
+            // Create a new key to ensure the modal is fresh
+            setModalKey(Date.now());
+        }
+    }, [isOpen, initialFiles, processFiles, resolvedTitle]);
+
+    // Complete cleanup when modal closes
+    const handleClose = () => {
+        // Reset all state to initial values to prevent memory leaks
+        setFiles([]);
+        setProcessedFiles([]);
+        setProcessingDone(false);
+        setSelectedType(null);
+        setFileStatuses([]);
+        setIsUploading(false);
+        setUploadComplete(false);
+        setOverallProgress(0);
+        setProcessingStats({ toCreate: 0, toUpdate: 0, toSkip: 0 });
+        setResult(null);
+        setTitle(resolvedTitle);
+        setDescription("");
+        setModalKey(Date.now());
+
+        // Call the provided onClose function
+        onClose();
+    };
+
+    // Handle file drop/selection
+    const handleFileSelect = (newFiles: File[]) => {
+        if (newFiles && newFiles.length > 0) {
+            setFiles(newFiles);
+            processFiles(newFiles);
         }
     };
 

--- a/packages/ui/src/features/store/types/ContentObjectTypesSearch.tsx
+++ b/packages/ui/src/features/store/types/ContentObjectTypesSearch.tsx
@@ -31,18 +31,18 @@ export function ContentObjectTypesSearch({ isDirty = false }: ContentObjectTypes
     const loadMoreRef = useRef<HTMLDivElement>(null);
     useIntersectionObserver(loadMoreRef, () => {
         if (isReady) search.loadMore();
-    }, { deps: [isReady] });
+    }, { deps: [isReady, search] });
 
     useEffect(() => {
         search.search()
             .then(() => setIsReady(true));
-    }, []);
+    }, [search]);
 
     useEffect(() => {
-        search.query.name = searchTerm;
+        search.query.name = debounceValue;
         search.search()
             .then(() => setIsReady(true));
-    }, [debounceValue]);
+    }, [debounceValue, search]);
 
     const [chunkable, setChunkable] = useState<string | undefined>(undefined);
     const onChunkableChange = (data: string | undefined) => {
@@ -53,13 +53,13 @@ export function ContentObjectTypesSearch({ isDirty = false }: ContentObjectTypes
         search.query.chunkable = chunkable ? chunkable == "Yes" : undefined
         search.search()
             .then(() => setIsReady(true));
-    }, [chunkable]);
+    }, [chunkable, search]);
 
     useEffect(() => {
         if (isDirty && isReady) {
             search.search().then(() => setIsReady(true));
         }
-    }, [isDirty]);
+    }, [isDirty, isReady, search]);
 
     const [showCreateModal, setShowCreateModal] = useState(false);
     const onOpenCreateModal = () => {

--- a/packages/ui/src/features/store/types/SelectContentType.tsx
+++ b/packages/ui/src/features/store/types/SelectContentType.tsx
@@ -43,7 +43,7 @@ export function SelectContentType({ className, defaultValue, onChange, isClearab
                 }
             }
         }
-    }, [typeRegistry, defaultValue, multiple])
+    }, [isMounted, typeRegistry, defaultValue, multiple])
 
     const _onChange = (option: ContentObjectTypeItem | null) => {
         setSelectedType(option || undefined);

--- a/packages/ui/src/features/store/types/TypeRegistryProvider.tsx
+++ b/packages/ui/src/features/store/types/TypeRegistryProvider.tsx
@@ -26,6 +26,7 @@ export function TypeRegistryProvider({ children }: TypeRegistryProviderProps) {
     const [registry, setRegistry] = useState<TypeRegistry | undefined>();
     const [isLoading, setIsLoading] = useState(false);
     const fetchRef = useRef(false);
+    const projectIdRef = useRef(project?.id);
 
     const load = useCallback(async () => {
         if (!project || fetchRef.current) return;
@@ -49,9 +50,12 @@ export function TypeRegistryProvider({ children }: TypeRegistryProviderProps) {
 
     // Reset when project changes
     useEffect(() => {
-        setRegistry(undefined);
-        fetchRef.current = false;
-    }, [project]);
+        if (projectIdRef.current !== project?.id) {
+            projectIdRef.current = project?.id;
+            setRegistry(undefined);
+            fetchRef.current = false;
+        }
+    });
 
     return (
         <TypeRegistryContext.Provider value={{ registry, isLoading, load, reload }}>
@@ -67,7 +71,7 @@ export function useTypeRegistry() {
         if (!ctx.registry && !ctx.isLoading) {
             ctx.load();
         }
-    }, [ctx.registry, ctx.isLoading]);
+    }, [ctx.registry, ctx.isLoading, ctx.load]);
 
     return ctx;
 }

--- a/packages/ui/src/features/store/types/search/ObjectTypeSearchProvider.tsx
+++ b/packages/ui/src/features/store/types/search/ObjectTypeSearchProvider.tsx
@@ -16,7 +16,7 @@ export function ObjectTypeSearchProvider({ children, limit, name, chunkable: chu
         search.query.name = name;
         search.query.chunkable = chunkable;
         return search;
-    }, [limit]);
+    }, [chunkable, limit, name, store]);
 
     return (
         <ObjectTypeSearchContext.Provider value={search}>{children}</ObjectTypeSearchContext.Provider>

--- a/packages/ui/src/features/user/UserInfo.test.tsx
+++ b/packages/ui/src/features/user/UserInfo.test.tsx
@@ -1,10 +1,12 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { I18nProvider } from '../../i18n/index.js';
 import { UserInfo } from './UserInfo';
 
-const { retrieveApiKey } = vi.hoisted(() => ({
+const { retrieveApiKey, retrieveGroup, retrieveUser } = vi.hoisted(() => ({
     retrieveApiKey: vi.fn(),
+    retrieveGroup: vi.fn(),
+    retrieveUser: vi.fn(),
 }));
 
 vi.mock('@vertesia/ui/session', () => ({
@@ -15,17 +17,21 @@ vi.mock('@vertesia/ui/session', () => ({
             },
             iam: {
                 groups: {
-                    retrieve: vi.fn(),
+                    retrieve: retrieveGroup,
                 },
             },
             users: {
-                retrieve: vi.fn(),
+                retrieve: retrieveUser,
             },
         },
     }),
 }));
 
 describe('UserInfo', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
     it('renders a missing API key as an unknown principal and caches the 404', async () => {
         const error = Object.assign(new Error('Not Found'), { status: 404 });
         retrieveApiKey.mockRejectedValueOnce(error);
@@ -42,5 +48,41 @@ describe('UserInfo', () => {
         });
         expect(screen.queryByText('Failed to fetch the apikey')).toBeNull();
         expect(retrieveApiKey).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders a missing user as an unknown principal and caches the 404', async () => {
+        const error = Object.assign(new Error('Not Found'), { status: 404 });
+        retrieveUser.mockRejectedValueOnce(error);
+
+        render(
+            <I18nProvider lng="en">
+                <UserInfo userRef="user:missing-user-for-test" showTitle />
+                <UserInfo userRef="user:missing-user-for-test" showTitle />
+            </I18nProvider>,
+        );
+
+        await waitFor(() => {
+            expect(screen.getAllByText('Unknown User')).toHaveLength(2);
+        });
+        expect(screen.queryByText('Failed to fetch user')).toBeNull();
+        expect(retrieveUser).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders a missing group as an unknown principal and caches the 404', async () => {
+        const error = Object.assign(new Error('Not Found'), { status: 404 });
+        retrieveGroup.mockRejectedValueOnce(error);
+
+        render(
+            <I18nProvider lng="en">
+                <UserInfo userRef="group:missing-group-for-test" showTitle />
+                <UserInfo userRef="group:missing-group-for-test" showTitle />
+            </I18nProvider>,
+        );
+
+        await waitFor(() => {
+            expect(screen.getAllByText('Unknown User')).toHaveLength(2);
+        });
+        expect(screen.queryByText('Failed to fetch group')).toBeNull();
+        expect(retrieveGroup).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/ui/src/features/user/UserInfo.test.tsx
+++ b/packages/ui/src/features/user/UserInfo.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { I18nProvider } from '../../i18n/index.js';
+import { UserInfo } from './UserInfo';
+
+const { retrieveApiKey } = vi.hoisted(() => ({
+    retrieveApiKey: vi.fn(),
+}));
+
+vi.mock('@vertesia/ui/session', () => ({
+    useUserSession: () => ({
+        client: {
+            apikeys: {
+                retrieve: retrieveApiKey,
+            },
+            iam: {
+                groups: {
+                    retrieve: vi.fn(),
+                },
+            },
+            users: {
+                retrieve: vi.fn(),
+            },
+        },
+    }),
+}));
+
+describe('UserInfo', () => {
+    it('renders a missing API key as an unknown principal and caches the 404', async () => {
+        const error = Object.assign(new Error('Not Found'), { status: 404 });
+        retrieveApiKey.mockRejectedValueOnce(error);
+
+        render(
+            <I18nProvider lng="en">
+                <UserInfo userRef="apikey:missing-key-for-test" showTitle />
+                <UserInfo userRef="apikey:missing-key-for-test" showTitle />
+            </I18nProvider>,
+        );
+
+        await waitFor(() => {
+            expect(screen.getAllByText('Unknown User')).toHaveLength(2);
+        });
+        expect(screen.queryByText('Failed to fetch the apikey')).toBeNull();
+        expect(retrieveApiKey).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/ui/src/features/user/UserInfo.tsx
+++ b/packages/ui/src/features/user/UserInfo.tsx
@@ -9,11 +9,20 @@ const USER_CACHE: Record<string, Promise<User>> = {};
 const GROUP_CACHE: Record<string, Promise<UserGroup>> = {};
 const APIKEY_CACHE: Record<string, Promise<ApiKey>> = {};
 
+function isNotFoundError(error: unknown) {
+    return typeof error === 'object'
+        && error !== null
+        && 'status' in error
+        && error.status === 404;
+}
+
 function cachedFetch<T>(cache: Record<string, Promise<T>>, key: string, fetcher: () => Promise<T>): Promise<T> {
     let entry = cache[key];
     if (!entry) {
         entry = fetcher().catch((err) => {
-            delete cache[key]; // evict on failure so retries work
+            if (!isNotFoundError(err)) {
+                delete cache[key]; // evict transient failures so retries work
+            }
             throw err;
         });
         cache[key] = entry;
@@ -29,7 +38,10 @@ function cachedFetch<T>(cache: Record<string, Promise<T>>, key: string, fetcher:
 export function useFetchUserInfo(userId: string) {
     const { client } = useUserSession();
 
-    return useFetch(() => cachedFetch(USER_CACHE, userId, () => client.users.retrieve(userId)), [userId]);
+    return useFetch(() => cachedFetch(USER_CACHE, userId, () => client.users.retrieve(userId)), {
+        deps: [userId],
+        condition: () => !!userId,
+    });
 }
 
 /**
@@ -39,7 +51,10 @@ export function useFetchUserInfo(userId: string) {
 export function useFetchGroupInfo(groupId: string) {
     const { client } = useUserSession();
 
-    return useFetch(() => cachedFetch(GROUP_CACHE, groupId, () => client.iam.groups.retrieve(groupId)), [groupId]);
+    return useFetch(() => cachedFetch(GROUP_CACHE, groupId, () => client.iam.groups.retrieve(groupId)), {
+        deps: [groupId],
+        condition: () => !!groupId,
+    });
 }
 
 /**
@@ -49,7 +64,10 @@ export function useFetchGroupInfo(groupId: string) {
 export function useFetchApiKeyInfo(keyId: string) {
     const { client } = useUserSession();
 
-    return useFetch(() => cachedFetch(APIKEY_CACHE, keyId, () => client.apikeys.retrieve(keyId)), [keyId]);
+    return useFetch(() => cachedFetch(APIKEY_CACHE, keyId, () => client.apikeys.retrieve(keyId)), {
+        deps: [keyId],
+        condition: () => !!keyId,
+    });
 }
 
 function AvatarPlaceholder() {
@@ -453,6 +471,17 @@ export function ApiKeyAvatar({ keyId, showTitle = false, size = "md" }: ApiKeyAv
     const { data, error } = useFetchApiKeyInfo(keyId);
 
     if (error) {
+        if (isNotFoundError(error)) {
+            return (
+                <UnknownAvatar
+                    title={t('user.unknownUser')}
+                    message={t('user.unknownUserDescription')}
+                    color="bg-pink-500"
+                    showTitle={showTitle}
+                    size={size}
+                />
+            );
+        }
         return <ErrorAvatar title={t('user.failedToFetchApiKey')} error={error} showTitle={showTitle} size={size} />
     }
 

--- a/packages/ui/src/features/user/UserInfo.tsx
+++ b/packages/ui/src/features/user/UserInfo.tsx
@@ -269,6 +269,19 @@ function ErrorAvatar({ title = "Error", error, showTitle = false, size = "md" }:
     );
 }
 
+function MissingPrincipalAvatar({ showTitle = false, size = "md", color }: InfoProps & { color?: string }) {
+    const { t } = useUITranslation();
+    return (
+        <UnknownAvatar
+            title={t('user.unknownUser')}
+            message={t('user.unknownUserDescription')}
+            color={color}
+            showTitle={showTitle}
+            size={size}
+        />
+    );
+}
+
 interface UserInfoProps extends InfoProps {
     /**
      * The user reference is a string that contains the type and id of the user.
@@ -403,6 +416,9 @@ function GroupAvatar({ userId, showTitle = false, size = "md" }: GroupAvatarProp
     const { data: group, error } = useFetchGroupInfo(userId);
 
     if (error) {
+        if (isNotFoundError(error)) {
+            return <MissingPrincipalAvatar showTitle={showTitle} size={size} color="bg-indigo-500" />
+        }
         return <ErrorAvatar title={t('user.failedToFetchGroup')} error={error} showTitle={showTitle} size={size} />
     }
 
@@ -442,6 +458,9 @@ function UserAvatar({ userId, showTitle = false, size = "md" }: UserAvatarProps)
     const { data: user, error } = useFetchUserInfo(userId);
 
     if (error) {
+        if (isNotFoundError(error)) {
+            return <MissingPrincipalAvatar showTitle={showTitle} size={size} color="bg-indigo-500" />
+        }
         return <ErrorAvatar title={t('user.failedToFetchUser')} error={error} showTitle={showTitle} size={size} />
     }
 
@@ -472,15 +491,7 @@ export function ApiKeyAvatar({ keyId, showTitle = false, size = "md" }: ApiKeyAv
 
     if (error) {
         if (isNotFoundError(error)) {
-            return (
-                <UnknownAvatar
-                    title={t('user.unknownUser')}
-                    message={t('user.unknownUserDescription')}
-                    color="bg-pink-500"
-                    showTitle={showTitle}
-                    size={size}
-                />
-            );
+            return <MissingPrincipalAvatar showTitle={showTitle} size={size} color="bg-pink-500" />
         }
         return <ErrorAvatar title={t('user.failedToFetchApiKey')} error={error} showTitle={showTitle} size={size} />
     }

--- a/packages/ui/src/router/FixLinks.tsx
+++ b/packages/ui/src/router/FixLinks.tsx
@@ -21,7 +21,7 @@ export function FixLinks({ basePath, children }: FixLinksProps) {
                 divElem.removeEventListener('click', listener);
             }
         }
-    }, [ref.current]);
+    }, [basePath]);
     return (
         <div ref={ref} className="h-full w-full">{children}</div>
     )

--- a/packages/ui/src/router/NestedRouterProvider.tsx
+++ b/packages/ui/src/router/NestedRouterProvider.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useMemo } from "react";
 import { FixLinks } from "./FixLinks";
-import { PathMatch } from "./PathMatcher";
 import { createRoute404 } from "./Route404";
 import { RouteComponent } from "./RouteComponent";
 import { NestedRouter, ReactRouterContext, Route, useRouterContext } from "./Router";
@@ -18,7 +17,6 @@ interface RouterProviderProps {
 }
 export function NestedRouterProvider({ routes, index, children, fixLinks = false }: RouterProviderProps) {
     const ctx = useRouterContext();
-    const [nestedRouteMatch, setNestedRouteMatch] = useState<PathMatch<Route> | undefined>(undefined);
     const nestedRouter = useMemo(() => {
         if (typeof window === 'undefined') return null;
         const basePath = ctx.matchedRoutePath;
@@ -27,17 +25,15 @@ export function NestedRouterProvider({ routes, index, children, fixLinks = false
         return nestedRouter;
     }, [ctx.matchedRoutePath, ctx.router, index, routes]);
 
-
-    useEffect(() => {
-        if (nestedRouter) {
-            if (ctx.matchedRoutePath !== nestedRouter.basePath) {
-                // the change doesn't belong to this nested router
-                // it should be handled by the top level router which will change the page or the nested router
-                return;
-            }
-            const route = nestedRouter.match(ctx.remainingPath || '/') || createRoute404();
-            setNestedRouteMatch(route);
+    const nestedRouteMatch = useMemo(() => {
+        if (!nestedRouter) {
+            return undefined;
         }
+        if (ctx.matchedRoutePath !== nestedRouter.basePath) {
+            // The change belongs to another router level and will be handled there.
+            return undefined;
+        }
+        return nestedRouter.match(ctx.remainingPath || '/') || createRoute404();
     }, [ctx.matchedRoutePath, ctx.remainingPath, nestedRouter]);
 
 

--- a/packages/ui/src/router/NestedRouterProvider.tsx
+++ b/packages/ui/src/router/NestedRouterProvider.tsx
@@ -25,7 +25,7 @@ export function NestedRouterProvider({ routes, index, children, fixLinks = false
         const nestedRouter = new NestedRouter(ctx.router, basePath, routes);
         nestedRouter.index = index;
         return nestedRouter;
-    }, []);
+    }, [ctx.matchedRoutePath, ctx.router, index, routes]);
 
 
     useEffect(() => {
@@ -38,7 +38,7 @@ export function NestedRouterProvider({ routes, index, children, fixLinks = false
             const route = nestedRouter.match(ctx.remainingPath || '/') || createRoute404();
             setNestedRouteMatch(route);
         }
-    }, [nestedRouter, ctx.remainingPath]);
+    }, [ctx.matchedRoutePath, ctx.remainingPath, nestedRouter]);
 
 
     const wrapWithFixLinks = fixLinks ?

--- a/packages/ui/src/router/Router.tsx
+++ b/packages/ui/src/router/Router.tsx
@@ -209,12 +209,13 @@ export function usePageTitle(title: string) {
 
 export function useNavigationPrompt(prompt: NavigationPrompt) {
     const { router } = useRouterContext();
+    const topRouter = router.getTopRouter();
     useEffect(() => {
-        router.getTopRouter().prompt = prompt;
+        topRouter.prompt = prompt;
         return () => {
-            router.getTopRouter().prompt = undefined;
+            topRouter.prompt = undefined;
         };
-    }, []);
+    }, [prompt, topRouter]);
 
     useEffect(() => {
         if (prompt.when) {

--- a/packages/ui/src/router/RouterProvider.tsx
+++ b/packages/ui/src/router/RouterProvider.tsx
@@ -39,13 +39,13 @@ export function RouterProvider({ routes, index, onChange, children }: RouterProv
         }).withObserver(onChange);
         router.index = index;
         return router;
-    }, []);
+    }, [index, onChange, routes]);
     useSafeLayoutEffect(() => {
         router?.start();
         return () => {
             router?.stop();
         }
-    }, []);
+    }, [router]);
 
     return state && (
         <ReactRouterContext.Provider value={state}>

--- a/packages/ui/src/session/UserSessionProvider.tsx
+++ b/packages/ui/src/session/UserSessionProvider.tsx
@@ -20,6 +20,7 @@ export function UserSessionProvider({ children, loadOnboardingStatus = true }: U
     const [session, setSession] = useState<UserSession>(new UserSession());
     const { generateState, verifyState, clearState } = useAuthState();
     const hasInitiatedAuthRef = useRef(false);
+    const authFlowRef = useRef<(() => void | (() => void)) | undefined>(undefined);
 
     const redirectToCentralAuth = (projectId?: string, accountId?: string) => {
         const url = new URL(`${CENTRAL_AUTH_REDIRECT}?sts=${Env.endpoints.sts ?? "https://sts.vertesia.io"}`);
@@ -32,7 +33,7 @@ export function UserSessionProvider({ children, loadOnboardingStatus = true }: U
         location.replace(url.toString());
     };
 
-    useEffect(() => {
+    authFlowRef.current = () => {
         // Make this effect idempotent - only run auth flow once
         if (hasInitiatedAuthRef.current) {
             console.log("Auth: skipping duplicate auth flow initiation");
@@ -194,6 +195,10 @@ export function UserSessionProvider({ children, loadOnboardingStatus = true }: U
                 setSession(session.clone());
             }
         });
+    };
+
+    useEffect(() => {
+        return authFlowRef.current?.();
     }, []);
 
     return <UserSessionContext.Provider value={session}>{children}</UserSessionContext.Provider>;

--- a/packages/ui/src/session/auth/useCurrentTenant.ts
+++ b/packages/ui/src/session/auth/useCurrentTenant.ts
@@ -12,7 +12,6 @@ interface TenantConfig {
 }
 
 export function useCurrentTenant() {
-    const t = i18nInstance.getFixedT(null, NAMESPACE);
     const { user } = useUserSession();
     const [currentTenant, setCurrentTenant] = useState<TenantConfig | null>(null);
     const [isLoading, setIsLoading] = useState(true);
@@ -57,7 +56,7 @@ export function useCurrentTenant() {
                 }
             } catch (error) {
                 console.error('Error loading current tenant:', error);
-                setError(t('errors.failedToLoadTenantConfig'));
+                setError(i18nInstance.getFixedT(null, NAMESPACE)('errors.failedToLoadTenantConfig'));
                 setCurrentTenant(null);
             } finally {
                 setIsLoading(false);

--- a/packages/ui/src/shell/apps/StandaloneApp.tsx
+++ b/packages/ui/src/shell/apps/StandaloneApp.tsx
@@ -55,7 +55,7 @@ export function StandaloneAppImpl({ name, AccessDenied = AccessDeniedMessage, ch
                 setState("error");
             }
         }
-    }, [name, authToken]);
+    }, [name, authToken, client.apps.getAppInstallationByName]);
 
     if (state === "loading") {
         return null;

--- a/packages/ui/src/shell/login/InviteAcceptModal.tsx
+++ b/packages/ui/src/shell/login/InviteAcceptModal.tsx
@@ -8,7 +8,7 @@ import { useUITranslation } from '@vertesia/ui/i18n'
 export function InviteAcceptModal() {
 
     const session = useUserSession()
-    const { client, account } = session;
+    const { client } = session;
     const { t } = useUITranslation()
     const [showModal, setShowModal] = useState(false)
     const [invites, setInvites] = useState<TransientToken<UserInviteTokenData>[]>([])
@@ -33,7 +33,7 @@ export function InviteAcceptModal() {
         }).catch(err => {
             console.error("Error fetching invites", err);
         })
-    }, [account?.id])
+    }, [client.account.listInvites])
 
     const closeModal = () => setShowModal(false)
 

--- a/packages/ui/src/shell/login/SigninScreen.tsx
+++ b/packages/ui/src/shell/login/SigninScreen.tsx
@@ -5,7 +5,7 @@ import { useUITranslation } from "@vertesia/ui/i18n";
 import { UserNotFoundError, useUserSession, useUXTracking } from "@vertesia/ui/session";
 import { RegionTag } from "@vertesia/ui/layout";
 import clsx from "clsx";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import EnterpriseSigninButton from "./EnterpriseSigninButton";
 import GitHubSignInButton from "./GitHubSignInButton";
 import GoogleSignInButton from "./GoogleSignInButton";
@@ -82,17 +82,17 @@ function StandardSigninPanel({ authError, darkLogo, lightLogo, preservePath }: {
         signOut();
     };
 
-    const goToSignup = () => {
+    const goToSignup = useCallback(() => {
         setSignupData(undefined);
         setCollectSignupData(true);
-    };
+    }, []);
 
     useEffect(() => {
         if (authError instanceof UserNotFoundError) {
             console.log("User not found, redirecting to signup");
             goToSignup();
         }
-    }, [authError]);
+    }, [authError, goToSignup]);
 
     const onSignup = (data: SignupData, fbToken: string) => {
         console.log("Got Signup data", data);

--- a/packages/ui/src/shell/login/SignupForm.tsx
+++ b/packages/ui/src/shell/login/SignupForm.tsx
@@ -64,7 +64,7 @@ export default function SignupForm({ onSignup, goBack }: SignupFormProps) {
             return;
         }
         setFbUser(user);
-    }, [fbUser]);
+    }, []);
 
     const isValid = () => {
         if (!accountType) {

--- a/packages/ui/src/widgets/SvgIcon.tsx
+++ b/packages/ui/src/widgets/SvgIcon.tsx
@@ -31,7 +31,7 @@ export function SvgIcon({ content, ...props }: SvgIconProps) {
         // Clear and append the new SVG
         containerRef.current.innerHTML = '';
         containerRef.current.appendChild(svgEl);
-    }, [content, props]);
+    });
 
     return <span ref={containerRef} />;
 }

--- a/packages/ui/src/widgets/markdown/useArtifactContent.ts
+++ b/packages/ui/src/widgets/markdown/useArtifactContent.ts
@@ -101,8 +101,6 @@ export function useArtifactContent<T = unknown>({
         contentType: undefined,
     });
 
-    const [retryCount, setRetryCount] = useState(0);
-
     const fetchContent = useCallback(async () => {
         if (!runId) {
             setState({
@@ -210,7 +208,7 @@ export function useArtifactContent<T = unknown>({
 
     useEffect(() => {
         fetchContent();
-    }, [fetchContent, retryCount]);
+    }, [fetchContent]);
 
     const retry = useCallback(() => {
         setState({
@@ -220,8 +218,8 @@ export function useArtifactContent<T = unknown>({
             error: undefined,
             contentType: undefined,
         });
-        setRetryCount(c => c + 1);
-    }, []);
+        void fetchContent();
+    }, [fetchContent]);
 
     return {
         data: state.data,

--- a/packages/ui/src/widgets/markdown/useResolvedUrl.ts
+++ b/packages/ui/src/widgets/markdown/useResolvedUrl.ts
@@ -128,8 +128,6 @@ export function useResolvedUrl({
         return { url: undefined, isLoading: true, error: undefined };
     });
 
-    const [retryCount, setRetryCount] = useState(0);
-
     const fetchUrl = useCallback(async () => {
         // Skip if already resolved or standard URL
         if (mappedRoute || scheme === 'standard') {
@@ -223,12 +221,12 @@ export function useResolvedUrl({
         return () => {
             cancelled = true;
         };
-    }, [fetchUrl, retryCount, state.url, state.error]);
+    }, [fetchUrl, state.url, state.error]);
 
     const retry = useCallback(() => {
         setState({ url: undefined, isLoading: true, error: undefined });
-        setRetryCount(c => c + 1);
-    }, []);
+        void fetchUrl();
+    }, [fetchUrl]);
 
     return {
         url: state.url,

--- a/packages/ui/src/widgets/monacoEditor/MonacoEditor.tsx
+++ b/packages/ui/src/widgets/monacoEditor/MonacoEditor.tsx
@@ -73,6 +73,7 @@ export function MonacoEditor({
     const resolvedTheme = theme === 'system'
         ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
         : theme;
+    const effectiveValue = value || defaultValue || '';
 
     const getValueRef = useRef(() => editorValue);
     const setValueRef = useRef((newValue: string) => {
@@ -182,23 +183,25 @@ export function MonacoEditor({
 
     // Update editor value when prop changes from outside
     useEffect(() => {
-        const effectiveValue = value || defaultValue || '';
-        if (effectiveValue !== editorValue) {
-            setEditorValue(effectiveValue);
+        setEditorValue(currentValue => {
+            if (effectiveValue === currentValue) {
+                return currentValue;
+            }
             if (editorInstanceRef.current) {
                 editorInstanceRef.current.setValue(effectiveValue);
             }
-        }
-    }, [value]); // Only depend on value prop, not editorValue
+            return effectiveValue;
+        });
+    }, [effectiveValue]);
 
     // Re-fold code blocks when value prop changes externally
     useEffect(() => {
-        if (!useCustomFolding || !editorInstanceRef.current || !monacoInstanceRef.current) return;
+        if (!effectiveValue || !useCustomFolding || !editorInstanceRef.current || !monacoInstanceRef.current) return;
         const editor = editorInstanceRef.current;
         const monacoInstance = monacoInstanceRef.current;
         const timer = setTimeout(() => foldAllCodeBlocks(editor, monacoInstance), 300);
         return () => clearTimeout(timer);
-    }, [value, useCustomFolding, foldAllCodeBlocks]);
+    }, [effectiveValue, useCustomFolding, foldAllCodeBlocks]);
 
     const defaultOptions: monaco.editor.IStandaloneEditorConstructionOptions = {
         fontSize: 14,

--- a/packages/ui/src/widgets/schema-editor/editor/PropertyEditor.tsx
+++ b/packages/ui/src/widgets/schema-editor/editor/PropertyEditor.tsx
@@ -140,7 +140,7 @@ function EditDescriptionModalForm({ value, onSave }: EditDescriptionModalFormPro
     const [currentValue, setCurrentValue] = useState(value || '');
     useEffect(() => {
         ref.current?.focus();
-    }, [ref.current]);
+    }, []);
     return (
         <>
             <ModalBody className="h-max">


### PR DESCRIPTION
## Summary
- Fix remaining React hook dependency lint warnings in `@vertesia/ui` and `@vertesia/react`.
- Promote `lint/correctness/useExhaustiveDependencies` to error in `composableai/biome.json`.
- Remove a stale unused Biome suppression in the document layout table.

## Verification
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm exec biome lint --only=lint/correctness/useExhaustiveDependencies --reporter=github .`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm --prefix composableai/packages/ui run lint`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm --prefix composableai/packages/ui exec tsc -p tsconfig.json --noEmit`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm --prefix composableai/packages/react run lint`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm --prefix composableai/packages/react run build`
- `git -C composableai diff --check`
