### PR TITLE
Use client wording in OpenAPI schema description

### DIFF
--- a/packages/common/src/apps.ts
+++ b/packages/common/src/apps.ts
@@ -193,7 +193,7 @@ export interface MCPToolCollectionObject extends BaseToolCollectionObject {
 }
 
 /**
- * Vertesia SDK tool collection configuration
+ * Vertesia client tool collection configuration
  */
 export interface VertesiaSDKToolCollectionObject extends BaseToolCollectionObject {
     type: "vertesia_sdk";


### PR DESCRIPTION
## Summary
- Change the OpenAPI-emitted tool collection schema description from Vertesia SDK to Vertesia client.
- Keep the existing vertesia_sdk wire value and TypeScript type names unchanged.

## Verification
- pnpm exec biome lint --diagnostic-level=error