### PR TITLE
feat: refactor Studio tool build support

### DIFF
--- a/packages/build-tools/rollup.config.js
+++ b/packages/build-tools/rollup.config.js
@@ -12,6 +12,7 @@ export default {
         'rollup',
         'gray-matter',
         'zod',
+        'typescript',
         /^node:/,  // All node: imports
         /^@rollup\//,  // All @rollup/* packages
         'rollup-plugin-terser'

--- a/packages/build-tools/src/index.ts
+++ b/packages/build-tools/src/index.ts
@@ -55,3 +55,8 @@ export {
 
 // Utilities
 export { parseFrontmatter, type FrontmatterResult } from './parsers/frontmatter.js';
+export {
+    createRollupTypescript,
+    isRollupWatchMode,
+    type RollupTypescriptOptions
+} from './utils/rollup-typescript.js';

--- a/packages/build-tools/src/utils/rollup-typescript.ts
+++ b/packages/build-tools/src/utils/rollup-typescript.ts
@@ -1,0 +1,37 @@
+import type * as ts from 'typescript';
+
+type TypescriptModule = typeof ts;
+
+export interface RollupTypescriptOptions {
+    watchMode?: boolean;
+}
+
+export function isRollupWatchMode(): boolean {
+    return process.env.ROLLUP_WATCH === 'true' || process.argv.includes('--watch') || process.argv.includes('-w');
+}
+
+export function createRollupTypescript(
+    typescript: TypescriptModule,
+    options: RollupTypescriptOptions = {}
+): TypescriptModule {
+    if (options.watchMode ?? isRollupWatchMode()) {
+        return typescript;
+    }
+
+    // @rollup/plugin-typescript creates a TypeScript watch program even for one-shot builds.
+    // No-op TS watchers here so Rollup can exit cleanly after writing output files.
+    const nonWatchingTypescript = Object.create(typescript) as TypescriptModule;
+    Object.defineProperty(nonWatchingTypescript, 'sys', {
+        enumerable: true,
+        value: {
+            ...typescript.sys,
+            watchFile() {
+                return { close() {} };
+            },
+            watchDirectory() {
+                return { close() {} };
+            },
+        },
+    });
+    return nonWatchingTypescript;
+}

--- a/packages/build-tools/src/utils/widget-compiler.ts
+++ b/packages/build-tools/src/utils/widget-compiler.ts
@@ -10,6 +10,7 @@ import type { RollupTypescriptOptions } from '@rollup/plugin-typescript';
 import type { RollupJsonOptions } from '@rollup/plugin-json';
 import type { RollupNodeResolveOptions } from '@rollup/plugin-node-resolve';
 import type { Options as TerserOptions } from '@rollup/plugin-terser';
+import { createRollupTypescript } from './rollup-typescript.js';
 
 type PluginFactory<TOptions = undefined> = (options?: TOptions) => Plugin;
 
@@ -67,6 +68,7 @@ export async function compileWidgets(
             await import('@rollup/plugin-typescript'),
             '@rollup/plugin-typescript'
         );
+        const ts = await import('typescript');
         const nodeResolve = getPluginFactory<RollupNodeResolveOptions>(
             await import('@rollup/plugin-node-resolve'),
             '@rollup/plugin-node-resolve'
@@ -85,6 +87,7 @@ export async function compileWidgets(
                 tsconfig,
                 declaration: false,
                 sourceMap: true,
+                typescript: createRollupTypescript(ts, { watchMode: false }),
                 ...typescriptOptions
             }),
             // Order matters: json must come before node-resolve so .json imports

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -42,6 +42,7 @@
       "import": "./lib/esm/index.js",
       "require": "./lib/cjs/index.js"
     },
+    "./package.json": "./package.json",
     "./node": {
       "types": "./lib/types/nodejs/index.d.ts",
       "import": "./lib/esm/nodejs/index.js",

--- a/packages/client/src/AppsApi.ts
+++ b/packages/client/src/AppsApi.ts
@@ -7,7 +7,6 @@ import type {
     AppInstallationWithManifest,
     AppManifest,
     AppManifestData,
-    AppPackage,
     AppToolCollection,
     CountResult,
     ProjectRef,
@@ -42,15 +41,6 @@ export default class AppsApi extends ApiTopic {
      */
     listAppInstallationTools(appInstallId: string): Promise<AppToolCollection[]> {
         return this.get(`/installations/${appInstallId}/tools`)
-    }
-
-    /**
-     * Fetch the always-on system tools package served by studio-server.
-     * Tools and skills (`learn_*`) are returned on separate fields so UIs can
-     * render them distinctly. URLs are already resolved per deployment.
-     */
-    getSystemToolsPackage(scope: string = 'tools'): Promise<AppPackage> {
-        return this.get('/studio-tools/package', { query: { scope } });
     }
 
     /**

--- a/packages/common/src/interaction.ts
+++ b/packages/common/src/interaction.ts
@@ -1349,6 +1349,8 @@ export interface SystemSkillCatalogEntry {
     description: string;
     /** Tool names this skill enables (unlocks) when called */
     tools: string[];
+    /** Whether this skill is part of the default agent toolkit */
+    default?: boolean;
 }
 
 /**

--- a/packages/ui/src/env/index.ts
+++ b/packages/ui/src/env/index.ts
@@ -15,6 +15,7 @@ export interface EnvProps {
         zeno: string,
         studio: string,
         sts: string, // Security Token Service endpoint
+        mcp?: string,
     },
     firebase?: {
         apiKey: string,

--- a/packages/ui/src/i18n/locales/ar.json
+++ b/packages/ui/src/i18n/locales/ar.json
@@ -660,6 +660,7 @@
   "user.failedToFetchUser": "فشل جلب المستخدم",
   "user.groupId": "معرف المجموعة: {{id}}",
   "user.key": "المفتاح:",
+  "user.mcpServer": "خادم MCP",
   "user.organizationId": "معرف المؤسسة",
   "user.organizationRoles": "أدوار المؤسسة",
   "user.privateKey": "المفتاح الخاص",

--- a/packages/ui/src/i18n/locales/de.json
+++ b/packages/ui/src/i18n/locales/de.json
@@ -616,6 +616,7 @@
   "user.failedToFetchUser": "Benutzer konnte nicht abgerufen werden",
   "user.groupId": "Gruppen-ID: {{id}}",
   "user.key": "Schlüssel:",
+  "user.mcpServer": "MCP-Server",
   "user.organizationId": "Organisations-ID",
   "user.organizationRoles": "Organisationsrollen",
   "user.privateKey": "Privater Schlüssel",

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -616,6 +616,7 @@
   "user.failedToFetchUser": "Failed to fetch user",
   "user.groupId": "Group ID: {{id}}",
   "user.key": "Key:",
+  "user.mcpServer": "MCP Server",
   "user.organizationId": "Organization ID",
   "user.organizationRoles": "Organization Roles",
   "user.privateKey": "Private Key",

--- a/packages/ui/src/i18n/locales/es.json
+++ b/packages/ui/src/i18n/locales/es.json
@@ -627,6 +627,7 @@
   "user.failedToFetchUser": "Error al obtener el usuario",
   "user.groupId": "ID del grupo: {{id}}",
   "user.key": "Clave:",
+  "user.mcpServer": "Servidor MCP",
   "user.organizationId": "ID de la organización",
   "user.organizationRoles": "Roles en la organización",
   "user.privateKey": "Clave privada",

--- a/packages/ui/src/i18n/locales/fr.json
+++ b/packages/ui/src/i18n/locales/fr.json
@@ -627,6 +627,7 @@
   "user.failedToFetchUser": "Échec de la récupération de l'utilisateur",
   "user.groupId": "ID du groupe : {{id}}",
   "user.key": "Clé :",
+  "user.mcpServer": "Serveur MCP",
   "user.organizationId": "ID de l'organisation",
   "user.organizationRoles": "Rôles dans l'organisation",
   "user.privateKey": "Clé privée",

--- a/packages/ui/src/i18n/locales/it.json
+++ b/packages/ui/src/i18n/locales/it.json
@@ -627,6 +627,7 @@
   "user.failedToFetchUser": "Impossibile recuperare l'utente",
   "user.groupId": "ID gruppo: {{id}}",
   "user.key": "Chiave:",
+  "user.mcpServer": "Server MCP",
   "user.organizationId": "ID organizzazione",
   "user.organizationRoles": "Ruoli organizzazione",
   "user.privateKey": "Chiave privata",

--- a/packages/ui/src/i18n/locales/ja.json
+++ b/packages/ui/src/i18n/locales/ja.json
@@ -616,6 +616,7 @@
   "user.failedToFetchUser": "ユーザーの取得に失敗しました",
   "user.groupId": "グループID：{{id}}",
   "user.key": "キー：",
+  "user.mcpServer": "MCPサーバー",
   "user.organizationId": "組織ID",
   "user.organizationRoles": "組織ロール",
   "user.privateKey": "秘密鍵",

--- a/packages/ui/src/i18n/locales/ko.json
+++ b/packages/ui/src/i18n/locales/ko.json
@@ -616,6 +616,7 @@
   "user.failedToFetchUser": "사용자 가져오기 실패",
   "user.groupId": "그룹 ID: {{id}}",
   "user.key": "키:",
+  "user.mcpServer": "MCP 서버",
   "user.organizationId": "조직 ID",
   "user.organizationRoles": "조직 역할",
   "user.privateKey": "개인 키",

--- a/packages/ui/src/i18n/locales/pt.json
+++ b/packages/ui/src/i18n/locales/pt.json
@@ -627,6 +627,7 @@
   "user.failedToFetchUser": "Falha ao obter o usuário",
   "user.groupId": "ID do grupo: {{id}}",
   "user.key": "Chave:",
+  "user.mcpServer": "Servidor MCP",
   "user.organizationId": "ID da organização",
   "user.organizationRoles": "Funções na organização",
   "user.privateKey": "Chave privada",

--- a/packages/ui/src/i18n/locales/ru.json
+++ b/packages/ui/src/i18n/locales/ru.json
@@ -638,6 +638,7 @@
   "user.failedToFetchUser": "Не удалось получить пользователя",
   "user.groupId": "ID группы: {{id}}",
   "user.key": "Ключ:",
+  "user.mcpServer": "MCP-сервер",
   "user.organizationId": "ID организации",
   "user.organizationRoles": "Роли в организации",
   "user.privateKey": "Закрытый ключ",

--- a/packages/ui/src/i18n/locales/tr.json
+++ b/packages/ui/src/i18n/locales/tr.json
@@ -616,6 +616,7 @@
   "user.failedToFetchUser": "Kullanıcı getirilemedi",
   "user.groupId": "Grup ID: {{id}}",
   "user.key": "Anahtar:",
+  "user.mcpServer": "MCP Sunucusu",
   "user.organizationId": "Kuruluş ID",
   "user.organizationRoles": "Kuruluş Rolleri",
   "user.privateKey": "Özel Anahtar",

--- a/packages/ui/src/i18n/locales/zh-TW.json
+++ b/packages/ui/src/i18n/locales/zh-TW.json
@@ -616,6 +616,7 @@
   "user.failedToFetchUser": "取得使用者失敗",
   "user.groupId": "群組ID：{{id}}",
   "user.key": "金鑰：",
+  "user.mcpServer": "MCP 伺服器",
   "user.organizationId": "組織ID",
   "user.organizationRoles": "組織角色",
   "user.privateKey": "私鑰",

--- a/packages/ui/src/i18n/locales/zh.json
+++ b/packages/ui/src/i18n/locales/zh.json
@@ -616,6 +616,7 @@
   "user.failedToFetchUser": "获取用户失败",
   "user.groupId": "群组ID：{{id}}",
   "user.key": "密钥：",
+  "user.mcpServer": "MCP 服务器",
   "user.organizationId": "组织ID",
   "user.organizationRoles": "组织角色",
   "user.privateKey": "私钥",

--- a/packages/ui/src/shell/login/UserInfo.tsx
+++ b/packages/ui/src/shell/login/UserInfo.tsx
@@ -39,6 +39,7 @@ export default function InfoList() {
     const { account, project, client, authToken } = session;
     const server = new URL(client.baseUrl).hostname;
     const store = new URL(client.store.baseUrl).hostname;
+    const mcpServer = Env.endpoints.mcp ? new URL(Env.endpoints.mcp).hostname : t('user.unknown');
     const tenantId = project ? getTenantIdFromProject(project) : '';
 
     const tabs = [
@@ -63,6 +64,7 @@ export default function InfoList() {
                     <InfoItems title={t('user.environment')} value={Env.type} />
                     <InfoItems title={t('user.server')} value={server} />
                     <InfoItems title={t('user.store')} value={store} />
+                    <InfoItems title={t('user.mcpServer')} value={mcpServer} />
                     <InfoItems title={t('user.appVersion')} value={Env.version} />
                     <InfoItems title={t('user.sdkVersion')} value={Env.sdkVersion || t('user.unknown')} />
                 </div>

--- a/packages/ui/src/widgets/json-view/JSONTable.tsx
+++ b/packages/ui/src/widgets/json-view/JSONTable.tsx
@@ -37,7 +37,7 @@ function formatValue(value: unknown): JSX.Element | string {
 			<>
 				{value.map((item, index) => (
 					<div className="flex gap-1" key={index}>
-						<span className="text-xs align-top pr-2 font-medium">{index + 1}:</span>
+						<span className="text-xs align-top pe-2 font-medium">{index + 1}:</span>
 						<span className="text-xs">{formatValue(item)}</span>
 					</div>
 				))}
@@ -50,7 +50,7 @@ function formatValue(value: unknown): JSX.Element | string {
 			<>
 				{Object.entries(value as Record<string, unknown>).map(([subKey, subValue]) => (
 					<div className="flex gap-1" key={subKey}>
-						<span className="text-xs align-top pr-2 font-medium">{formatCamelCaseKey(subKey)}:</span>
+						<span className="text-xs align-top pe-2 font-medium">{formatCamelCaseKey(subKey)}:</span>
 						<span className="text-xs">{formatValue(subValue)}</span>
 					</div>
 				))}
@@ -69,7 +69,7 @@ export function JSONTable({ data, className }: JSONTableProps): JSX.Element {
 			<tbody>
 				{entries.map(([key, value]) => (
 					<tr key={key} className="align-top hover:bg-background border-y">
-						<td className="align-top pr-4 p-2">{formatCamelCaseKey(key)}</td>
+						<td className="align-top pe-4 p-2">{formatCamelCaseKey(key)}</td>
 						<td className="p-2">{formatValue(value)}</td>
 					</tr>
 				))}


### PR DESCRIPTION
## Summary
- Add a shared Rollup TypeScript wrapper that disables TypeScript watcher handles for one-shot builds while preserving watch mode.
- Use the wrapper in build-tools widget compilation so nested Rollup widget builds exit cleanly.
- Remove the obsolete system tools package client helper and add default metadata to system skill catalog entries.

## Test Plan
- [x] pnpm --prefix composableai/packages/build-tools lint
- [x] pnpm --prefix composableai/packages/build-tools exec tsc --noEmit
- [x] pnpm --prefix composableai/packages/build-tools test
- [x] pnpm --prefix composableai/packages/build-tools build
- [x] pnpm --prefix composableai/packages/common build
- [x] pnpm --prefix composableai/packages/client build
- [x] git -C composableai diff --check