### PR TITLE
fix: fix AskUserWidget option button overflow and label alignment

### DIFF
--- a/packages/ui/src/features/agent/chat/AskUserWidget.tsx
+++ b/packages/ui/src/features/agent/chat/AskUserWidget.tsx
@@ -258,7 +258,7 @@ export function AskUserWidget({
                                         key={option.id}
                                         onClick={() => onSelect?.(option.id)}
                                         disabled={isLoading}
-                                        className={`w-full text-left px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-700
+                                        className={`w-full h-auto whitespace-normal text-left px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-700
                                             bg-white dark:bg-gray-800
                                             hover:bg-gray-50 dark:hover:bg-gray-700 hover:border-gray-300 dark:hover:border-gray-600
                                             focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1
@@ -273,7 +273,7 @@ export function AskUserWidget({
                                                 </span>
                                             )}
                                             <div className="flex-1 overflow-hidden">
-                                                <div className="font-medium text-sm text-gray-900 dark:text-gray-100 break-words">
+                                                <div className="font-medium text-sm text-gray-900 dark:text-gray-100 break-words text-center">
                                                     {option.label}
                                                 </div>
                                                 {option.description && (


### PR DESCRIPTION
When an agent uses the `ask_user` tool to present options to the user, and the options contain both a label (with an icon) and a description, the option text overflows the button area.  
- Add h-auto and whitespace-normal to override global button styles that applied a fixed h-9 height and whitespace-nowrap, causing description text to overflow vertically
- Center label text to match description alignment