### PR TITLE
feat: support datastore row mutations

### DIFF
--- a/packages/client/src/store/DataApi.ts
+++ b/packages/client/src/store/DataApi.ts
@@ -16,6 +16,8 @@ import {
     DataTable,
     DataStoreTableDetail,
     DataStoreTableDropResult,
+    DataStoreMutateRowsPayload,
+    DataStoreMutateRowsResult,
     DataTableSummary,
     ImportDataPayload,
     ImportJob,
@@ -391,6 +393,20 @@ export class DataApi extends ApiTopic {
 
     queryBatch(id: string, queries: QueryPayload[]): Promise<BatchQueryResult> {
         return this.post(`/${id}/query/batch`, { payload: { queries }, headers: this.storeHeaders(id) });
+    }
+
+    /**
+     * Execute a single row mutation statement against the data store.
+     *
+     * Only UPDATE and DELETE statements are accepted. The mutation is versioned
+     * and rolled back automatically if the statement or subsequent persistence fails.
+     *
+     * @param id - Data store ID
+     * @param payload - Mutation SQL and commit message
+     * @returns Resulting version ID and affected table row counts
+     */
+    mutateRows(id: string, payload: DataStoreMutateRowsPayload): Promise<DataStoreMutateRowsResult> {
+        return this.post(`/${id}/mutate`, { payload, headers: this.storeHeaders(id) });
     }
 
     /**

--- a/packages/common/src/data-platform.ts
+++ b/packages/common/src/data-platform.ts
@@ -79,6 +79,8 @@ export interface DataColumn {
     default?: string;
     /** Whether this is the primary key */
     primary_key?: boolean;
+    /** Whether this column should use a sequence-backed auto-increment default */
+    auto_increment?: boolean;
     /** Whether values must be unique */
     unique?: boolean;
     /** Semantic type for AI understanding */
@@ -517,6 +519,32 @@ export interface QueryPayload {
 }
 
 /**
+ * Payload for mutating data rows with a single SQL statement.
+ */
+export interface DataStoreMutateRowsPayload {
+    /** SQL statement. Only UPDATE and DELETE statements are accepted. */
+    sql: string;
+    /** Commit message recorded on the resulting data store version. */
+    message: string;
+    /** Allow UPDATE/DELETE statements without a WHERE clause. Defaults to false. */
+    allow_full_table?: boolean;
+}
+
+/**
+ * Result from mutating rows in a data store.
+ */
+export interface DataStoreMutateRowsResult {
+    /** Resulting data store version ID */
+    version_id: string;
+    /** Tables affected by the statement */
+    affected_tables: string[];
+    /** Current row counts for affected tables after the mutation */
+    row_counts: Record<string, number>;
+    /** Statement execution time in milliseconds */
+    execution_time_ms: number;
+}
+
+/**
  * Column metadata in query results.
  */
 export interface QueryResultColumn {
@@ -629,6 +657,8 @@ export interface DataColumnForAI {
     nullable: boolean;
     /** Whether primary key */
     primary_key: boolean;
+    /** Whether sequence-backed auto-increment is enabled */
+    auto_increment: boolean;
     /** Example values */
     examples?: string[];
 }


### PR DESCRIPTION
## Summary
- Add shared request/response types for mutating data store rows with a single UPDATE or DELETE statement.
- Add the `DataApi.mutateRows` client wrapper for `POST /data/{storeId}/mutate`.
- Surface sequence-backed `auto_increment` metadata in data store column types so agents and clients can create sequence-backed IDs.

## Test Plan
- [x] `pnpm --filter @vertesia/common build`
- [x] `pnpm --filter @vertesia/client build`
- [x] Parent studio CI `(dev) build and deploy` passed on `d12ee5924`: https://github.com/vertesia/studio/actions/runs/26339183742
