### PR TITLE
fix: add opt-in fetch retries

### DIFF
--- a/packages/api-fetch-client/README.md
+++ b/packages/api-fetch-client/README.md
@@ -140,6 +140,31 @@ try {
 }
 ```
 
+## Retries
+
+Retries are disabled by default. Enable them explicitly on a client or a single request:
+
+```typescript
+const client = new FetchClient('https://api.example.com')
+  .withRetryPolicy({
+    attempts: 3,
+    methods: ['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE'],
+    statuses: [502, 503, 504],
+    baseDelayMs: 250,
+    maxDelayMs: 4000
+  });
+
+// POST requests are not retried by the default method list. Opt in only when
+// the operation is safe to replay.
+await client.post('/workflow/execute', {
+  payload,
+  retryPolicy: { methods: ['POST'] }
+});
+
+// Disable a client-level retry policy for one request.
+await client.get('/no-retry', { retryPolicy: false });
+```
+
 ### Custom Error Factory
 
 Transform errors before they're thrown:

--- a/packages/api-fetch-client/src/base.ts
+++ b/packages/api-fetch-client/src/base.ts
@@ -5,6 +5,53 @@ import { buildQueryString, join, removeTrailingSlash } from "./utils.js";
 export type FETCH_FN = (input: RequestInfo, init?: RequestInit) => Promise<Response>;
 type IPrimitives = string | number | boolean | null | undefined | string[] | number[] | boolean[];
 
+export interface IRequestRetryPolicy {
+    /**
+     * Total attempts, including the first request. Defaults to 3 when a retry policy is enabled.
+     */
+    attempts?: number;
+    /**
+     * HTTP methods that may be retried. Defaults to idempotent methods.
+     */
+    methods?: string[];
+    /**
+     * HTTP response statuses that should be retried. Defaults to 502, 503, and 504.
+     */
+    statuses?: number[];
+    /**
+     * Retry network failures thrown by fetch. Defaults to true.
+     */
+    retryOnConnectionError?: boolean;
+    /**
+     * Initial backoff delay in milliseconds. Defaults to 250.
+     */
+    baseDelayMs?: number;
+    /**
+     * Maximum backoff delay in milliseconds. Defaults to 4000.
+     */
+    maxDelayMs?: number;
+    /**
+     * Use full jitter for backoff delays. Defaults to true.
+     */
+    jitter?: boolean;
+}
+
+type NormalizedRetryPolicy = {
+    attempts: number;
+    methods: Set<string>;
+    statuses: Set<number>;
+    retryOnConnectionError: boolean;
+    baseDelayMs: number;
+    maxDelayMs: number;
+    jitter: boolean;
+};
+
+const DEFAULT_RETRY_METHODS = ['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE'];
+const DEFAULT_RETRY_STATUSES = [502, 503, 504];
+const DEFAULT_RETRY_ATTEMPTS = 3;
+const DEFAULT_RETRY_BASE_DELAY_MS = 250;
+const DEFAULT_RETRY_MAX_DELAY_MS = 4000;
+
 function isRecord(value: unknown): value is Record<string, unknown> {
     return value !== null && typeof value === 'object';
 }
@@ -27,6 +74,11 @@ export interface IRequestParams {
      * If you need to post other data than a json payload, set this to false and use the `payload` property to set the desired payload
      */
     jsonPayload?: boolean
+    /**
+     * Opt-in retry policy for this request. Retries are disabled by default.
+     * Set to false to disable a client-level retry policy for this request.
+     */
+    retryPolicy?: IRequestRetryPolicy | false | null;
 }
 
 export interface IRequestParamsWithPayload extends IRequestParams {
@@ -50,12 +102,66 @@ function isInvalidJsonPayload(payload: unknown) {
     return isRecord(payload) && payload.error === "Not a valid JSON payload" && typeof payload.text === "string";
 }
 
+function isReplayableBody(body: BodyInit | undefined) {
+    return !body || typeof ReadableStream === 'undefined' || !(body instanceof ReadableStream);
+}
+
+function normalizeRetryPolicy(policy: IRequestRetryPolicy): NormalizedRetryPolicy {
+    const attempts = Math.max(1, Math.floor(policy.attempts ?? DEFAULT_RETRY_ATTEMPTS));
+    const baseDelayMs = Math.max(0, policy.baseDelayMs ?? DEFAULT_RETRY_BASE_DELAY_MS);
+    const maxDelayMs = Math.max(baseDelayMs, policy.maxDelayMs ?? DEFAULT_RETRY_MAX_DELAY_MS);
+    return {
+        attempts,
+        methods: new Set((policy.methods ?? DEFAULT_RETRY_METHODS).map(method => method.toUpperCase())),
+        statuses: new Set(policy.statuses ?? DEFAULT_RETRY_STATUSES),
+        retryOnConnectionError: policy.retryOnConnectionError ?? true,
+        baseDelayMs,
+        maxDelayMs,
+        jitter: policy.jitter ?? true,
+    };
+}
+
+function retryAfterDelayMs(res: Response): number | undefined {
+    const retryAfter = res.headers.get('retry-after');
+    if (!retryAfter) {
+        return undefined;
+    }
+    const seconds = Number(retryAfter);
+    if (Number.isFinite(seconds) && seconds >= 0) {
+        return seconds * 1000;
+    }
+    const retryAt = Date.parse(retryAfter);
+    if (!Number.isNaN(retryAt)) {
+        return Math.max(0, retryAt - Date.now());
+    }
+    return undefined;
+}
+
+function retryDelayMs(policy: NormalizedRetryPolicy, attempt: number, res?: Response): number {
+    const retryAfter = res ? retryAfterDelayMs(res) : undefined;
+    const delay = retryAfter ?? Math.min(policy.maxDelayMs, policy.baseDelayMs * 2 ** attempt);
+    return policy.jitter ? Math.floor(Math.random() * delay) : delay;
+}
+
+function toError(err: unknown): Error {
+    return err instanceof Error ? err : new Error(String(err));
+}
+
+async function discardBody(res: Response) {
+    try {
+        await res.body?.cancel();
+    } catch {
+        // Ignore body cleanup failures while retrying the original request.
+    }
+}
+
 export abstract class ClientBase {
 
     _fetch: Promise<FETCH_FN>;
     baseUrl: string;
     errorFactory: (err: RequestError) => Error = (err) => err;
     verboseErrors = true;
+    retryPolicy?: IRequestRetryPolicy;
 
     abstract get headers(): Record<string, string>;
 
@@ -70,6 +176,15 @@ export abstract class ClientBase {
      */
     throwError(err: RequestError): never {
         throw this.errorFactory(err);
+    }
+
+    withRetryPolicy(policy?: IRequestRetryPolicy | null): this {
+        this.retryPolicy = policy || undefined;
+        return this;
+    }
+
+    getRetryPolicy(): IRequestRetryPolicy | undefined {
+        return this.retryPolicy;
     }
 
     /**
@@ -121,6 +236,9 @@ export abstract class ClientBase {
     */
     createRequest(url: string, init: RequestInit): Promise<Request> {
         return Promise.resolve(new Request(url, init));
+    }
+
+    handleFetchResponse(_req: Request, _res: Response): void {
     }
 
     createServerError(req: Request, res: Response, payload: unknown): RequestError {
@@ -220,18 +338,105 @@ export abstract class ClientBase {
             headers.accept = 'text/event-stream';
         }
 
-        const init: RequestInit = {
-            method: method,
-            headers: headers,
-            body: body,
+        const normalizedMethod = method.toUpperCase();
+        const createRequestInit = (): RequestInit => {
+            return {
+                method: normalizedMethod,
+                headers: Object.assign({}, headers),
+                body: body,
+            };
         }
-        const req = await this.createRequest(url, init);
-        return this._fetch.then(fetch => fetch(req).catch(err => {
-            console.error(`Failed to connect to ${url}`, err);
-            this.throwError(new ConnectionError(req, err));
-        }).then(res => {
+        const retryPolicy = this.resolveRetryPolicy(params);
+        const fetch = await this._fetch;
+
+        if (!retryPolicy) {
+            const req = await this.createRequest(url, createRequestInit());
+            let res: Response;
+            try {
+                res = await fetch(req);
+            } catch (err: unknown) {
+                console.error(`Failed to connect to ${url}`, err);
+                this.throwError(new ConnectionError(req, toError(err)));
+            }
+            this.handleFetchResponse(req, res);
             return this.handleResponse<T>(req, res, params);
-        }));
+        }
+
+        const replayableBody = isReplayableBody(body);
+        let lastReq: Request | undefined;
+        for (let attempt = 0; attempt < retryPolicy.attempts; attempt++) {
+            const req = await this.createRequest(url, createRequestInit());
+            lastReq = req;
+            let res: Response;
+            try {
+                res = await fetch(req);
+            } catch (err: unknown) {
+                if (!this.shouldRetryConnectionError(retryPolicy, normalizedMethod, attempt, replayableBody)) {
+                    console.error(`Failed to connect to ${url}`, err);
+                    this.throwError(new ConnectionError(req, toError(err)));
+                }
+                await this.waitBeforeRetry(retryPolicy, attempt);
+                continue;
+            }
+            this.handleFetchResponse(req, res);
+            if (this.shouldRetryResponse(retryPolicy, normalizedMethod, attempt, replayableBody, res)) {
+                await discardBody(res);
+                await this.waitBeforeRetry(retryPolicy, attempt, res);
+                continue;
+            }
+            return this.handleResponse<T>(req, res, params);
+        }
+
+        if (lastReq) {
+            this.throwError(new ConnectionError(lastReq, new Error(`Retry attempts exhausted for ${normalizedMethod} ${url}`)));
+        }
+        throw new Error(`Retry attempts exhausted for ${normalizedMethod} ${url}`);
+    }
+
+    protected resolveRetryPolicy(params: IRequestParamsWithPayload | undefined): NormalizedRetryPolicy | undefined {
+        if (params?.reader === 'sse' || params?.retryPolicy === false || params?.retryPolicy === null) {
+            return undefined;
+        }
+        const requestPolicy = params?.retryPolicy;
+        const clientPolicy = this.getRetryPolicy();
+        if (!requestPolicy && !clientPolicy) {
+            return undefined;
+        }
+        const policy = normalizeRetryPolicy({
+            ...clientPolicy,
+            ...requestPolicy,
+        });
+        return policy.attempts > 1 ? policy : undefined;
+    }
+
+    private shouldRetryResponse(
+        policy: NormalizedRetryPolicy,
+        method: string,
+        attempt: number,
+        replayableBody: boolean,
+        res: Response,
+    ) {
+        return attempt < policy.attempts - 1
+            && replayableBody
+            && policy.methods.has(method)
+            && policy.statuses.has(res.status);
+    }
+
+    private shouldRetryConnectionError(
+        policy: NormalizedRetryPolicy,
+        method: string,
+        attempt: number,
+        replayableBody: boolean,
+    ) {
+        return attempt < policy.attempts - 1
+            && replayableBody
+            && policy.retryOnConnectionError
+            && policy.methods.has(method);
+    }
+
+    private waitBeforeRetry(policy: NormalizedRetryPolicy, attempt: number, res?: Response) {
+        const delay = retryDelayMs(policy, attempt, res);
+        return new Promise<void>(resolve => setTimeout(resolve, delay));
     }
 
     /**

--- a/packages/api-fetch-client/src/client.ts
+++ b/packages/api-fetch-client/src/client.ts
@@ -101,10 +101,9 @@ export class AbstractFetchClient<T extends AbstractFetchClient<T>> extends Clien
         return request;
     }
 
-    async handleResponse<T = unknown>(req: Request, res: Response, params: IRequestParamsWithPayload | undefined): Promise<T> {
+    handleFetchResponse(req: Request, res: Response): void {
         this.response = res; // store last response
         this.onResponse?.(res, req);
-        return super.handleResponse<T>(req, res, params);
     }
 
 }
@@ -130,6 +129,14 @@ export abstract class ApiTopic extends ClientBase {
 
     handleResponse<T = unknown>(req: Request, res: Response, params: IRequestParamsWithPayload | undefined): T | Promise<T> {
         return this.client.handleResponse<T>(req, res, params);
+    }
+
+    handleFetchResponse(req: Request, res: Response): void {
+        this.client.handleFetchResponse(req, res);
+    }
+
+    getRetryPolicy() {
+        return this.client.getRetryPolicy();
     }
 
     get headers() {

--- a/packages/api-fetch-client/test/test.ts
+++ b/packages/api-fetch-client/test/test.ts
@@ -66,4 +66,111 @@ describe('Test requests', () => {
             done();
         }).catch(done);
     });
+    it('does not retry by default', async () => {
+        let attempts = 0;
+        const noRetryClient = new FetchClient('http://example.test', async () => {
+            attempts++;
+            return new Response(JSON.stringify({ message: 'unavailable' }), {
+                status: 503,
+                headers: { 'content-type': 'application/json' },
+            });
+        });
+
+        let error: unknown;
+        try {
+            await noRetryClient.get('/unstable');
+        } catch (err: unknown) {
+            error = err;
+        }
+
+        assert.equal(attempts, 1);
+        assert.equal((error as { status?: number }).status, 503);
+    });
+    it('retries opted-in transient responses for idempotent methods', async () => {
+        let attempts = 0;
+        const retryClient = new FetchClient('http://example.test', async () => {
+            attempts++;
+            return new Response(JSON.stringify({ attempts }), {
+                status: attempts === 1 ? 503 : 200,
+                headers: { 'content-type': 'application/json' },
+            });
+        }).withRetryPolicy({
+            attempts: 2,
+            baseDelayMs: 0,
+            jitter: false,
+        });
+
+        const payload = await retryClient.get('/unstable') as { attempts: number };
+
+        assert.equal(attempts, 2);
+        assert.equal(payload.attempts, 2);
+    });
+    it('does not retry POST unless the request opts in', async () => {
+        let attempts = 0;
+        const retryClient = new FetchClient('http://example.test', async () => {
+            attempts++;
+            return new Response(JSON.stringify({ message: 'unavailable' }), {
+                status: 503,
+                headers: { 'content-type': 'application/json' },
+            });
+        }).withRetryPolicy({
+            attempts: 2,
+            baseDelayMs: 0,
+            jitter: false,
+        });
+
+        let error: unknown;
+        try {
+            await retryClient.post('/unstable', { payload: { value: true } });
+        } catch (err: unknown) {
+            error = err;
+        }
+
+        assert.equal(attempts, 1);
+        assert.equal((error as { status?: number }).status, 503);
+    });
+    it('retries POST when the request policy explicitly allows it', async () => {
+        let attempts = 0;
+        const retryClient = new FetchClient('http://example.test', async () => {
+            attempts++;
+            return new Response(JSON.stringify({ attempts }), {
+                status: attempts === 1 ? 503 : 200,
+                headers: { 'content-type': 'application/json' },
+            });
+        }).withRetryPolicy({
+            attempts: 2,
+            baseDelayMs: 0,
+            jitter: false,
+        });
+
+        const payload = await retryClient.post('/unstable', {
+            payload: { value: true },
+            retryPolicy: { methods: ['POST'] },
+        }) as { attempts: number };
+
+        assert.equal(attempts, 2);
+        assert.equal(payload.attempts, 2);
+    });
+    it('retries opted-in connection errors', async () => {
+        let attempts = 0;
+        const retryClient = new FetchClient('http://example.test', async () => {
+            attempts++;
+            if (attempts === 1) {
+                throw new TypeError('connection reset');
+            }
+            return new Response(JSON.stringify({ attempts }), {
+                status: 200,
+                headers: { 'content-type': 'application/json' },
+            });
+        }).withRetryPolicy({
+            attempts: 2,
+            baseDelayMs: 0,
+            jitter: false,
+        });
+
+        const payload = await retryClient.get('/unstable') as { attempts: number };
+
+        assert.equal(attempts, 2);
+        assert.equal(payload.attempts, 2);
+    });
 });

--- a/packages/client/src/OAuthServerApi.ts
+++ b/packages/client/src/OAuthServerApi.ts
@@ -28,6 +28,14 @@ export default class OAuthServerApi extends ClientBase {
         return this.parent.handleResponse<T>(req, res, params);
     }
 
+    handleFetchResponse(req: Request, res: Response): void {
+        this.parent.handleFetchResponse(req, res);
+    }
+
+    getRetryPolicy() {
+        return this.parent.getRetryPolicy();
+    }
+
     createAuthorizationRequest(payload: CreateOAuthAuthorizationRequestPayload): Promise<OAuthAuthorizationRequest> {
         return this.post('/requests', { payload });
     }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,4 +1,4 @@
-import { AbstractFetchClient } from "@vertesia/api-fetch-client";
+import { AbstractFetchClient, type IRequestRetryPolicy } from "@vertesia/api-fetch-client";
 import type { AuthTokenPayload, AuthTokenResponse } from "@vertesia/common";
 import AccountApi from "./AccountApi.js";
 import AccountsApi from "./AccountsApi.js";
@@ -63,6 +63,7 @@ export type VertesiaClientProps = {
     sessionTags?: string | string[];
     onRequest?: (request: Request) => void;
     onResponse?: (response: Response) => void;
+    retryPolicy?: IRequestRetryPolicy;
 };
 
 export class VertesiaClient extends AbstractFetchClient<VertesiaClient> {
@@ -190,7 +191,12 @@ export class VertesiaClient extends AbstractFetchClient<VertesiaClient> {
             apikey: opts.apikey,
             onRequest: opts.onRequest,
             onResponse: opts.onResponse,
+            retryPolicy: opts.retryPolicy,
         });
+
+        if (opts.retryPolicy) {
+            this.withRetryPolicy(opts.retryPolicy);
+        }
 
         if (opts.apikey) {
             void this.withApiKey(opts.apikey);
@@ -224,6 +230,11 @@ export class VertesiaClient extends AbstractFetchClient<VertesiaClient> {
     withAuthCallback(authCb?: (() => Promise<string>) | null) {
         this.store.withAuthCallback(authCb);
         return super.withAuthCallback(authCb);
+    }
+
+    withRetryPolicy(policy?: IRequestRetryPolicy | null) {
+        this.store.withRetryPolicy(policy);
+        return super.withRetryPolicy(policy);
     }
 
     async withApiKey(apiKey: string | null) {

--- a/packages/client/src/store/client.ts
+++ b/packages/client/src/store/client.ts
@@ -1,4 +1,4 @@
-import { AbstractFetchClient, type RequestError } from "@vertesia/api-fetch-client";
+import { AbstractFetchClient, type IRequestRetryPolicy, type RequestError } from "@vertesia/api-fetch-client";
 import type { BulkOperationPayload, BulkOperationResponse } from "@vertesia/common";
 import { AgentsApi } from "./AgentsApi.js";
 import { CollectionsApi } from "./CollectionsApi.js";
@@ -29,6 +29,7 @@ export interface ZenoClientProps {
     apikey?: string;
     onRequest?: (request: Request) => void;
     onResponse?: (response: Response) => void;
+    retryPolicy?: IRequestRetryPolicy;
 }
 
 function ensureDefined(serverUrl: string | undefined) {
@@ -46,6 +47,9 @@ export class ZenoClient extends AbstractFetchClient<ZenoClient> {
         super(ensureDefined(opts.serverUrl));
         if (opts.apikey) {
             this.withApiKey(opts.apikey);
+        }
+        if (opts.retryPolicy) {
+            this.withRetryPolicy(opts.retryPolicy);
         }
         this.onRequest = opts.onRequest;
         this.onResponse = opts.onResponse;


### PR DESCRIPTION
## Summary
- Add a default-off `retryPolicy` to `@vertesia/api-fetch-client`.
- Retry only opted-in transient failures: configured statuses, configured methods, network errors, exponential backoff, jitter, and `Retry-After`.
- Propagate retry policy through `VertesiaClient`, `ZenoClient`, and the direct `OAuthServerApi` client path.
- Update the nested llumiverse pointer to a commit already on llumiverse `origin/main`.

## Verification
- `CI=true pnpm --prefix composableai/packages/api-fetch-client build`
- `pnpm --prefix composableai/packages/api-fetch-client lint`
- `pnpm --prefix composableai/packages/api-fetch-client typecheck:test`
- `pnpm --prefix composableai/packages/api-fetch-client test`
- `pnpm --prefix composableai/packages/client build`
- `pnpm --prefix composableai/packages/client lint`
- `pnpm --prefix composableai/packages/client test`
- `pnpm --prefix composableai/packages/client typecheck:test`
- `pnpm run build`
