### PR TITLE
Add project search tier config

### DIFF
--- a/packages/client/src/store/IndexingApi.ts
+++ b/packages/client/src/store/IndexingApi.ts
@@ -26,6 +26,7 @@ import {
     SwapAliasResult,
     ReindexViaBulkRequest,
     ReindexViaBulkResult,
+    ElasticsearchBackend,
 } from "@vertesia/common";
 
 /**
@@ -306,11 +307,17 @@ export class IndexingApi extends ApiTopic {
      * Compute shard boundaries for a tenant via zeno-bulk.
      * Creates the target index and returns shard ranges for parallel indexing.
      */
-    computeShards(tenantId: string, shardSize?: number, updatedSince?: string): Promise<ComputeShardsResult> {
+    computeShards(
+        tenantId: string,
+        shardSize?: number,
+        updatedSince?: string,
+        backend?: ElasticsearchBackend,
+    ): Promise<ComputeShardsResult> {
         return this.zenoBulkPost('/reindex/compute-shards', {
             tenant_id: tenantId,
             shard_size: shardSize ?? 50000,
             updated_since: updatedSince,
+            backend,
         } satisfies ComputeShardsRequest);
     }
 
@@ -326,11 +333,17 @@ export class IndexingApi extends ApiTopic {
      * Atomically swap ES alias via zeno-bulk.
      * @param alias Optional alias name. If not provided, the Go service derives it from the tenant ID.
      */
-    swapAlias(tenantId: string, targetIndex: string, alias?: string): Promise<SwapAliasResult> {
+    swapAlias(
+        tenantId: string,
+        targetIndex: string,
+        alias?: string,
+        backend?: ElasticsearchBackend,
+    ): Promise<SwapAliasResult> {
         return this.zenoBulkPost('/reindex/swap-alias', {
             tenant_id: tenantId,
             target_index: targetIndex,
             alias,
+            backend,
         } satisfies SwapAliasRequest);
     }
 
@@ -347,11 +360,13 @@ export class IndexingApi extends ApiTopic {
         tenantId: string,
         onEvent?: ((event: ServerSentEvent) => void) | null,
         dryRun?: boolean,
+        backend?: ElasticsearchBackend,
     ): Promise<ReindexViaBulkResult> {
         const bulkUrl = this.zenoBulkBaseUrl + '/reindex';
         const payload = {
             tenant_id: tenantId,
             dry_run: dryRun ?? false,
+            backend,
         } satisfies ReindexViaBulkRequest;
 
         if (!onEvent) {

--- a/packages/client/src/store/IndexingApi.ts
+++ b/packages/client/src/store/IndexingApi.ts
@@ -306,10 +306,11 @@ export class IndexingApi extends ApiTopic {
      * Compute shard boundaries for a tenant via zeno-bulk.
      * Creates the target index and returns shard ranges for parallel indexing.
      */
-    computeShards(tenantId: string, shardSize?: number): Promise<ComputeShardsResult> {
+    computeShards(tenantId: string, shardSize?: number, updatedSince?: string): Promise<ComputeShardsResult> {
         return this.zenoBulkPost('/reindex/compute-shards', {
             tenant_id: tenantId,
             shard_size: shardSize ?? 50000,
+            updated_since: updatedSince,
         } satisfies ComputeShardsRequest);
     }
 

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -163,6 +163,7 @@ export interface ProjectModelDefaults {
 // ==========================================
 
 export type ProjectSearchTier = "standard" | "performance";
+export type ElasticsearchBackend = 'serverless' | 'hosted';
 
 export interface ProjectConfiguration {
 
@@ -214,7 +215,7 @@ export interface ProjectConfiguration {
          * Elasticsearch backend override for this project.
          * Prefer search_tier for project configuration unless an explicit backend override is needed.
          */
-        backend?: 'serverless' | 'hosted';
+        backend?: ElasticsearchBackend;
     };
 
     /**
@@ -426,6 +427,7 @@ export interface CreateReindexTargetResult {
     index_name: string;
     alias_name: string;
     version: number;
+    backend?: ElasticsearchBackend;
     dimensions?: {
         text?: number;
         image?: number;
@@ -485,6 +487,7 @@ export interface ComputeShardsRequest {
     tenant_id: string;
     shard_size?: number;
     updated_since?: string;
+    backend?: ElasticsearchBackend;
 }
 
 export interface ComputeShardsResult {
@@ -497,6 +500,7 @@ export interface IndexShardParams {
     target_index: string;
     shard_min: string;
     shard_max?: string;
+    backend?: ElasticsearchBackend;
     embedding_dimensions?: {
         text?: number;
         image?: number;
@@ -536,6 +540,7 @@ export interface IndexShardResult {
 export interface SwapAliasRequest {
     tenant_id: string;
     target_index: string;
+    backend?: ElasticsearchBackend;
     /** ES alias name. If not provided, the Go service derives it from the tenant ID. */
     alias?: string;
 }
@@ -549,6 +554,7 @@ export interface SwapAliasResult {
 
 export interface ReindexViaBulkRequest {
     tenant_id: string;
+    backend?: ElasticsearchBackend;
     dry_run?: boolean;
 }
 
@@ -572,6 +578,7 @@ export interface ReindexViaBulkResult {
  */
 export interface ElasticsearchIndexStats {
     enabled: boolean;
+    backend?: ElasticsearchBackend;
     exists?: boolean;
     document_count?: number;
     size_in_bytes?: number;

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -163,7 +163,7 @@ export interface ProjectModelDefaults {
 // ==========================================
 
 export type ProjectSearchTier = "standard" | "performance";
-export type ElasticsearchBackend = 'serverless' | 'hosted';
+export type ElasticsearchBackend = "serverless" | "hosted";
 
 export interface ProjectConfiguration {
 

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -162,6 +162,8 @@ export interface ProjectModelDefaults {
 // Project Configuration
 // ==========================================
 
+export type ProjectSearchTier = "standard" | "performance";
+
 export interface ProjectConfiguration {
 
     human_context: string;
@@ -199,6 +201,20 @@ export interface ProjectConfiguration {
          * Defaults to true - indexing is always on when ES infrastructure is available.
          */
         enabled?: boolean;
+
+        /**
+         * Search tier for this project.
+         * standard uses the regional hosted Elasticsearch deployment.
+         * performance uses the regional serverless Elasticsearch project.
+         * Defaults to standard when omitted.
+         */
+        search_tier?: ProjectSearchTier;
+
+        /**
+         * Elasticsearch backend override for this project.
+         * Prefer search_tier for project configuration unless an explicit backend override is needed.
+         */
+        backend?: 'serverless' | 'hosted';
     };
 
     /**

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -484,6 +484,7 @@ export interface TriggerReindexResult {
 export interface ComputeShardsRequest {
     tenant_id: string;
     shard_size?: number;
+    updated_since?: string;
 }
 
 export interface ComputeShardsResult {


### PR DESCRIPTION
## Summary
- Add shared project search tier types for routing Elasticsearch-backed search.
- Define `standard` and `performance` tiers so project configuration can select hosted or serverless-backed search behavior from the server side.

## Verification
- `git status --short --branch` reviewed in `composableai` and nested `llumiverse`; both clean.
- Changed package: `@vertesia/common`.
- `pnpm --filter @vertesia/common build` passed.
- `git diff --check origin/preview..HEAD` passed.

Note: local commands warn that this machine is on Node v26 while the repo declares Node 24.x, but the listed checks passed.