### PR TITLE
Add Elasticsearch search tier config

### DIFF
--- a/packages/client/src/store/IndexingApi.ts
+++ b/packages/client/src/store/IndexingApi.ts
@@ -26,6 +26,7 @@ import type {
     SwapAliasResult,
     ReindexViaBulkRequest,
     ReindexViaBulkResult,
+    ElasticsearchBackend,
 } from "@vertesia/common";
 
 /**
@@ -306,11 +307,17 @@ export class IndexingApi extends ApiTopic {
      * Compute shard boundaries for a tenant via zeno-bulk.
      * Creates the target index and returns shard ranges for parallel indexing.
      */
-    computeShards(tenantId: string, shardSize?: number, updatedSince?: string): Promise<ComputeShardsResult> {
+    computeShards(
+        tenantId: string,
+        shardSize?: number,
+        updatedSince?: string,
+        backend?: ElasticsearchBackend,
+    ): Promise<ComputeShardsResult> {
         return this.zenoBulkPost('/reindex/compute-shards', {
             tenant_id: tenantId,
             shard_size: shardSize ?? 50000,
             updated_since: updatedSince,
+            backend,
         } satisfies ComputeShardsRequest);
     }
 
@@ -326,11 +333,17 @@ export class IndexingApi extends ApiTopic {
      * Atomically swap ES alias via zeno-bulk.
      * @param alias Optional alias name. If not provided, the Go service derives it from the tenant ID.
      */
-    swapAlias(tenantId: string, targetIndex: string, alias?: string): Promise<SwapAliasResult> {
+    swapAlias(
+        tenantId: string,
+        targetIndex: string,
+        alias?: string,
+        backend?: ElasticsearchBackend,
+    ): Promise<SwapAliasResult> {
         return this.zenoBulkPost('/reindex/swap-alias', {
             tenant_id: tenantId,
             target_index: targetIndex,
             alias,
+            backend,
         } satisfies SwapAliasRequest);
     }
 
@@ -347,11 +360,13 @@ export class IndexingApi extends ApiTopic {
         tenantId: string,
         onEvent?: ((event: ServerSentEvent) => void) | null,
         dryRun?: boolean,
+        backend?: ElasticsearchBackend,
     ): Promise<ReindexViaBulkResult> {
         const bulkUrl = `${this.zenoBulkBaseUrl}/reindex`;
         const payload = {
             tenant_id: tenantId,
             dry_run: dryRun ?? false,
+            backend,
         } satisfies ReindexViaBulkRequest;
 
         if (!onEvent) {

--- a/packages/client/src/store/IndexingApi.ts
+++ b/packages/client/src/store/IndexingApi.ts
@@ -306,10 +306,11 @@ export class IndexingApi extends ApiTopic {
      * Compute shard boundaries for a tenant via zeno-bulk.
      * Creates the target index and returns shard ranges for parallel indexing.
      */
-    computeShards(tenantId: string, shardSize?: number): Promise<ComputeShardsResult> {
+    computeShards(tenantId: string, shardSize?: number, updatedSince?: string): Promise<ComputeShardsResult> {
         return this.zenoBulkPost('/reindex/compute-shards', {
             tenant_id: tenantId,
             shard_size: shardSize ?? 50000,
+            updated_since: updatedSince,
         } satisfies ComputeShardsRequest);
     }
 

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -265,6 +265,7 @@ export const BrowserUseProjectConfigurationSchema: JSONSchemaType<BrowserUseProj
 // ==========================================
 
 export type ProjectSearchTier = "standard" | "performance";
+export type ElasticsearchBackend = 'serverless' | 'hosted';
 
 export interface ProjectConfiguration {
 
@@ -316,7 +317,7 @@ export interface ProjectConfiguration {
          * Elasticsearch backend override for this project.
          * Prefer search_tier for project configuration unless an explicit backend override is needed.
          */
-        backend?: 'serverless' | 'hosted';
+        backend?: ElasticsearchBackend;
     };
 
     /**
@@ -539,6 +540,7 @@ export interface CreateReindexTargetResult {
     index_name: string;
     alias_name: string;
     version: number;
+    backend?: ElasticsearchBackend;
     dimensions?: {
         text?: number;
         image?: number;
@@ -598,6 +600,7 @@ export interface ComputeShardsRequest {
     tenant_id: string;
     shard_size?: number;
     updated_since?: string;
+    backend?: ElasticsearchBackend;
 }
 
 export interface ComputeShardsResult {
@@ -610,6 +613,7 @@ export interface IndexShardParams {
     target_index: string;
     shard_min: string;
     shard_max?: string;
+    backend?: ElasticsearchBackend;
     embedding_dimensions?: {
         text?: number;
         image?: number;
@@ -649,6 +653,7 @@ export interface IndexShardResult {
 export interface SwapAliasRequest {
     tenant_id: string;
     target_index: string;
+    backend?: ElasticsearchBackend;
     /** ES alias name. If not provided, the Go service derives it from the tenant ID. */
     alias?: string;
 }
@@ -662,6 +667,7 @@ export interface SwapAliasResult {
 
 export interface ReindexViaBulkRequest {
     tenant_id: string;
+    backend?: ElasticsearchBackend;
     dry_run?: boolean;
 }
 
@@ -685,6 +691,7 @@ export interface ReindexViaBulkResult {
  */
 export interface ElasticsearchIndexStats {
     enabled: boolean;
+    backend?: ElasticsearchBackend;
     exists?: boolean;
     document_count?: number;
     size_in_bytes?: number;

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -265,7 +265,7 @@ export const BrowserUseProjectConfigurationSchema: JSONSchemaType<BrowserUseProj
 // ==========================================
 
 export type ProjectSearchTier = "standard" | "performance";
-export type ElasticsearchBackend = 'serverless' | 'hosted';
+export type ElasticsearchBackend = "serverless" | "hosted";
 
 export interface ProjectConfiguration {
 

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -264,6 +264,8 @@ export const BrowserUseProjectConfigurationSchema: JSONSchemaType<BrowserUseProj
 // Project Configuration
 // ==========================================
 
+export type ProjectSearchTier = "standard" | "performance";
+
 export interface ProjectConfiguration {
 
     human_context?: string;
@@ -301,6 +303,20 @@ export interface ProjectConfiguration {
          * Defaults to true - indexing is always on when ES infrastructure is available.
          */
         enabled?: boolean;
+
+        /**
+         * Search tier for this project.
+         * standard uses the regional hosted Elasticsearch deployment.
+         * performance uses the regional serverless Elasticsearch project.
+         * Defaults to standard when omitted.
+         */
+        search_tier?: ProjectSearchTier;
+
+        /**
+         * Elasticsearch backend override for this project.
+         * Prefer search_tier for project configuration unless an explicit backend override is needed.
+         */
+        backend?: 'serverless' | 'hosted';
     };
 
     /**

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -597,6 +597,7 @@ export interface TriggerReindexResult {
 export interface ComputeShardsRequest {
     tenant_id: string;
     shard_size?: number;
+    updated_since?: string;
 }
 
 export interface ComputeShardsResult {


### PR DESCRIPTION
## Summary
- Add project search tier config types for standard/performance routing.
- Pass Elasticsearch backend through indexing client requests.
- Support modified-since reindex shard parameters.

## Verification
- pnpm --filter @vertesia/common lint
- pnpm --dir llumiverse --filter @llumiverse/common build
- pnpm --filter @vertesia/common build
- pnpm --filter @vertesia/client lint
- pnpm --filter @vertesia/api-fetch-client build
- pnpm --filter @vertesia/client build

Note: local shell is Node 26, repo engine warns for Node 24, commands above passed.