### PR TITLE
fix(ui): stabilise toast() ref to break upload-find loop

### DIFF
--- a/packages/ui/src/core/components/toast/ToastProvider.tsx
+++ b/packages/ui/src/core/components/toast/ToastProvider.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { Portal } from "../Portal.js";
 import { NotificationPanel } from "./NotificationPanel.js";
 import { ToastContext } from "./ToastContext.js";
@@ -11,9 +11,15 @@ interface ToastProviderProps {
 export function ToastProvider({ children }: ToastProviderProps) {
     const [data, setData] = useState<ToastProps | null>(null);
 
-    const toast = (data: ToastProps | null) => {
-        setData(data);
-    }
+    // Stable reference: consumers (`useToast`) place this fn in useEffect /
+    // useCallback dep arrays. Without useCallback, ToastProvider re-renders
+    // (e.g. after setData fires from a `toast(...)` call) produce a NEW fn
+    // identity, cascading into broken-effect loops in callers — most notably
+    // DocumentUploadModal's `processFiles` useCallback, which would re-fire
+    // its open-effect on every toast, looping POST /api/v1/objects/find.
+    const toast = useCallback((next: ToastProps | null) => {
+        setData(next);
+    }, []);
 
     return (
         <>


### PR DESCRIPTION
## Summary

`ToastProvider` created a new `toast` function reference on every render and
passed it directly through `ToastContext.Provider`. Consumers (`useToast`)
place that function in `useEffect` / `useCallback` dep arrays — so any call to
`toast(...)` (which fires `setData` inside the provider, re-rendering it and
producing a new function identity) cascades into broken-effect loops.

The most visible regression: in `DocumentUploadModal`, `processFiles` is a
`useCallback` over `[..., toast, ...]`, and the open-effect that resets modal
state lists `processFiles` as a dep. So:

1. User attaches a file → `processFiles` runs.
2. `processFiles` ends with `toast({...})` → `setData` in provider.
3. Provider re-renders → new `toast` reference.
4. `processFiles` useCallback sees a new dep → new identity.
5. Open-effect watcher fires → `processFiles` runs again.
6. Loop. `POST /api/v1/objects/find` x2 per cycle.

Wrap `toast` in `useCallback` with `[]` deps. `setData` from `useState` is
stable, so the empty array is correct. Same patch breaks the cascade for any
other consumer that places `toast` in dep arrays.

## Test plan

- Verified locally via Playwright MCP against `https://localhost:5173`:
  - Pre-fix: modal flickers back to "Drag and drop files here…" right after
    `processFiles` finishes (open-effect re-runs and resets all state).
  - Post-fix: modal stabilises on "File Analysis Results 1 file" surface.
  - Network: `POST /api/v1/objects/find` count is exactly 2 (hash + name
    dedup), no growth.
- Playwright regression test landing alongside in the parent repo:
  see `playwright-tests/vertesia-tests/auth-flow.upload-loop.spec.ts` in
  the corresponding studio PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>