### PR TITLE
Add agent-run reindex API types

### DIFF
--- a/packages/client/src/store/IndexingApi.ts
+++ b/packages/client/src/store/IndexingApi.ts
@@ -27,6 +27,8 @@ import {
     ReindexViaBulkRequest,
     ReindexViaBulkResult,
     ElasticsearchBackend,
+    ReindexAgentRunsPayload,
+    ReindexAgentRunsResponse,
 } from "@vertesia/common";
 
 /**
@@ -61,6 +63,13 @@ export class IndexingApi extends ApiTopic {
      */
     async reindex(options?: StartProjectReindexPayload): Promise<GenericCommandResponse> {
         return this.post("/reindex", { payload: options });
+    }
+
+    /**
+     * Rebuild the agent-run Elasticsearch index directly from MongoDB.
+     */
+    async reindexAgentRuns(options?: ReindexAgentRunsPayload): Promise<ReindexAgentRunsResponse> {
+        return this.post("/agent-runs/reindex", { payload: options });
     }
 
     /**

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -382,6 +382,33 @@ export interface StartProjectReindexPayload {
     bulk_concurrency?: number;
 }
 
+export interface ReindexAgentRunsPayload {
+    /**
+     * Drop any existing agent-runs index/alias family and recreate the stable concrete index before indexing.
+     * Defaults to true.
+     */
+    recreate_index?: boolean;
+    /** Number of MongoDB records to scan per batch. Defaults to 500. */
+    batch_size?: number;
+    /** Optional cap for partial/manual repair runs. Omit for all agent runs in the project. */
+    limit?: number;
+}
+
+export interface ReindexAgentRunsResponse {
+    status: string;
+    backend: ElasticsearchBackend;
+    index_name: string;
+    recreated: boolean;
+    total: number;
+    scanned: number;
+    indexed: number;
+    failed: number;
+    errors?: Array<{
+        id: string;
+        message: string;
+    }>;
+}
+
 // ============================================================================
 // Internal indexing types (used by Temporal workflows)
 // ============================================================================


### PR DESCRIPTION
## Summary
- Add public request/response types for rebuilding agent-run Elasticsearch indices.
- Add `IndexingApi.reindexAgentRuns()` so callers can trigger the zeno agent-run reindex endpoint through the client.

## Verification
- `pnpm turbo build --filter=@dglabs/admin-api --filter=@dglabs/admin-client --filter=@dglabs/admin-cli --filter=@dglabs/zeno-server --filter=@vertesia/common --filter=@vertesia/client`
- `git diff --check` in `composableai`

## Parent PR
- Studio PR will link this submodule update once opened.