### PR TITLE
fix: scope Panel overflow-hidden to clickableHeader

### DIFF
--- a/packages/ui/src/core/components/shadcn/Panel.tsx
+++ b/packages/ui/src/core/components/shadcn/Panel.tsx
@@ -57,7 +57,7 @@ export function Panel({
     const footerPadding = isSmall ? 'px-4 pb-3' : 'px-4 pb-4';
 
     return (
-        <div className={`flex flex-col ${sectioned ? '' : 'p-4 gap-2'} rounded-sm border bg-card overflow-hidden ${className ?? ''}`}>
+        <div className={`flex flex-col ${sectioned ? '' : 'p-4 gap-2'} rounded-sm border bg-card ${useClickableHeader ? 'overflow-hidden' : ''} ${className ?? ''}`}>
             {useClickableHeader ? (
                 <button
                     type="button"


### PR DESCRIPTION
The unconditional overflow-hidden added in #1343 clips content of any Panel whose flex-shrunk height is smaller than its natural content height (e.g. the Information/Features/Model Defaults cards on the project settings page). Restrict it to the clickableHeader case, which is the only one that needs rounded-corner clipping of the hover bg.