### PR TITLE
Add ES reindex client visibility on main

### DIFF
--- a/packages/api-fetch-client/src/base.ts
+++ b/packages/api-fetch-client/src/base.ts
@@ -335,7 +335,7 @@ export abstract class ClientBase {
         }
         // When using SSE reader, ensure the Accept header requests event-stream
         if (params?.reader === 'sse') {
-            headers['accept'] = 'text/event-stream';
+            headers.accept = 'text/event-stream';
         }
 
         const normalizedMethod = method.toUpperCase();

--- a/packages/api-fetch-client/src/base.ts
+++ b/packages/api-fetch-client/src/base.ts
@@ -334,8 +334,8 @@ export abstract class ClientBase {
             }
         }
         // When using SSE reader, ensure the Accept header requests event-stream
-        if (params?.reader === 'sse' && !('accept' in headers)) {
-            headers.accept = 'text/event-stream';
+        if (params?.reader === 'sse') {
+            headers['accept'] = 'text/event-stream';
         }
 
         const normalizedMethod = method.toUpperCase();

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -194,7 +194,6 @@ export class VertesiaClient extends AbstractFetchClient<VertesiaClient> {
             onResponse: opts.onResponse,
             retryPolicy: opts.retryPolicy,
             fetch: opts.fetch,
-            retryPolicy: opts.retryPolicy,
         });
 
         if (opts.retryPolicy) {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,4 +1,4 @@
-import { AbstractFetchClient, type IRequestRetryPolicy } from "@vertesia/api-fetch-client";
+import { AbstractFetchClient, type FETCH_FN, type IRequestRetryPolicy } from "@vertesia/api-fetch-client";
 import type { AuthTokenPayload, AuthTokenResponse } from "@vertesia/common";
 import AccountApi from "./AccountApi.js";
 import AccountsApi from "./AccountsApi.js";
@@ -64,6 +64,7 @@ export type VertesiaClientProps = {
     onRequest?: (request: Request) => void;
     onResponse?: (response: Response) => void;
     retryPolicy?: IRequestRetryPolicy;
+    fetch?: FETCH_FN | Promise<FETCH_FN>;
 };
 
 export class VertesiaClient extends AbstractFetchClient<VertesiaClient> {
@@ -149,7 +150,7 @@ export class VertesiaClient extends AbstractFetchClient<VertesiaClient> {
             );
         }
 
-        super(studioServerUrl);
+        super(studioServerUrl, opts.fetch);
 
         if (opts.tokenServerUrl) {
             this.tokenServerUrl = opts.tokenServerUrl;
@@ -191,6 +192,8 @@ export class VertesiaClient extends AbstractFetchClient<VertesiaClient> {
             apikey: opts.apikey,
             onRequest: opts.onRequest,
             onResponse: opts.onResponse,
+            retryPolicy: opts.retryPolicy,
+            fetch: opts.fetch,
             retryPolicy: opts.retryPolicy,
         });
 

--- a/packages/client/src/store/IndexingApi.ts
+++ b/packages/client/src/store/IndexingApi.ts
@@ -361,23 +361,25 @@ export class IndexingApi extends ApiTopic {
         onEvent?: ((event: ServerSentEvent) => void) | null,
         dryRun?: boolean,
         backend?: ElasticsearchBackend,
+        projectId?: string,
     ): Promise<ReindexViaBulkResult> {
-        const bulkUrl = `${this.zenoBulkBaseUrl}/reindex`;
-        const payload = {
+        const bulkUrl = this.zenoBulkBaseUrl + '/reindex';
+        const params = {
             tenant_id: tenantId,
+            project_id: projectId,
             dry_run: dryRun ?? false,
             backend,
         } satisfies ReindexViaBulkRequest;
 
         if (!onEvent) {
-            return this.client.post(bulkUrl, { payload });
+            return this.client.post(bulkUrl, { payload: { params } });
         }
 
         // SSE mode: stream progress events from zeno-bulk
         let lastResult: ReindexViaBulkResult | undefined;
 
         await this.client.sseRequest('POST', bulkUrl, {
-            payload,
+            payload: { params },
         }, (event) => {
             onEvent(event);
             if (event.type === 'event' && event.event === 'done') {

--- a/packages/client/src/store/IndexingApi.ts
+++ b/packages/client/src/store/IndexingApi.ts
@@ -363,7 +363,7 @@ export class IndexingApi extends ApiTopic {
         backend?: ElasticsearchBackend,
         projectId?: string,
     ): Promise<ReindexViaBulkResult> {
-        const bulkUrl = this.zenoBulkBaseUrl + '/reindex';
+        const bulkUrl = `${this.zenoBulkBaseUrl}/reindex`;
         const params = {
             tenant_id: tenantId,
             project_id: projectId,

--- a/packages/client/src/store/client.ts
+++ b/packages/client/src/store/client.ts
@@ -1,4 +1,4 @@
-import { AbstractFetchClient, type IRequestRetryPolicy, type RequestError } from "@vertesia/api-fetch-client";
+import { AbstractFetchClient, type FETCH_FN, type IRequestRetryPolicy, type RequestError } from "@vertesia/api-fetch-client";
 import type { BulkOperationPayload, BulkOperationResponse } from "@vertesia/common";
 import { AgentsApi } from "./AgentsApi.js";
 import { CollectionsApi } from "./CollectionsApi.js";
@@ -29,6 +29,7 @@ export interface ZenoClientProps {
     onRequest?: (request: Request) => void;
     onResponse?: (response: Response) => void;
     retryPolicy?: IRequestRetryPolicy;
+    fetch?: FETCH_FN | Promise<FETCH_FN>;
 }
 
 function ensureDefined(serverUrl: string | undefined) {
@@ -43,7 +44,7 @@ export class ZenoClient extends AbstractFetchClient<ZenoClient> {
     constructor(
         opts: ZenoClientProps = {}
     ) {
-        super(ensureDefined(opts.serverUrl));
+        super(ensureDefined(opts.serverUrl), opts.fetch);
         if (opts.apikey) {
             this.withApiKey(opts.apikey);
         }

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -495,6 +495,33 @@ export interface StartProjectReindexPayload {
     bulk_concurrency?: number;
 }
 
+export interface ReindexAgentRunsPayload {
+    /**
+     * Drop any existing agent-runs index/alias family and recreate the stable concrete index before indexing.
+     * Defaults to true.
+     */
+    recreate_index?: boolean;
+    /** Number of MongoDB records to scan per batch. Defaults to 500. */
+    batch_size?: number;
+    /** Optional cap for partial/manual repair runs. Omit for all agent runs in the project. */
+    limit?: number;
+}
+
+export interface ReindexAgentRunsResponse {
+    status: string;
+    backend: ElasticsearchBackend;
+    index_name: string;
+    recreated: boolean;
+    total: number;
+    scanned: number;
+    indexed: number;
+    failed: number;
+    errors?: Array<{
+        id: string;
+        message: string;
+    }>;
+}
+
 // ============================================================================
 // Internal indexing types (used by Temporal workflows)
 // ============================================================================

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -472,6 +472,22 @@ export interface IndexingStatusResponse {
         written: number;
         /** Documents that failed to index */
         errors: number;
+        /** Embedding vectors written to target index */
+        embeddings_written?: number;
+        /** Embedding vectors skipped because they were invalid or dimension-mismatched */
+        skipped_embeddings?: number;
+        /** Text embedding vectors written to target index */
+        embeddings_text_written?: number;
+        /** Image embedding vectors written to target index */
+        embeddings_image_written?: number;
+        /** Properties embedding vectors written to target index */
+        embeddings_properties_written?: number;
+        /** Text embedding vectors skipped because they were invalid or dimension-mismatched */
+        embeddings_text_skipped?: number;
+        /** Image embedding vectors skipped because they were invalid or dimension-mismatched */
+        embeddings_image_skipped?: number;
+        /** Properties embedding vectors skipped because they were invalid or dimension-mismatched */
+        embeddings_properties_skipped?: number;
         /** Documents processed per second */
         docs_per_second: number;
         /** Elapsed time in seconds */
@@ -669,6 +685,12 @@ export interface IndexShardResult {
     errors: number;
     embeddings_written?: number;
     skipped_embeddings?: number;
+    embeddings_text_written?: number;
+    embeddings_image_written?: number;
+    embeddings_properties_written?: number;
+    embeddings_text_skipped?: number;
+    embeddings_image_skipped?: number;
+    embeddings_properties_skipped?: number;
     read_docs_s: string;
     write_docs_s: string;
     read_mb: string;
@@ -717,6 +739,12 @@ export interface ReindexViaBulkResult {
     errors: number;
     embeddings_written?: number;
     skipped_embeddings?: number;
+    embeddings_text_written?: number;
+    embeddings_image_written?: number;
+    embeddings_properties_written?: number;
+    embeddings_text_skipped?: number;
+    embeddings_image_skipped?: number;
+    embeddings_properties_skipped?: number;
     read_docs_s: string;
     write_docs_s: string;
     read_mb: string;

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -667,12 +667,20 @@ export interface IndexShardResult {
     written: number;
     skipped: number;
     errors: number;
+    embeddings_written?: number;
+    skipped_embeddings?: number;
     read_docs_s: string;
     write_docs_s: string;
     read_mb: string;
     write_mb: string;
+    mongo_read_mb?: string;
+    gcs_read_mb?: string;
+    es_bulk_mb?: string;
     read_mb_s: string;
     write_mb_s: string;
+    mongo_read_mb_s?: string;
+    gcs_read_mb_s?: string;
+    es_bulk_mb_s?: string;
     duration_sec: number;
     failed_projects?: Array<{ tenant: string; error: string }>;
 }
@@ -694,6 +702,7 @@ export interface SwapAliasResult {
 
 export interface ReindexViaBulkRequest {
     tenant_id: string;
+    project_id?: string;
     backend?: ElasticsearchBackend;
     dry_run?: boolean;
 }
@@ -706,10 +715,20 @@ export interface ReindexViaBulkResult {
     scanned: number;
     written: number;
     errors: number;
+    embeddings_written?: number;
+    skipped_embeddings?: number;
     read_docs_s: string;
     write_docs_s: string;
     read_mb: string;
     write_mb: string;
+    mongo_read_mb?: string;
+    gcs_read_mb?: string;
+    es_bulk_mb?: string;
+    read_mb_s?: string;
+    write_mb_s?: string;
+    mongo_read_mb_s?: string;
+    gcs_read_mb_s?: string;
+    es_bulk_mb_s?: string;
     duration_sec: number;
 }
 

--- a/packages/ui/src/features/agent/chat/hooks/useAgentStream.ts
+++ b/packages/ui/src/features/agent/chat/hooks/useAgentStream.ts
@@ -6,8 +6,7 @@ import {
     type ConversationFile,
     type FileProcessingDetails,
 } from '@vertesia/common';
-// biome-ignore lint/suspicious/noDeprecatedImports: legacy AgentMessage stream still uses StreamingChunkDetails; migration to CompactMessage tracked separately
-import type { StreamingChunkDetails } from '@vertesia/common';
+import type * as Common from '@vertesia/common';
 import { insertMessageInTimeline, isInProgress } from '../ModernAgentOutput/utils';
 
 /** Streaming data for a single active stream, keyed by streaming/activity ID */
@@ -133,7 +132,7 @@ export function useAgentStream(
             // Handle streaming chunks separately for real-time aggregation
             // PERFORMANCE: Batch updates using RAF instead of immediate state updates
             if (message.type === AgentMessageType.STREAMING_CHUNK) {
-                const details = message.details as StreamingChunkDetails;
+                const details = message.details as Common.StreamingChunkDetails;
                 const streamKey = details?.activity_id || details?.streaming_id;
                 if (!streamKey) return;
 

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -53,6 +53,7 @@
     "tiktoken": "^1.0.22",
     "tmp": "^0.2.4",
     "tmp-promise": "^3.0.3",
+    "undici": "^7.25.0",
     "yaml": "^2.6.0"
   },
   "ts_dual_module": {

--- a/packages/workflow/src/utils/client.ts
+++ b/packages/workflow/src/utils/client.ts
@@ -7,8 +7,15 @@ import {
     VertesiaClient,
     type VertesiaClientProps,
 } from "@vertesia/client";
+import type { FETCH_FN } from "@vertesia/api-fetch-client";
 import type { WorkflowExecutionBaseParams } from "@vertesia/common";
+import { Agent } from "undici";
 import { WorkflowParamNotFoundError } from "../errors.js";
+
+const DEFAULT_WORKFLOW_FETCH_TIMEOUT_MS = 30 * 60 * 1000;
+const WORKFLOW_FETCH_TIMEOUT_ENV = "VERTESIA_WORKFLOW_FETCH_TIMEOUT_MS";
+
+let workflowFetch: Promise<FETCH_FN> | undefined;
 
 export function getVertesiaClient(payload: WorkflowExecutionBaseParams<unknown>) {
     return new VertesiaClient(getVertesiaClientOptions(payload));
@@ -42,5 +49,46 @@ export function getVertesiaClientOptions(
         storeUrl: payload.config.store_url,
         tokenServerUrl: token.iss,
         apikey: payload.auth_token,
+        fetch: getWorkflowFetch(),
     };
+}
+
+function getWorkflowFetch(): Promise<FETCH_FN> {
+    workflowFetch ??= createWorkflowFetch();
+    return workflowFetch;
+}
+
+async function createWorkflowFetch(): Promise<FETCH_FN> {
+    if (typeof globalThis.fetch !== "function") {
+        throw new Error("No Fetch implementation found");
+    }
+
+    const timeoutMs = parseWorkflowFetchTimeoutMs();
+    if (timeoutMs === 0) {
+        return globalThis.fetch.bind(globalThis);
+    }
+
+    const dispatcher = new Agent({
+        headersTimeout: timeoutMs,
+        bodyTimeout: timeoutMs,
+    });
+
+    return (input, init) =>
+        globalThis.fetch(input, {
+            ...init,
+            dispatcher,
+        } as unknown as RequestInit);
+}
+
+function parseWorkflowFetchTimeoutMs(): number {
+    const raw = process.env[WORKFLOW_FETCH_TIMEOUT_ENV];
+    if (!raw) {
+        return DEFAULT_WORKFLOW_FETCH_TIMEOUT_MS;
+    }
+
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+        return DEFAULT_WORKFLOW_FETCH_TIMEOUT_MS;
+    }
+    return parsed;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -927,6 +927,9 @@ importers:
       tmp-promise:
         specifier: ^3.0.3
         version: 3.0.3
+      undici:
+        specifier: ^7.25.0
+        version: 7.25.0
       yaml:
         specifier: ^2.8.3
         version: 2.8.3


### PR DESCRIPTION
## Summary
- Add fetch injection support for long workflow/STSes calls in the composableai clients.
- Stream zeno-bulk direct reindex progress via SSE client support.
- Add shared ES reindex result counters, including per-field embedding write/skip stats.
- Include the agent-run reindex API type commit already referenced by the root main branch.

## Verification
- `pnpm --filter @vertesia/common build` passed from the root main worktree.
- `pnpm --filter @dglabs/admin-cli... build` passed from the root main worktree, building `@vertesia/api-fetch-client`, `@vertesia/common`, and `@vertesia/client` as dependencies.
- Standalone `/private/tmp/composableai-es-main` build attempt was blocked by the isolated worktree missing the nested `llumiverse` workspace and registry access (`@llumiverse/common@workspace:*` / `ENOTFOUND registry.npmjs.org`).