### PR TITLE
chore: configure Renovate and stale PR cleanup

### DIFF
--- a/.github/workflows/dev-stale.yaml
+++ b/.github/workflows/dev-stale.yaml
@@ -1,0 +1,59 @@
+name: (dev) stale pull requests
+
+on:
+  schedule:
+    # Run twice per day at 00:00 and 12:00 UTC
+    - cron: "0 0,12 * * *"
+  workflow_dispatch:
+
+# Cancel superseded stale runs on the same ref.
+concurrency:
+  group: dev-stale-${{ github.ref }}
+  cancel-in-progress: true
+
+# see "Recommended permissions"
+# https://github.com/actions/stale?tab=readme-ov-file#recommended-permissions
+permissions:
+  contents: read
+
+jobs:
+  stale-pull-request:
+    name: Mark stale pull requests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      issues: write # required to label PRs because PR labels are issue labels
+      contents: write # for delete-branch option
+      pull-requests: write # required to mark and close stale PRs
+    steps:
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
+        with:
+          # Only process pull requests, not issues
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+
+          # A pull request is stale after 30 days of inactivity
+          days-before-pr-stale: 30
+          # A stale pull request is closed 3 days after being marked stale
+          days-before-pr-close: 3
+
+          stale-pr-label: "stale"
+          stale-pr-message: >
+            This pull request has been marked as stale due to inactivity for 30 days.
+
+
+            If this is still a priority, please add a comment or push an update to keep it active.
+
+
+            Otherwise, it may be closed to keep the backlog manageable.
+
+          close-pr-message: "This pull request has been closed due to continued inactivity."
+
+          # Include draft PRs since long-lived drafts can also go stale
+          include-only-assigned: false
+
+          # Delete the branch when closing a stale PR
+          delete-branch: true
+
+          # Remove the stale label when the PR is updated
+          remove-stale-when-updated: true

--- a/.github/workflows/dev-stale.yaml
+++ b/.github/workflows/dev-stale.yaml
@@ -49,7 +49,7 @@ jobs:
 
           close-pr-message: "This pull request has been closed due to continued inactivity."
 
-          # Include draft PRs since long-lived drafts can also go stale
+          # Process pull requests whether or not they are assigned
           include-only-assigned: false
 
           # Delete the branch when closing a stale PR

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -33,7 +33,21 @@
   ],
   "prConcurrentLimit": 40,
   "labels": ["dependencies"],
+  // Security advisories bypass the release-age cooldown defined below so CVE fixes can
+  // land immediately. See https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": "0 days"
+  },
   "packageRules": [
+    // 7-day cooldown on all updates to mitigate supply-chain attacks: compromised
+    // package releases (e.g. xz-utils, eslint-config-prettier) are typically detected and
+    // yanked within days, so waiting before adopting any new version blocks the bulk of
+    // these incidents. Also gives the ecosystem time to surface regressions. Applies to
+    // patch, minor, and major; security fixes bypass via the `vulnerabilityAlerts` block
+    // above.
+    {
+      "minimumReleaseAge": "7 days"
+    },
     // Catch-all npm dependencies, later groups take precedence
     {
       "groupName": "node dependencies",
@@ -188,6 +202,20 @@
       ],
       "rangeStrategy": "bump",
       "schedule": "* * * * 5" // Friday
+    },
+    {
+      "description": "Keep Node.js-related updates on v24 until the runtime is upgraded deliberately.",
+      "matchManagers": [
+        "npm",
+        "nvm",
+        "nodenv"
+      ],
+      "matchPackageNames": [
+        "node",
+        "@types/node"
+      ],
+      "allowedVersions": "<25",
+      "rangeStrategy": "bump"
     },
     {
       "groupName": "package manager dependencies",


### PR DESCRIPTION
## Summary
- Add a Renovate 7-day release-age cooldown while allowing vulnerability alerts to bypass the cooldown.
- Keep Renovate Node-related updates on Node 24 by capping node and @types/node to versions below 25.
- Add a scheduled stale PR cleanup workflow using the same PR stale policy as Studio: stale after 30 days, close after 3 more days, delete stale branches, and remove the stale label when updated.

## Test Plan
- [x] JSON5 syntax check for .renovaterc.json5
- [x] YAML parse for .github/workflows/dev-stale.yaml
- [x] zizmor --no-exit-codes --persona=auditor .github llumiverse/.github
- [ ] Package build/tests not run; no runtime package code changed.