### PR TITLE
fix: update useEventSource

### DIFF
--- a/packages/ui/src/core/hooks/useEventSource.ts
+++ b/packages/ui/src/core/hooks/useEventSource.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 function startSse<T>(url: string, onMessage: (content: string) => void,
     onCompleted: (payload: T) => void) {
@@ -22,24 +22,40 @@ function startSse<T>(url: string, onMessage: (content: string) => void,
 
 }
 
+/**
+ * Opens an EventSource to `url` and routes events to `onMessage` / `onCompleted`.
+ *
+ * Callbacks are read through refs, so callers don't have to memoize them —
+ * the EventSource is only re-created when the URL itself changes. Previously,
+ * an inline `onMessage` that called `setState` would trigger a re-render →
+ * new callback identity → effect re-fire → close-and-reopen the EventSource
+ * after every chunk, which the server side sees as a torn-down response.
+ */
 export function useEventSource<T>(url: string | (() => Promise<string>),
     onMessage: (content: string) => void,
     onCompleted: (payload: T) => void) {
+    const onMessageRef = useRef(onMessage);
+    const onCompletedRef = useRef(onCompleted);
+    onMessageRef.current = onMessage;
+    onCompletedRef.current = onCompleted;
+
     useEffect(() => {
         let stop: (() => void) | undefined;
         let cancelled = false;
+        const dispatchMessage = (content: string) => onMessageRef.current(content);
+        const dispatchCompleted = (payload: T) => onCompletedRef.current(payload);
         if (typeof url === 'function') {
-            void url().then(url => {
+            void url().then(resolvedUrl => {
                 if (!cancelled) {
-                    stop = startSse(url, onMessage, onCompleted);
+                    stop = startSse(resolvedUrl, dispatchMessage, dispatchCompleted);
                 }
             });
         } else {
-            stop = startSse(url, onMessage, onCompleted);
+            stop = startSse(url, dispatchMessage, dispatchCompleted);
         }
         return () => {
             cancelled = true;
             stop?.();
         }
-    }, [onCompleted, onMessage, url])
+    }, [url])
 }


### PR DESCRIPTION
 useEventSource

## Changes

- Hold the latest `onMessage` / `onCompleted` in refs and dispatch through them.
- Effect now depends only on `url`, so the EventSource is reopened only when the URL itself changes.
- Hook is now robust to non-memoized callbacks — callers don't have to remember to `useCallback` them.


`useEventSource` listed the `onMessage` / `onCompleted` callbacks in its effect deps. Callers nearly always pass inline closures, whose identity changes on every render — so any `setState` inside `onMessage` would re-render the parent → new callback identities → effect re-fire → close the EventSource and open a new one. For server-sent streams that ran multiple chunks (LLM streaming, etc.), this meant a fresh `GET /…/stream` connection per chunk, which the browser collapsed to a single in-flight request, dropping all but the last.
