### PR TITLE
fix: scope Panel overflow-hidden to clickableHeader (#1363)

### DIFF
--- a/packages/ui/src/core/components/shadcn/Panel.tsx
+++ b/packages/ui/src/core/components/shadcn/Panel.tsx
@@ -57,7 +57,7 @@ export function Panel({
     const footerPadding = isSmall ? 'px-4 pb-3' : 'px-4 pb-4';
 
     return (
-        <div className={`flex flex-col ${sectioned ? '' : 'p-4 gap-2'} rounded-sm border bg-card overflow-hidden ${className ?? ''}`}>
+        <div className={`flex flex-col ${sectioned ? '' : 'p-4 gap-2'} rounded-sm border bg-card ${useClickableHeader ? 'overflow-hidden' : ''} ${className ?? ''}`}>
             {useClickableHeader ? (
                 <button
                     type="button"


### PR DESCRIPTION
The composableai sync failed https://github.com/vertesia/composableai/actions/runs/26404164380.  

Cherry pick from https://github.com/vertesia/composableai/pull/1363