### PR TITLE
fix(workflow): let Temporal generate child workflow IDs for dsl: children

### DIFF
--- a/packages/workflow/src/dsl/dsl-workflow.ts
+++ b/packages/workflow/src/dsl/dsl-workflow.ts
@@ -10,6 +10,7 @@ import {
     sleep,
     startChild,
     UntypedActivities,
+    uuid4,
 } from "@temporalio/workflow";
 import {
     DSLActivityExecutionPayload,
@@ -246,8 +247,7 @@ async function startChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWorkfl
         const specPayload = dslActivityPayload(basePayload, { name: 'loadChildWorkflowSpec' } as DSLActivitySpec, { workflowName });
         const spec = await proxy.loadChildWorkflowSpec(specPayload) as DSLWorkflowSpec;
         const humanName = spec.name.replace(/([A-Z])/g, ' $1').trim();
-        const objectIds = getDocumentIds(payload);
-        const workflowId = objectIds.length > 0 ? `${humanName}:${objectIds[0]}` : humanName;
+        const workflowId = `${humanName}:${uuid4()}`;
         step = { ...step, name: 'dslWorkflow', spec, options: { ...step.options, workflowId } };
     }
     const resolvedVars = vars.resolve();
@@ -293,8 +293,7 @@ async function executeChildWorkflow(step: DSLChildWorkflowStep, payload: DSLWork
         const specPayload = dslActivityPayload(basePayload, { name: 'loadChildWorkflowSpec' } as DSLActivitySpec, { workflowName });
         const spec = await proxy.loadChildWorkflowSpec(specPayload) as DSLWorkflowSpec;
         const humanName = spec.name.replace(/([A-Z])/g, ' $1').trim();
-        const objectIds = getDocumentIds(payload);
-        const workflowId = objectIds.length > 0 ? `${humanName}:${objectIds[0]}` : humanName;
+        const workflowId = `${humanName}:${uuid4()}`;
         step = { ...step, name: 'dslWorkflow', spec, options: { ...step.options, workflowId } };
     }
     const resolvedVars = vars.resolve();


### PR DESCRIPTION
## Summary

Keep a friendly human-readable prefix on `dsl:`-prefixed child workflow IDs and use a workflow-safe `uuid4()` for the suffix. The resulting form is `"<HumanName>:<uuid4()>"` (e.g. `Standard Video Intake:9b3c7c4e-…`) — replacing the old deterministic `"<HumanName>:<objectId>"`.

## Why

In production for the `Nuxeo - PRODUCTION` project, `Standard Media Container Intake` parent runs were failing with `WorkflowExecutionAlreadyStartedError` when re-triggered for the same object. The DSL handler in `packages/workflow/src/dsl/dsl-workflow.ts` forced the child workflow ID to `${humanName}:${objectIds[0]}`, so if any previous run with the same deterministic ID was still open (or two parent triggers fired concurrently), Temporal rejected the new child at the spawn step (`Activator.resolveChildWorkflowExecutionStart`).

`Standard Document Intake` re-runs cleanly because its children are statically-registered TS workflows (not `dsl:` ones) and get Temporal-generated UUIDs as workflow IDs. This change brings parity to `dsl:` children.

## Why keep the human-readable prefix

Document Intake's TS children render nicely in the Vertesia workflow list UI because each child has its own workflow TYPE NAME (e.g. `generateObjectText`, `GenerateTableOfContentWorkflow`). DSL children all share the generic `dslWorkflow` workflow type, so the UI can't distinguish them by type — it parses the workflow ID prefix to derive a friendly title. Keeping `${humanName}:` preserves that title; the `uuid4()` suffix replaces the colliding `:${objectId}` part.

## Scope

`dsl:`-prefixed children are only used in `apps/zeno-server/workflow-specs/StandardMediaContainerIntake.wf.json` (`dsl:StandardVideoIntake`, `dsl:StandardAudioIntake`). No code in the monorepo looks up workflows by the `${humanName}:${objectIds[0]}` pattern — `grep` returned only the two assignments themselves. Blast radius is limited to Video/Audio intake child runs spawned from Media Container intake.

## Trade-offs

- Object-level dedup at the child layer is gone: if two parents both reach the child-spawn step, both will spawn their own video-intake child and the LLM cost is paid twice. The matching fix at the parent start site (`workflowIdConflictPolicy: 'TERMINATE_EXISTING'` on the parent) is tracked separately.
- Datadog filtering by object id no longer hits the child workflow ID — but the `DocumentId` search attribute is set on every `startChild` / `executeChild` (preserved), so correlation by object id still works via search attributes.

## Verification

- `npx tsc --noEmit` in `packages/workflow`: same 63 pre-existing errors as before the change, none in `dsl-workflow.ts`.
- `uuid4` import sourced from `@temporalio/workflow` (workflow-safe deterministic UUID), matching the pattern already used in `packages/workflows/src/workflows/generateObjectText.ts` and elsewhere in the studio worker.

## Test Plan

- [ ] Confirm `Standard Media Container Intake` no longer fails with `WorkflowExecutionAlreadyStartedError` when re-triggered for the same object
- [ ] Confirm child Video/Audio Intake runs appear in the Vertesia workflow list with a friendly title (`Standard Video Intake`, `Standard Audio Intake`) and complete successfully
- [ ] Confirm Datadog correlation by object ID still works via `DocumentId` search attribute

🤖 Generated with [Claude Code](https://claude.com/claude-code)