### PR TITLE
feat: ES reindex observability + autotune + batching diagnostics (follow-up)

### DIFF
--- a/packages/api-fetch-client/tsconfig.cjs.json
+++ b/packages/api-fetch-client/tsconfig.cjs.json
@@ -6,6 +6,7 @@
         "declaration": false,
         "outDir": "./lib/cjs",
         "module": "CommonJS",
-        "moduleResolution": "bundler"
+        "moduleResolution": "bundler",
+        "ignoreDeprecations": "6.0"
     }
 }

--- a/packages/client/src/store/IndexingApi.ts
+++ b/packages/client/src/store/IndexingApi.ts
@@ -362,6 +362,7 @@ export class IndexingApi extends ApiTopic {
         projectId?: string,
         tuning?: {
             shardSize?: number;
+            shards?: number;
             bulkConcurrency?: number;
             bulkSizeBytes?: number;
             bulkMaxDocs?: number;
@@ -374,6 +375,7 @@ export class IndexingApi extends ApiTopic {
             dry_run: dryRun ?? false,
             backend,
             shard_size: tuning?.shardSize,
+            shards: tuning?.shards,
             bulk_concurrency: tuning?.bulkConcurrency,
             bulk_size_bytes: tuning?.bulkSizeBytes,
             bulk_max_docs: tuning?.bulkMaxDocs,

--- a/packages/client/src/store/IndexingApi.ts
+++ b/packages/client/src/store/IndexingApi.ts
@@ -324,7 +324,7 @@ export class IndexingApi extends ApiTopic {
     ): Promise<ComputeShardsResult> {
         return this.zenoBulkPost('/reindex/compute-shards', {
             tenant_id: tenantId,
-            shard_size: shardSize ?? 50000,
+            shard_size: shardSize ?? 250000,
             updated_since: updatedSince,
             backend,
         } satisfies ComputeShardsRequest);

--- a/packages/client/src/store/IndexingApi.ts
+++ b/packages/client/src/store/IndexingApi.ts
@@ -5,7 +5,6 @@ import {
     ElasticsearchDocumentData,
     BulkIndexResult,
     CreateReindexTargetResult,
-    ReindexRangeResult,
     FetchBatchResult,
     NextIndexCursorResult,
     TriggerReindexResult,
@@ -179,16 +178,6 @@ export class IndexingApi extends ApiTopic {
      */
     getStats(): Promise<ElasticsearchIndexStats> {
         return this.post("/internal/stats", {
-            payload: {},
-        });
-    }
-
-    /**
-     * Get the _id range for reindexing (first, last, count)
-     * Used by workflow to set up cursor-based pagination
-     */
-    getReindexRange(): Promise<ReindexRangeResult> {
-        return this.post("/internal/reindex-range", {
             payload: {},
         });
     }

--- a/packages/client/src/store/IndexingApi.ts
+++ b/packages/client/src/store/IndexingApi.ts
@@ -371,6 +371,12 @@ export class IndexingApi extends ApiTopic {
         dryRun?: boolean,
         backend?: ElasticsearchBackend,
         projectId?: string,
+        tuning?: {
+            shardSize?: number;
+            bulkConcurrency?: number;
+            bulkSizeBytes?: number;
+            bulkMaxDocs?: number;
+        },
     ): Promise<ReindexViaBulkResult> {
         const bulkUrl = `${this.zenoBulkBaseUrl}/reindex`;
         const params = {
@@ -378,6 +384,10 @@ export class IndexingApi extends ApiTopic {
             project_id: projectId,
             dry_run: dryRun ?? false,
             backend,
+            shard_size: tuning?.shardSize,
+            bulk_concurrency: tuning?.bulkConcurrency,
+            bulk_size_bytes: tuning?.bulkSizeBytes,
+            bulk_max_docs: tuning?.bulkMaxDocs,
         } satisfies ReindexViaBulkRequest;
 
         if (!onEvent) {

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -414,6 +414,38 @@ export interface StartProjectReindexPayload {
     bulk_concurrency?: number;
 }
 
+/**
+ * Auto-tunes shard_size and parallel_shard_count based on project doc count.
+ *
+ * The default shard_size (250k) leaves small/medium projects under-sharded —
+ * a 48k-doc project runs as a single Mongo cursor feeding 10 bulk workers,
+ * which sit half-idle. This heuristic picks a shard size that produces
+ * roughly 4-20 shards per project, sized to keep cursors saturating the
+ * bulk pool without overwhelming Temporal coordination on huge projects.
+ *
+ * Explicit overrides should bypass this function and use user-provided values.
+ */
+export function autoTuneReindexParams(docCount: number): { shard_size: number; parallel_shard_count: number } {
+    if (docCount < 50_000) {
+        // Tiny/small project: aim for ~4 shards, with a 5k floor so we don't
+        // create more shards than is useful (each shard has ~constant overhead).
+        return {
+            shard_size: Math.max(Math.ceil(docCount / 4), 5_000),
+            parallel_shard_count: Math.min(4, Math.max(1, Math.ceil(docCount / 5_000))),
+        };
+    }
+    if (docCount < 500_000) {
+        // Medium project: 50k shards → 1-10 shards
+        return { shard_size: 50_000, parallel_shard_count: 8 };
+    }
+    if (docCount < 2_000_000) {
+        // Large project: 100k shards → 5-20 shards
+        return { shard_size: 100_000, parallel_shard_count: 8 };
+    }
+    // Huge project: stick to 250k shards to keep coordination overhead bounded.
+    return { shard_size: 250_000, parallel_shard_count: 8 };
+}
+
 export interface ReindexAgentRunsPayload {
     /**
      * Drop any existing agent-runs index/alias family and recreate the stable concrete index before indexing.

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -379,6 +379,10 @@ export interface IndexingStatusResponse {
         embeddings_image_skipped?: number;
         /** Properties embedding vectors skipped because they were invalid or dimension-mismatched */
         embeddings_properties_skipped?: number;
+        /** Oversized property string values dropped during transform (size-based pruning) */
+        properties_values_trimmed?: number;
+        /** Total bytes dropped from oversized property values */
+        properties_bytes_dropped?: number;
         /** Documents processed per second */
         docs_per_second: number;
         /** Elapsed time in seconds */
@@ -582,6 +586,8 @@ export interface IndexShardResult {
     embeddings_text_skipped?: number;
     embeddings_image_skipped?: number;
     embeddings_properties_skipped?: number;
+    properties_values_trimmed?: number;
+    properties_bytes_dropped?: number;
     read_docs_s: string;
     write_docs_s: string;
     read_mb: string;
@@ -636,6 +642,8 @@ export interface ReindexViaBulkResult {
     embeddings_text_skipped?: number;
     embeddings_image_skipped?: number;
     embeddings_properties_skipped?: number;
+    properties_values_trimmed?: number;
+    properties_bytes_dropped?: number;
     read_docs_s: string;
     write_docs_s: string;
     read_mb: string;

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -322,6 +322,10 @@ export interface IndexingStatusResponse {
     indexing_enabled: boolean;
     /** @deprecated Now derived from indexing_enabled - queries automatically route to index when indexing is enabled */
     query_enabled: boolean;
+    /** Resolved Elasticsearch backend serving this project */
+    backend: ElasticsearchBackend;
+    /** Resolved search tier for this project */
+    search_tier: ProjectSearchTier;
     /** Index status */
     index: {
         /** Whether the index exists */

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -528,15 +528,6 @@ export interface CreateReindexTargetResult {
 }
 
 /**
- * Result from getting reindex range
- */
-export interface ReindexRangeResult {
-    first: string | null;
-    last: string | null;
-    count: number;
-}
-
-/**
  * Result from fetching a batch
  */
 export interface FetchBatchResult {

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -638,6 +638,14 @@ export interface ReindexViaBulkRequest {
     project_id?: string;
     backend?: ElasticsearchBackend;
     dry_run?: boolean;
+    /** Approximate documents per shard; drives auto-shard count (total / shard_size). Default 250_000. */
+    shard_size?: number;
+    /** Number of ES bulk-write workers per shard. Default 10. */
+    bulk_concurrency?: number;
+    /** Hard cap per ES bulk request body in bytes. Default 12 MB. */
+    bulk_size_bytes?: number;
+    /** Max documents per batcher flush (size cap still regulates ES bulk requests). Default 200. */
+    bulk_max_docs?: number;
 }
 
 export interface ReindexViaBulkResult {

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -415,35 +415,39 @@ export interface StartProjectReindexPayload {
 }
 
 /**
- * Auto-tunes shard_size and parallel_shard_count based on project doc count.
+ * Auto-tunes shard sizing based on project doc count.
  *
- * The default shard_size (250k) leaves small/medium projects under-sharded —
- * a 48k-doc project runs as a single Mongo cursor feeding 10 bulk workers,
- * which sit half-idle. This heuristic picks a shard size that produces
- * roughly 4-20 shards per project, sized to keep cursors saturating the
- * bulk pool without overwhelming Temporal coordination on huge projects.
+ * Returns:
+ * - shard_size: target docs per shard (workflow path uses this; zeno-bulk
+ *   computes shard count from total/shard_size).
+ * - parallel_shard_count: max in-flight shard activities (workflow path only).
+ * - max_shards: hard cap on shard count for the direct path. Direct path
+ *   passes this as `shards` to zeno-bulk so all shards run as cursors in
+ *   ONE process; without this cap, an under-estimated shard_size (e.g.
+ *   from stale estimatedDocumentCount) can spawn 10+ in-flight cursors
+ *   and exceed Cloud Run memory.
  *
  * Explicit overrides should bypass this function and use user-provided values.
  */
-export function autoTuneReindexParams(docCount: number): { shard_size: number; parallel_shard_count: number } {
+export function autoTuneReindexParams(docCount: number): { shard_size: number; parallel_shard_count: number; max_shards: number } {
     if (docCount < 50_000) {
-        // Tiny/small project: aim for ~4 shards, with a 5k floor so we don't
-        // create more shards than is useful (each shard has ~constant overhead).
+        // Tiny/small project: aim for ~4 shards, with a 5k floor.
         return {
             shard_size: Math.max(Math.ceil(docCount / 4), 5_000),
             parallel_shard_count: Math.min(4, Math.max(1, Math.ceil(docCount / 5_000))),
+            max_shards: 4,
         };
     }
     if (docCount < 500_000) {
         // Medium project: 50k shards → 1-10 shards
-        return { shard_size: 50_000, parallel_shard_count: 8 };
+        return { shard_size: 50_000, parallel_shard_count: 8, max_shards: 10 };
     }
     if (docCount < 2_000_000) {
         // Large project: 100k shards → 5-20 shards
-        return { shard_size: 100_000, parallel_shard_count: 8 };
+        return { shard_size: 100_000, parallel_shard_count: 8, max_shards: 20 };
     }
     // Huge project: stick to 250k shards to keep coordination overhead bounded.
-    return { shard_size: 250_000, parallel_shard_count: 8 };
+    return { shard_size: 250_000, parallel_shard_count: 8, max_shards: 40 };
 }
 
 export interface ReindexAgentRunsPayload {
@@ -663,6 +667,8 @@ export interface ReindexViaBulkRequest {
     dry_run?: boolean;
     /** Approximate documents per shard; drives auto-shard count (total / shard_size). Default 250_000. */
     shard_size?: number;
+    /** Explicit shard count. When set, overrides shard_size-based auto-sharding. Useful to cap in-process concurrency for the direct path. */
+    shards?: number;
     /** Number of ES bulk-write workers per shard. Default 10. */
     bulk_concurrency?: number;
     /** Hard cap per ES bulk request body in bytes. Default 12 MB. */

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -387,6 +387,8 @@ export interface IndexingStatusResponse {
         batches_flushed?: number;
         /** Total ES bulk requests sent across all completed shards (cumulative) */
         bulk_chunks_written?: number;
+        /** Total per-document ES bulk-item failures across all shards (cumulative). Counts docs ES rejected — they aren't in the indexed set. */
+        bulk_errors?: number;
         /** Average documents per batch flush (written / batches_flushed) — useful to spot under/over-batching */
         avg_docs_per_batch?: number;
         /** Average chunks per batch (>1 means bulk_size_bytes cap is splitting batches frequently) */
@@ -613,6 +615,15 @@ export interface IndexShardResult {
     written: number;
     skipped: number;
     errors: number;
+    /** Per-document ES bulk-item errors (e.g. mapping timeouts). Doc-level data-quality, not pipeline failure. */
+    bulk_errors?: number;
+    /** Sampled details of bulk-item failures (capped at 100 per shard). */
+    bulk_error_sample?: Array<{
+        tenant?: string;
+        doc_id: string;
+        type: string;
+        reason: string;
+    }>;
     embeddings_written?: number;
     skipped_embeddings?: number;
     embeddings_text_written?: number;

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -383,6 +383,14 @@ export interface IndexingStatusResponse {
         properties_values_trimmed?: number;
         /** Total bytes dropped from oversized property values */
         properties_bytes_dropped?: number;
+        /** Total batcher flushes across all completed shards (cumulative) */
+        batches_flushed?: number;
+        /** Total ES bulk requests sent across all completed shards (cumulative) */
+        bulk_chunks_written?: number;
+        /** Average documents per batch flush (written / batches_flushed) — useful to spot under/over-batching */
+        avg_docs_per_batch?: number;
+        /** Average chunks per batch (>1 means bulk_size_bytes cap is splitting batches frequently) */
+        avg_chunks_per_batch?: number;
         /** Documents processed per second */
         docs_per_second: number;
         /** Elapsed time in seconds */
@@ -588,6 +596,12 @@ export interface IndexShardResult {
     embeddings_properties_skipped?: number;
     properties_values_trimmed?: number;
     properties_bytes_dropped?: number;
+    batches_flushed?: number;
+    bulk_chunks_written?: number;
+    avg_docs_per_batch?: number;
+    avg_chunks_per_batch?: number;
+    avg_bytes_per_doc?: number;
+    avg_bytes_per_chunk?: number;
     read_docs_s: string;
     write_docs_s: string;
     read_mb: string;
@@ -644,6 +658,12 @@ export interface ReindexViaBulkResult {
     embeddings_properties_skipped?: number;
     properties_values_trimmed?: number;
     properties_bytes_dropped?: number;
+    batches_flushed?: number;
+    bulk_chunks_written?: number;
+    avg_docs_per_batch?: number;
+    avg_chunks_per_batch?: number;
+    avg_bytes_per_doc?: number;
+    avg_bytes_per_chunk?: number;
     read_docs_s: string;
     write_docs_s: string;
     read_mb: string;


### PR DESCRIPTION
## Summary

Follow-up to #1369 — additional observability, sharding heuristics, and API surface for the ongoing ES reindex perf work tracked in studio #5324.

- **Auto-tune heuristic** (\`autoTuneReindexParams\`): picks \`shard_size\`, \`parallel_shard_count\`, and \`max_shards\` from a project's MongoDB doc count so small/medium projects don't run as a single Mongo cursor on either reindex path.
- **\`max_shards\` cap on direct path**: caps in-process parallelism when zeno-bulk auto-shards from a stale \`estimatedDocumentCount\`.
- **Reindex tuning knobs** on \`ReindexViaBulkRequest\`: \`shard_size\`, \`shards\`, \`bulk_concurrency\`, \`bulk_size_bytes\`, \`bulk_max_docs\` so the CLI / scripts can override without curling zeno-bulk directly.
- **Per-shard observability**: \`bulk_errors\`, \`batches_flushed\`, \`bulk_chunks_written\`, \`avg_docs_per_batch\`, \`avg_chunks_per_batch\`, \`avg_bytes_per_doc\`, \`avg_bytes_per_chunk\` on \`IndexShardResult\` and \`ReindexProgress\`. Plus \`properties_values_trimmed\` / \`properties_bytes_dropped\` for size-driven property pruning.
- **\`getReindexRange\` cleanup**: removed the unused endpoint + type (drift workflow now uses the cheap \`getIndexingStatus\` for its progress total).
- **TS5107 lint fix**: \`ignoreDeprecations: '6.0'\` on api-fetch-client cjs build.

## Test plan

- [x] \`pnpm build\` clean
- [ ] Pair with studio #5324 — that PR exercises every type change end-to-end through the CLI + workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>