### PR TITLE
fix(cli): make OAuth server URL explicit on the profile

### DIFF
--- a/packages/cli/src/profiles/auth.ts
+++ b/packages/cli/src/profiles/auth.ts
@@ -53,6 +53,7 @@ export async function refreshProfileAuthentication(
     try {
         const refreshed = await refreshProfileAccessToken(profile, onResult, options);
         if (refreshed) {
+            logRefreshSuccess(profileName, refreshed);
             return refreshed;
         }
     } catch (error) {
@@ -72,6 +73,17 @@ export async function refreshProfileAuthentication(
     const updater = config.updateProfile(profileName);
     await updater.start(onResult, signal);
     return undefined;
+}
+
+function logRefreshSuccess(profileName: string, result: ConfigResult): void {
+    const expiresAtMs =
+        typeof result.access_token_expires_at === 'number'
+            ? result.access_token_expires_at
+            : typeof result.expires_in === 'number'
+              ? Date.now() + result.expires_in * 1000
+              : undefined;
+    const suffix = expiresAtMs ? ` (expires ${new Date(expiresAtMs).toISOString()})` : '';
+    console.log(`Refreshed access token for profile "${profileName}"${suffix}.`);
 }
 
 export async function refreshCurrentProfileAuthentication(

--- a/packages/cli/src/profiles/index.ts
+++ b/packages/cli/src/profiles/index.ts
@@ -57,11 +57,12 @@ export function getConfigUrl(value: ConfigUrlRef, region: Region = DEFAULT_REGIO
 export function getServerUrls(
     value: ConfigUrlRef,
     region: Region = DEFAULT_REGION,
-): { studio_server_url: string; zeno_server_url: string } {
+): { studio_server_url: string; zeno_server_url: string; oauth_server_url?: string } {
     if (isDevDeploymentTarget(value)) {
         return {
             studio_server_url: `https://studio-server-${value}.api.dev1.vertesia.io`,
             zeno_server_url: `https://zeno-server-${value}.api.dev1.vertesia.io`,
+            oauth_server_url: 'https://sts.dev1.vertesia.io',
         };
     }
     switch (value) {
@@ -69,26 +70,32 @@ export function getServerUrls(
             return {
                 studio_server_url: 'http://localhost:8091',
                 zeno_server_url: 'http://localhost:8092',
+                // Local CLI dev still authenticates against the shared dev1 STS.
+                oauth_server_url: 'https://sts.dev1.vertesia.io',
             };
         case 'dev-main':
             return {
                 studio_server_url: 'https://studio-server-dev-main.api.dev1.vertesia.io',
                 zeno_server_url: 'https://zeno-server-dev-main.api.dev1.vertesia.io',
+                oauth_server_url: 'https://sts.dev1.vertesia.io',
             };
         case 'dev-preview':
             return {
                 studio_server_url: 'https://studio-server-dev-preview.api.dev1.vertesia.io',
                 zeno_server_url: 'https://zeno-server-dev-preview.api.dev1.vertesia.io',
+                oauth_server_url: 'https://sts.dev1.vertesia.io',
             };
         case 'preview':
             return {
                 studio_server_url: `https://api-preview.${region}.vertesia.io`,
                 zeno_server_url: `https://api-preview.${region}.vertesia.io`,
+                oauth_server_url: `https://sts-preview.${region}.vertesia.io`,
             };
         case 'prod':
             return {
                 studio_server_url: `https://api.${region}.vertesia.io`,
                 zeno_server_url: `https://api.${region}.vertesia.io`,
+                oauth_server_url: `https://sts.${region}.vertesia.io`,
             };
         default:
             throw new Error('Unable to detect server urls from custom target.');
@@ -129,6 +136,10 @@ export interface Profile {
     project: string;
     studio_server_url: string;
     zeno_server_url: string;
+    // Optional: when set, the CLI uses this URL directly as the OAuth authorization server
+    // (no fallback derivation from studio_server_url). Old profiles without this field keep
+    // working via the legacy derivation in oauth.ts.
+    oauth_server_url?: string;
     region?: Region;
     session_tags?: string;
 }
@@ -182,6 +193,9 @@ export class ConfigureProfile {
         this.data.project = result.project;
         this.data.studio_server_url = result.studio_server_url;
         this.data.zeno_server_url = result.zeno_server_url;
+        if (result.oauth_server_url) {
+            this.data.oauth_server_url = result.oauth_server_url;
+        }
         delete this.data.apikey;
         writeAuthBundle(result.profile, {
             accessToken: result.token,

--- a/packages/cli/src/profiles/oauth.ts
+++ b/packages/cli/src/profiles/oauth.ts
@@ -14,7 +14,7 @@ const OAUTH_CLIENT_METADATA_PATH = '/.well-known/oauth-client/vertesia-cli';
 const DEFAULT_OAUTH_SCOPE = 'openid profile';
 
 type OAuthProfile = Pick<Profile, 'name' | 'studio_server_url' | 'zeno_server_url'> &
-    Partial<Pick<Profile, 'account' | 'config_url' | 'project'>>;
+    Partial<Pick<Profile, 'account' | 'config_url' | 'project' | 'oauth_server_url'>>;
 
 interface TokenRefs {
     account?: string;
@@ -82,7 +82,7 @@ export async function startOAuthSession(profile: OAuthProfile, signal?: AbortSig
     });
 
     const response = await pollDeviceToken(metadata, clientId, deviceAuthorization, signal);
-    return buildConfigResult(profile, response, clientId, resource);
+    return buildConfigResult(profile, response, clientId, resource, serverUrl);
 }
 
 export async function refreshOAuthSession(
@@ -99,7 +99,7 @@ export async function refreshOAuthSession(
     const clientId = getOAuthClientId(serverUrl);
     const resource = bundle?.oauthResource || readTokenRefs(bundle?.accessToken).audience || getOAuthResource(metadata);
     const response = await exchangeRefreshToken(metadata, clientId, refreshToken, resource, options.projectId);
-    return buildConfigResult(profile, response, clientId, resource);
+    return buildConfigResult(profile, response, clientId, resource, serverUrl);
 }
 
 function assertOAuthProfile(
@@ -121,7 +121,7 @@ function withTrailingSlash(url: string): string {
 }
 
 async function discoverAuthorizationServer(
-    profile: Pick<Profile, 'studio_server_url'> & Partial<Pick<Profile, 'config_url'>>,
+    profile: Pick<Profile, 'studio_server_url'> & Partial<Pick<Profile, 'config_url' | 'oauth_server_url'>>,
 ): Promise<OAuthDiscovery> {
     const candidates = getOAuthServerUrlCandidates(profile);
     let unavailableError: OAuthUnavailableError | undefined;
@@ -160,28 +160,39 @@ function applyProfileAuthorizationEndpoint(
     };
 }
 
-function getOAuthServerUrlCandidates(profile: Pick<Profile, 'studio_server_url'>): string[] {
+function getOAuthServerUrlCandidates(
+    profile: Pick<Profile, 'studio_server_url'> & Partial<Pick<Profile, 'oauth_server_url'>>,
+): string[] {
     if (process.env.VERTESIA_TOKEN_SERVER_URL) {
         return [process.env.VERTESIA_TOKEN_SERVER_URL];
     }
+    if (profile.oauth_server_url) {
+        return [profile.oauth_server_url.replace(/\/+$/, '')];
+    }
 
+    // Back-compat for profiles that predate explicit oauth_server_url: derive the STS host
+    // from the studio URL. studio-server itself is intentionally NOT in this list — it used
+    // to serve OAuth metadata in-process (apps/studio-server/src/public/oauth.ts, deleted in
+    // commit 254532963) but the canonical owner is now token-server (STS).
     const studioUrl = new URL(profile.studio_server_url);
     const isLoopbackHost = studioUrl.hostname === 'localhost' || studioUrl.hostname === '127.0.0.1';
     if (isLoopbackHost) {
         return ['https://sts.dev1.vertesia.io'];
     }
 
-    const candidates = [new URL('/', studioUrl).toString()];
+    const candidates: string[] = [];
+    // api{,-preview}.{region}.vertesia.io → sts{,-preview}.{region}.vertesia.io
     if (studioUrl.hostname.startsWith('api')) {
-        const stsHost = studioUrl.hostname.replace('api-preview.', 'api.').replace(/^api/, 'sts');
+        const stsHost = studioUrl.hostname.replace(/^api/, 'sts');
         candidates.push(`${studioUrl.protocol}//${stsHost}`);
     }
-
-    if (studioUrl.hostname.endsWith('.api.dev1.vertesia.io') || studioUrl.hostname.endsWith('.ui.dev1.vertesia.io')) {
+    // dev branch services (studio-server-dev-*.api.dev1.vertesia.io) → shared dev1 STS
+    if (
+        studioUrl.hostname.endsWith('.api.dev1.vertesia.io') ||
+        studioUrl.hostname.endsWith('.ui.dev1.vertesia.io')
+    ) {
         candidates.push('https://sts.dev1.vertesia.io');
     }
-
-    candidates.push('https://sts.dev1.vertesia.io');
     return Array.from(new Set(candidates.map((candidate) => candidate.replace(/\/+$/, ''))));
 }
 
@@ -427,6 +438,7 @@ function buildConfigResult(
     response: OAuthTokenResponse,
     oauthClientId: string,
     oauthResource: string,
+    oauthServerUrl: string,
 ): ConfigResult {
     const refs = readTokenRefs(response.access_token);
     const account = refs.account || profile.account;
@@ -445,6 +457,7 @@ function buildConfigResult(
         project,
         studio_server_url: profile.studio_server_url,
         zeno_server_url: profile.zeno_server_url,
+        oauth_server_url: oauthServerUrl,
         token: response.access_token,
         id_token: response.id_token,
         refresh_token: response.refresh_token,

--- a/packages/cli/src/profiles/server/index.ts
+++ b/packages/cli/src/profiles/server/index.ts
@@ -16,6 +16,7 @@ export interface ConfigPayload {
 export interface ConfigResult extends Required<ConfigPayload> {
     studio_server_url: string;
     zeno_server_url: string;
+    oauth_server_url?: string;
     token: string;
     id_token?: string;
     refresh_token?: string;


### PR DESCRIPTION
## Summary

- Adds an explicit `oauth_server_url` field to the CLI `Profile` and threads it through `getServerUrls()` → `ConfigureProfile.persistConfigResult` → `ConfigResult`. New profiles get the canonical STS host per env (`sts.dev1` for local/`dev-*`, `sts-preview.{region}` for preview, `sts.{region}` for prod).
- `discoverAuthorizationServer` now short-circuits to that URL when set. The candidate-derivation loop only runs for legacy profiles that don't have `oauth_server_url` yet.
- Removes `studio_server_url` from the candidate list entirely — studio-server used to serve OAuth AS metadata itself via `apps/studio-server/src/public/oauth.ts` (deleted in studio commit `254532963`), but the canonical owner is now `token-server`/STS. Asking studio-server is what made stale deploys silently break device login.
- Fixes the `api-preview.{region}` → `sts-preview.{region}` mapping (the old code incorrectly collapsed it to prod `sts.{region}`).
- Drops the unconditional `sts.dev1.vertesia.io` fallback — that could send a prod profile to dev1 STS when DNS/routing was misconfigured.

## Background

The vertesia CLI was failing OAuth login against the staging/dev-main environment with "OAuth device authorization is not available for this endpoint." Trace:

1. CLI's `discoverAuthorizationServer` walks `getOAuthServerUrlCandidates`. The first candidate has always been the studio URL itself (a legacy of the pre-STS architecture).
2. The currently-deployed `studio-server-dev1` (commit `eadafce5a`) predates the preview→main merge that deleted `apps/studio-server/src/public/oauth.ts`, so it still answers `/.well-known/oauth-authorization-server` with the legacy doc — no `device_authorization_endpoint`, no `device_code` grant.
3. The CLI accepted that response, never tried `sts.dev1.vertesia.io` (which has the correct metadata), and `createDeviceAuthorization` threw on the missing endpoint.

The deploy fix is to redeploy current `main` to studio-server in dev1/preview/prod. This PR is the code-side fix that prevents the same class of breakage from recurring, by routing OAuth discovery directly at the STS that owns the endpoint.

## Test plan

- [x] `pnpm exec tsc --noEmit` in `packages/cli` passes
- [ ] Create a fresh `dev-main` profile via `vertesia profiles add`, verify `oauth_server_url=https://sts.dev1.vertesia.io` lands in `~/.vertesia/profiles.json`
- [ ] `vertesia login` succeeds against `dev-main` (device flow opens browser, completes)
- [ ] Existing profiles without `oauth_server_url` still log in (back-compat derivation)
- [ ] Token refresh path (`refreshOAuthSession`) still works
- [ ] `vertesia login` against a `preview`/`prod` profile fails cleanly with `OAuthUnavailableError` until `sts-preview.{region}` / `sts.{region}` are deployed, and falls back to legacy login

🤖 Generated with [Claude Code](https://claude.com/claude-code)