### PR TITLE
feat: seamlessly continue completed agent conversations

### DIFF
--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.test.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.test.tsx
@@ -1,0 +1,219 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { type AgentMessage, AgentMessageType } from '@vertesia/common';
+import type React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../__tests__/test-utils.js';
+import { ModernAgentConversation } from './ModernAgentConversation';
+
+const mocks = vi.hoisted(() => ({
+    addOptimisticMessage: vi.fn(),
+    removeOptimisticMessages: vi.fn(),
+    reconnect: vi.fn(),
+    restart: vi.fn(),
+    sendSignal: vi.fn(),
+    useAgentStream: vi.fn(),
+    useAgentPlans: vi.fn(),
+    useDocumentPanel: vi.fn(),
+    useFileProcessing: vi.fn(),
+}));
+
+vi.mock('@vertesia/ui/session', () => ({
+    useUserSession: () => ({
+        client: {
+            agents: {
+                restart: mocks.restart,
+                sendSignal: mocks.sendSignal,
+                getActiveWorkstreams: vi.fn().mockResolvedValue({ running: [] }),
+            },
+        },
+        project: undefined,
+        user: undefined,
+    }),
+}));
+
+vi.mock('./SkillWidgetProvider', () => ({
+    SkillWidgetProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('./ModernAgentOutput/Header', () => ({
+    default: () => <div data-testid="agent-header" />,
+}));
+
+vi.mock('./ModernAgentOutput/MessageInput', () => ({
+    default: ({ onSend }: { onSend: (message: string) => void }) => (
+        <button type="button" onClick={() => onSend('follow up')}>
+            composer send
+        </button>
+    ),
+}));
+
+vi.mock('./ModernAgentOutput/AllMessagesMixed', () => ({
+    default: ({ onSendMessage }: { onSendMessage: (message: string) => void }) => (
+        <button type="button" onClick={() => onSendMessage('follow up')}>
+            inline send
+        </button>
+    ),
+}));
+
+vi.mock('./AgentRightPanel.js', () => ({
+    AgentRightPanel: () => <div data-testid="agent-right-panel" />,
+}));
+
+vi.mock('./hooks/useAgentStream.js', () => ({
+    useAgentStream: (...args: unknown[]) => mocks.useAgentStream(...args),
+}));
+
+vi.mock('./hooks/useAgentPlans.js', () => ({
+    useAgentPlans: (...args: unknown[]) => mocks.useAgentPlans(...args),
+}));
+
+vi.mock('./hooks/useDocumentPanel.js', () => ({
+    useDocumentPanel: (...args: unknown[]) => mocks.useDocumentPanel(...args),
+}));
+
+vi.mock('./hooks/useFileProcessing.js', () => ({
+    useFileProcessing: (...args: unknown[]) => mocks.useFileProcessing(...args),
+}));
+
+function createMessage(type: AgentMessageType, message: string): AgentMessage {
+    return {
+        timestamp: Date.now(),
+        workflow_run_id: 'agent-run-1',
+        type,
+        message,
+        workstream_id: 'main',
+    };
+}
+
+function mockStreamState(options: {
+    messages: AgentMessage[];
+    isCompleted?: boolean;
+    agentRunStatus?: string | null;
+}) {
+    mocks.useAgentStream.mockReturnValue({
+        messages: options.messages,
+        streamingMessages: new Map(),
+        isCompleted: options.isCompleted ?? true,
+        debugChunkFlash: false,
+        addOptimisticMessage: mocks.addOptimisticMessage,
+        removeOptimisticMessages: mocks.removeOptimisticMessages,
+        reconnect: mocks.reconnect,
+        agentRunStatus: options.agentRunStatus ?? null,
+        workflowRunId: 'workflow-run-1',
+        serverFileUpdates: new Map(),
+    });
+}
+
+function renderConversation(props: Partial<React.ComponentProps<typeof ModernAgentConversation>> = {}) {
+    return renderWithProviders(
+        <ModernAgentConversation
+            agentRunId="agent-run-1"
+            title="Agent"
+            hideHeader
+            hideMessageInput
+            showRightPanel={false}
+            {...props}
+        />,
+    );
+}
+
+describe('ModernAgentConversation send handling', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.restart.mockResolvedValue({ id: 'agent-run-1' });
+        mocks.sendSignal.mockResolvedValue({});
+        mocks.useAgentPlans.mockReturnValue({
+            plans: [],
+            activePlanIndex: 0,
+            setActivePlanIndex: vi.fn(),
+            workstreamStatusMap: new Map(),
+            showInput: true,
+            showSlidingPanel: false,
+            setShowSlidingPanel: vi.fn(),
+        });
+        mocks.useDocumentPanel.mockReturnValue({
+            openDocuments: [],
+            activeDocumentId: null,
+            isDocPanelOpen: false,
+            docRefreshKey: 0,
+            closeDocPanel: vi.fn(),
+            closeDocument: vi.fn(),
+            selectDocument: vi.fn(),
+            openDocInPanel: vi.fn(),
+            updateDocumentTitle: vi.fn(),
+        });
+        mocks.useFileProcessing.mockReturnValue({
+            processingFiles: new Map(),
+            hasProcessingFiles: false,
+            handleFileUpload: vi.fn(),
+        });
+    });
+
+    it('restarts a terminal continuable run before sending the follow-up message', async () => {
+        mockStreamState({
+            messages: [createMessage(AgentMessageType.COMPLETE, 'done')],
+            agentRunStatus: 'COMPLETED',
+        });
+
+        renderConversation({ onRestart: vi.fn() });
+
+        fireEvent.click(screen.getByRole('button', { name: 'inline send' }));
+
+        await waitFor(() => {
+            expect(mocks.sendSignal).toHaveBeenCalledTimes(1);
+        });
+
+        expect(mocks.restart).toHaveBeenCalledWith('agent-run-1');
+        expect(mocks.reconnect).toHaveBeenCalledTimes(1);
+        expect(mocks.sendSignal).toHaveBeenCalledWith(
+            'agent-run-1',
+            'UserInput',
+            expect.objectContaining({
+                message: 'follow up',
+                metadata: expect.objectContaining({
+                    _messageId: expect.any(String),
+                }),
+            }),
+        );
+        expect(mocks.restart.mock.invocationCallOrder[0]).toBeLessThan(mocks.sendSignal.mock.invocationCallOrder[0]);
+        expect(mocks.reconnect.mock.invocationCallOrder[0]).toBeLessThan(mocks.sendSignal.mock.invocationCallOrder[0]);
+    });
+
+    it('does not restart or send from a terminal run that cannot continue', () => {
+        mockStreamState({
+            messages: [createMessage(AgentMessageType.COMPLETE, 'done')],
+            agentRunStatus: 'COMPLETED',
+        });
+
+        renderConversation();
+
+        fireEvent.click(screen.getByRole('button', { name: 'inline send' }));
+
+        expect(mocks.restart).not.toHaveBeenCalled();
+        expect(mocks.sendSignal).not.toHaveBeenCalled();
+        expect(mocks.addOptimisticMessage).not.toHaveBeenCalled();
+    });
+
+    it('sends directly without restart while the run is active', async () => {
+        mockStreamState({
+            messages: [createMessage(AgentMessageType.ANSWER, 'still running')],
+            agentRunStatus: 'RUNNING',
+        });
+
+        renderConversation({ onRestart: vi.fn() });
+
+        fireEvent.click(screen.getByRole('button', { name: 'inline send' }));
+
+        await waitFor(() => {
+            expect(mocks.sendSignal).toHaveBeenCalledTimes(1);
+        });
+
+        expect(mocks.restart).not.toHaveBeenCalled();
+        expect(mocks.reconnect).not.toHaveBeenCalled();
+        expect(mocks.sendSignal).toHaveBeenCalledWith(
+            'agent-run-1',
+            'UserInput',
+            expect.objectContaining({ message: 'follow up' }),
+        );
+    });
+});

--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
@@ -855,6 +855,18 @@ function ModernAgentConversationInner({
         );
     }, [effectiveWorkflowStatus]);
 
+    // When a terminal conversation can be restarted (interactive + a restart handler),
+    // we keep the composer visible and seamlessly resume the agent on the next message
+    // instead of forcing the user to click "Continue Conversation".
+    const canContinueConversation = useMemo(
+        () => isWorkflowTerminal && interactive && !!onRestart,
+        [isWorkflowTerminal, interactive, onRestart],
+    );
+
+    // Read inside handleSendMessage (a stable callback) without widening its deps.
+    const isWorkflowTerminalRef = useRef(isWorkflowTerminal);
+    isWorkflowTerminalRef.current = isWorkflowTerminal;
+
     console.debug('[ModernAgentConversation] render', {
         agentRunId,
         instanceId: instanceIdRef.current,
@@ -1114,6 +1126,10 @@ function ModernAgentConversationInner({
     // Notify parent when input availability is determined
     useEffect(() => {
         if (messages.length === 0) return;
+        if (canContinueConversation) {
+            onShowInputChange?.(true);
+            return;
+        }
         if (!showInput) {
             onShowInputChange?.(false);
             return;
@@ -1125,7 +1141,7 @@ function ModernAgentConversationInner({
         if (effectiveWorkflowStatus !== null) {
             onShowInputChange?.(true);
         }
-    }, [showInput, effectiveWorkflowStatus, messages.length, onShowInputChange]);
+    }, [showInput, effectiveWorkflowStatus, messages.length, onShowInputChange, canContinueConversation]);
 
     // ────────────────────────────────────────────
     // Handlers
@@ -1178,14 +1194,28 @@ function ModernAgentConversationInner({
                 _messageId: messageId,
             };
 
-            client.agents
-                .sendSignal(agentRunId, 'UserInput', {
+            const sendUserInput = () =>
+                client.agents.sendSignal(agentRunId, 'UserInput', {
                     message: messageContent,
                     metadata,
-                } as UserInputSignal)
-                .then(() => {
-                    onAttachmentsSent?.();
-                })
+                } as UserInputSignal);
+
+            // When the workflow has already completed, restart it first so it resumes
+            // from the existing conversation history, then deliver the message. Temporal
+            // buffers the signal until the new run is ready to receive it.
+            const deliver = isWorkflowTerminalRef.current
+                ? client.agents.restart(agentRunId).then((newRun) =>
+                      sendUserInput().then(() => {
+                          onAttachmentsSent?.();
+                          // Reconnect the stream to the freshly running workflow.
+                          onRestart?.(newRun);
+                      }),
+                  )
+                : sendUserInput().then(() => {
+                      onAttachmentsSent?.();
+                  });
+
+            deliver
                 .catch((err) => {
                     removeOptimisticMessages((m) => m.details?._messageId === messageId);
                     toast({
@@ -1206,6 +1236,7 @@ function ModernAgentConversationInner({
             getAttachedDocs,
             getMessageContext,
             onAttachmentsSent,
+            onRestart,
             addOptimisticMessage,
             removeOptimisticMessages,
             t,
@@ -1509,7 +1540,7 @@ function ModernAgentConversationInner({
 
             {!hideMessageInput && (
                 <div className="flex-shrink-0" style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}>
-                    {effectiveWorkflowStatus && effectiveWorkflowStatus !== 'RUNNING' ? (
+                    {effectiveWorkflowStatus && effectiveWorkflowStatus !== 'RUNNING' && !canContinueConversation ? (
                         <MessageBox
                             status={effectiveWorkflowStatus === 'COMPLETED' ? 'success' : 'done'}
                             icon={null}
@@ -1518,7 +1549,7 @@ function ModernAgentConversationInner({
                             This Workflow is {effectiveWorkflowStatus}
                         </MessageBox>
                     ) : (
-                        showInput && (
+                        (showInput || canContinueConversation) && (
                             <MessageInput
                                 onSend={handleSendMessage}
                                 onStop={handleStopWorkflow}

--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
@@ -867,6 +867,8 @@ function ModernAgentConversationInner({
     // Read inside handleSendMessage (a stable callback) without widening its deps.
     const isWorkflowTerminalRef = useRef(isWorkflowTerminal);
     isWorkflowTerminalRef.current = isWorkflowTerminal;
+    const canContinueConversationRef = useRef(canContinueConversation);
+    canContinueConversationRef.current = canContinueConversation;
 
     console.debug('[ModernAgentConversation] render', {
         agentRunId,
@@ -1153,6 +1155,11 @@ function ModernAgentConversationInner({
         (message: string) => {
             const trimmed = message.trim();
             if (!trimmed || isSendingRef.current) return;
+
+            // A terminal run only accepts input when it can be continued (restarted).
+            // handleSendMessage is also reachable from inline message actions (AllMessagesMixed),
+            // so guard here too — read-only terminal views that hide the composer must not restart.
+            if (isWorkflowTerminalRef.current && !canContinueConversationRef.current) return;
 
             // Block if files are still processing
             if (hasProcessingFilesRef.current) {

--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
@@ -760,6 +760,7 @@ function ModernAgentConversationInner({
         debugChunkFlash,
         addOptimisticMessage,
         removeOptimisticMessages,
+        reconnect: reconnectStream,
         agentRunStatus,
         workflowRunId,
         serverFileUpdates,
@@ -1202,15 +1203,16 @@ function ModernAgentConversationInner({
 
             // When the workflow has already completed, restart it first so it resumes
             // from the existing conversation history, then deliver the message. Temporal
-            // buffers the signal until the new run is ready to receive it.
+            // buffers the signal until the new run is ready to receive it. We reconnect
+            // the stream in place (rather than remounting via onRestart) so the existing
+            // timeline is preserved and the new exchange appends seamlessly at the bottom.
             const deliver = isWorkflowTerminalRef.current
-                ? client.agents.restart(agentRunId).then((newRun) =>
-                      sendUserInput().then(() => {
+                ? client.agents.restart(agentRunId).then(() => {
+                      reconnectStream();
+                      return sendUserInput().then(() => {
                           onAttachmentsSent?.();
-                          // Reconnect the stream to the freshly running workflow.
-                          onRestart?.(newRun);
-                      }),
-                  )
+                      });
+                  })
                 : sendUserInput().then(() => {
                       onAttachmentsSent?.();
                   });
@@ -1236,7 +1238,7 @@ function ModernAgentConversationInner({
             getAttachedDocs,
             getMessageContext,
             onAttachmentsSent,
-            onRestart,
+            reconnectStream,
             addOptimisticMessage,
             removeOptimisticMessages,
             t,
@@ -1481,7 +1483,6 @@ function ModernAgentConversationInner({
                         onTogglePlanPanel={handleTogglePlanPanel}
                         onDownload={downloadConversation}
                         resetWorkflow={resetWorkflow}
-                        onRestart={onRestart}
                         onClone={onClone}
                         onShowDetails={onShowDetails}
                         onExportPdf={exportConversationPdf}

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/Header.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/Header.tsx
@@ -38,6 +38,12 @@ export interface HeaderProps {
     onExportPdf?: () => void;
     /** Called to show run details/internals modal */
     onShowDetails?: () => void;
+    /**
+     * @deprecated No longer used. Continuing a completed conversation now happens
+     * automatically when the user sends a message. Kept as an optional no-op to preserve
+     * type compatibility for external consumers of this public component.
+     */
+    onRestart?: (newRun: AgentRun) => void;
     /** Called after a clone succeeds — receives the new AgentRun */
     onClone?: (newRun: AgentRun) => void;
     /** Show green indicator when receiving streaming chunks */

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/Header.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/Header.tsx
@@ -10,7 +10,6 @@ import {
     GitFork,
     InfoIcon,
     MoreVertical,
-    RefreshCcw,
     XIcon,
 } from 'lucide-react';
 import { useUITranslation } from '@vertesia/ui/i18n';
@@ -39,8 +38,6 @@ export interface HeaderProps {
     onExportPdf?: () => void;
     /** Called to show run details/internals modal */
     onShowDetails?: () => void;
-    /** Called after a restart succeeds — receives the new AgentRun */
-    onRestart?: (newRun: AgentRun) => void;
     /** Called after a clone succeeds — receives the new AgentRun */
     onClone?: (newRun: AgentRun) => void;
     /** Show green indicator when receiving streaming chunks */
@@ -67,13 +64,11 @@ export default function Header({
     resetWorkflow,
     onExportPdf,
     onShowDetails,
-    onRestart,
     onClone,
     isReceivingChunks = false,
     className,
 }: HeaderProps) {
     const { t } = useUITranslation();
-    const continueWorkflow = useContinueWorkflow(agentRunId, onRestart);
     return (
         <PayloadBuilderProvider>
             <div
@@ -140,19 +135,6 @@ export default function Header({
                         </div>
                     )}
 
-                    {onRestart && isTerminal && (
-                        <Button
-                            size="sm"
-                            variant="secondary"
-                            onClick={continueWorkflow}
-                            className="transition-all duration-200 rounded-md"
-                            title={t('agent.continueConversation')}
-                        >
-                            <RefreshCcw className="size-4 me-1.5" />
-                            <span className="font-medium text-xs">{t('agent.continueConversation')}</span>
-                        </Button>
-                    )}
-
                     {/* More actions */}
                     <MoreDropdown
                         agentRunId={agentRunId}
@@ -164,7 +146,6 @@ export default function Header({
                         resetWorkflow={resetWorkflow}
                         onExportPdf={onExportPdf}
                         onShowDetails={onShowDetails}
-                        onRestart={onRestart}
                         onClone={onClone}
                     />
                     {onClose && !isModal && (
@@ -178,30 +159,6 @@ export default function Header({
     );
 }
 
-function useContinueWorkflow(agentRunId: string, onRestart?: (newRun: AgentRun) => void) {
-    const { t } = useUITranslation();
-    const toast = useToast();
-    const { client } = useUserSession();
-
-    return async () => {
-        try {
-            const newRun = await client.agents.restart(agentRunId);
-            toast({
-                status: 'success',
-                title: t('agent.conversationContinued'),
-                duration: 2000,
-            });
-            onRestart?.(newRun);
-        } catch (_error) {
-            toast({
-                status: 'error',
-                title: t('agent.failedToContinueConversation'),
-                duration: 2000,
-            });
-        }
-    };
-}
-
 function MoreDropdown({
     agentRunId,
     workflowRunId,
@@ -212,7 +169,6 @@ function MoreDropdown({
     resetWorkflow,
     onExportPdf,
     onShowDetails,
-    onRestart,
     onClone,
 }: {
     agentRunId: string;
@@ -225,14 +181,12 @@ function MoreDropdown({
     resetWorkflow?: () => void;
     onExportPdf?: () => void;
     onShowDetails?: () => void;
-    onRestart?: (newRun: AgentRun) => void;
     onClone?: (newRun: AgentRun) => void;
 }) {
     const { t } = useUITranslation();
     const toast = useToast();
     const { client } = useUserSession();
     const builder = usePayloadBuilder();
-    const continueWorkflow = useContinueWorkflow(agentRunId, onRestart);
 
     const cancelWorkflow = async () => {
         try {
@@ -344,11 +298,6 @@ function MoreDropdown({
                 {onClose && isModal && (
                     <MenuItem onClick={onClose}>
                         <XIcon className="size-3.5 text-muted" /> {t('agent.close')}
-                    </MenuItem>
-                )}
-                {onRestart && isTerminal && (
-                    <MenuItem onClick={continueWorkflow}>
-                        <RefreshCcw className="size-3.5 text-muted" /> {t('agent.continueConversation')}
                     </MenuItem>
                 )}
                 {onClone && (

--- a/packages/ui/src/features/agent/chat/hooks/useAgentStream.test.tsx
+++ b/packages/ui/src/features/agent/chat/hooks/useAgentStream.test.tsx
@@ -1,0 +1,185 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { VertesiaClient } from '@vertesia/client';
+import { type AgentMessage, AgentMessageType } from '@vertesia/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAgentStream } from './useAgentStream';
+
+type StreamMessagesMock = ReturnType<typeof vi.fn<
+    (
+        id: string,
+        onMessage?: (message: AgentMessage, exitFn?: (payload: unknown) => void) => void,
+        since?: number,
+        signal?: AbortSignal,
+    ) => Promise<unknown>
+>>;
+
+function createMessage(type: AgentMessageType, timestamp: number, message: string): AgentMessage {
+    return {
+        timestamp,
+        workflow_run_id: 'run-1',
+        type,
+        message,
+        workstream_id: 'main',
+    };
+}
+
+function createClient(streamMessages: StreamMessagesMock): VertesiaClient {
+    return {
+        agents: {
+            getInternals: vi.fn().mockResolvedValue({
+                status: 'RUNNING',
+                first_workflow_run_id: 'workflow-run-1',
+            }),
+            streamMessages,
+        },
+    } as unknown as VertesiaClient;
+}
+
+describe('useAgentStream', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('reconnects the same agent run from the last delivered timestamp without clearing messages', async () => {
+        const complete = createMessage(AgentMessageType.COMPLETE, 1_000, 'done');
+        const answer = createMessage(AgentMessageType.ANSWER, 1_100, 'continued');
+        const streamMessages = vi
+            .fn<
+                (
+                    id: string,
+                    onMessage?: (message: AgentMessage, exitFn?: (payload: unknown) => void) => void,
+                    since?: number,
+                    signal?: AbortSignal,
+                ) => Promise<unknown>
+            >()
+            .mockImplementationOnce(async (_id, onMessage) => {
+                onMessage?.(complete);
+                return null;
+            })
+            .mockImplementationOnce(async (_id, onMessage) => {
+                onMessage?.(answer);
+                return null;
+            });
+        const client = createClient(streamMessages);
+
+        const { result } = renderHook(() => useAgentStream(client, 'agent-run-1'));
+
+        await waitFor(() => {
+            expect(result.current.messages.map((message) => message.message)).toEqual(['done']);
+        });
+
+        act(() => {
+            result.current.reconnect();
+        });
+
+        await waitFor(() => {
+            expect(streamMessages).toHaveBeenCalledTimes(2);
+        });
+
+        expect(streamMessages.mock.calls[0][2]).toBeUndefined();
+        expect(streamMessages.mock.calls[1][2]).toBe(1_000);
+
+        await waitFor(() => {
+            expect(result.current.messages.map((message) => message.message)).toEqual(['done', 'continued']);
+        });
+    });
+
+    it('resets state and fetches full history when the agent run id changes', async () => {
+        const firstRunMessage = createMessage(AgentMessageType.ANSWER, 1_000, 'first run');
+        const secondRunMessage = {
+            ...createMessage(AgentMessageType.ANSWER, 2_000, 'second run'),
+            workflow_run_id: 'run-2',
+        };
+        const streamMessages = vi
+            .fn<
+                (
+                    id: string,
+                    onMessage?: (message: AgentMessage, exitFn?: (payload: unknown) => void) => void,
+                    since?: number,
+                    signal?: AbortSignal,
+                ) => Promise<unknown>
+            >()
+            .mockImplementationOnce(async (_id, onMessage) => {
+                onMessage?.(firstRunMessage);
+                return null;
+            })
+            .mockImplementationOnce(async (_id, onMessage) => {
+                onMessage?.(secondRunMessage);
+                return null;
+            });
+        const client = createClient(streamMessages);
+
+        const { result, rerender } = renderHook(({ agentRunId }) => useAgentStream(client, agentRunId), {
+            initialProps: { agentRunId: 'agent-run-1' },
+        });
+
+        await waitFor(() => {
+            expect(result.current.messages.map((message) => message.message)).toEqual(['first run']);
+        });
+
+        rerender({ agentRunId: 'agent-run-2' });
+
+        await waitFor(() => {
+            expect(streamMessages).toHaveBeenCalledTimes(2);
+        });
+
+        expect(streamMessages.mock.calls[1][0]).toBe('agent-run-2');
+        expect(streamMessages.mock.calls[1][2]).toBeUndefined();
+
+        await waitFor(() => {
+            expect(result.current.messages.map((message) => message.message)).toEqual(['second run']);
+        });
+    });
+
+    it('dedupes re-delivered messages by timestamp and replaces optimistic questions', async () => {
+        let onStreamMessage: ((message: AgentMessage) => void) | undefined;
+        const streamMessages = vi.fn<
+            (
+                id: string,
+                onMessage?: (message: AgentMessage, exitFn?: (payload: unknown) => void) => void,
+                since?: number,
+                signal?: AbortSignal,
+            ) => Promise<unknown>
+        >(async (_id, onMessage) => {
+            onStreamMessage = onMessage;
+            return null;
+        });
+        const client = createClient(streamMessages);
+
+        const { result } = renderHook(() => useAgentStream(client, 'agent-run-1'));
+
+        await waitFor(() => {
+            expect(onStreamMessage).toBeDefined();
+        });
+
+        act(() => {
+            result.current.addOptimisticMessage({
+                ...createMessage(AgentMessageType.QUESTION, 1_000, 'optimistic'),
+                details: { _optimistic: true, _messageId: 'message-1' },
+            });
+        });
+
+        expect(result.current.messages).toHaveLength(1);
+
+        act(() => {
+            onStreamMessage?.({
+                ...createMessage(AgentMessageType.QUESTION, 1_100, 'server question'),
+                details: { _messageId: 'message-1' },
+            });
+        });
+
+        await waitFor(() => {
+            expect(result.current.messages.map((message) => message.message)).toEqual(['server question']);
+        });
+
+        const answer = createMessage(AgentMessageType.ANSWER, 1_200, 'answer');
+        act(() => {
+            onStreamMessage?.(answer);
+            onStreamMessage?.(answer);
+        });
+
+        await waitFor(() => {
+            expect(result.current.messages.map((message) => message.message)).toEqual(['server question', 'answer']);
+        });
+    });
+});

--- a/packages/ui/src/features/agent/chat/hooks/useAgentStream.ts
+++ b/packages/ui/src/features/agent/chat/hooks/useAgentStream.ts
@@ -74,6 +74,12 @@ export function useAgentStream(client: VertesiaClient, agentRunId: string): UseA
     // can be distinguished from switching to a different conversation.
     const prevAgentRunIdRef = useRef<string | null>(null);
 
+    // Highest message timestamp delivered so far. On a same-run reconnect this is passed
+    // as the `since` cursor so the history replay excludes the previous run's terminal
+    // (COMPLETE/TERMINATED) message — otherwise streamMessages would treat that stale
+    // event as stream-ending and close before the restarted run's reply arrives.
+    const lastDeliveredTsRef = useRef(0);
+
     // Streaming messages by streaming_id for real-time chunk aggregation
     const [streamingMessages, setStreamingMessages] = useState<Map<string, StreamingData>>(new Map());
 
@@ -128,8 +134,14 @@ export function useAgentStream(client: VertesiaClient, agentRunId: string): UseA
             setWorkflowRunId(null);
             setStreamingMessages(new Map());
             setServerFileUpdates(new Map());
+            lastDeliveredTsRef.current = 0;
         }
         const abortController = new AbortController();
+
+        // Resume from the last delivered message on a reconnect; fetch full history for a
+        // new conversation. The cursor is exclusive server-side (ts > since), so the prior
+        // run's terminal message is skipped on reconnect.
+        const since = isNewConversation ? undefined : lastDeliveredTsRef.current || undefined;
 
         // Check agent run status
         client.agents
@@ -151,6 +163,11 @@ export function useAgentStream(client: VertesiaClient, agentRunId: string): UseA
                 agentRunId,
                 (message) => {
                     if (abortController.signal.aborted) return;
+
+                    // Advance the reconnect cursor past every delivered message.
+                    if (message.timestamp && message.timestamp > lastDeliveredTsRef.current) {
+                        lastDeliveredTsRef.current = message.timestamp;
+                    }
 
                     // Handle streaming chunks separately for real-time aggregation
                     // PERFORMANCE: Batch updates using RAF instead of immediate state updates
@@ -263,7 +280,7 @@ export function useAgentStream(client: VertesiaClient, agentRunId: string): UseA
                         });
                     }
                 },
-                undefined,
+                since,
                 abortController.signal,
             )
             .catch((error) => {

--- a/packages/ui/src/features/agent/chat/hooks/useAgentStream.ts
+++ b/packages/ui/src/features/agent/chat/hooks/useAgentStream.ts
@@ -28,6 +28,12 @@ export interface UseAgentStreamResult {
     addOptimisticMessage: (msg: AgentMessage) => void;
     /** Remove optimistic messages matching a predicate */
     removeOptimisticMessages: (predicate: (msg: AgentMessage) => boolean) => void;
+    /**
+     * Re-open the SSE stream for the SAME agentRunId without clearing the existing
+     * timeline. Used after restarting a completed workflow so newly produced messages
+     * append seamlessly at the bottom instead of forcing a full reload.
+     */
+    reconnect: () => void;
     /** AgentRun status fetched from API (RUNNING, COMPLETED, FAILED, etc.) */
     agentRunStatus: string | null;
     /** Temporal workflow run ID (first_workflow_run_id from AgentRun) */
@@ -59,6 +65,14 @@ export function useAgentStream(client: VertesiaClient, agentRunId: string): UseA
 
     // Server-side file processing status updates
     const [serverFileUpdates, setServerFileUpdates] = useState<Map<string, ConversationFile>>(new Map());
+
+    // Bumped to re-open the stream in place (same agentRunId) without resetting the timeline.
+    const [streamNonce, setStreamNonce] = useState(0);
+    const reconnect = useCallback(() => setStreamNonce((n) => n + 1), []);
+
+    // Tracks the last agentRunId the stream effect ran for, so a reconnect (nonce bump)
+    // can be distinguished from switching to a different conversation.
+    const prevAgentRunIdRef = useRef<string | null>(null);
 
     // Streaming messages by streaming_id for real-time chunk aggregation
     const [streamingMessages, setStreamingMessages] = useState<Map<string, StreamingData>>(new Map());
@@ -100,13 +114,21 @@ export function useAgentStream(client: VertesiaClient, agentRunId: string): UseA
 
     // Stream messages from the agent
     useEffect(() => {
-        // Reset all state when agentRunId changes (new agent)
-        console.debug('[useAgentStream] effect:start', { agentRunId });
-        setMessages([]);
-        setAgentRunStatus(null);
-        setWorkflowRunId(null);
-        setStreamingMessages(new Map());
-        setServerFileUpdates(new Map());
+        // Only reset state when switching to a different conversation. A reconnect
+        // (nonce bump for the same agentRunId) keeps the existing timeline so newly
+        // streamed messages append in place — re-delivered history is de-duped by
+        // timestamp below.
+        const isNewConversation = prevAgentRunIdRef.current !== agentRunId;
+        prevAgentRunIdRef.current = agentRunId;
+
+        console.debug('[useAgentStream] effect:start', { agentRunId, streamNonce, isNewConversation });
+        if (isNewConversation) {
+            setMessages([]);
+            setAgentRunStatus(null);
+            setWorkflowRunId(null);
+            setStreamingMessages(new Map());
+            setServerFileUpdates(new Map());
+        }
         const abortController = new AbortController();
 
         // Check agent run status
@@ -253,7 +275,9 @@ export function useAgentStream(client: VertesiaClient, agentRunId: string): UseA
         return () => {
             console.debug('[useAgentStream] effect:cleanup', { agentRunId });
             abortController.abort();
-            setMessages([]);
+            // Note: messages are intentionally NOT cleared here. Switching conversations
+            // resets them at effect start (isNewConversation); a reconnect must preserve
+            // the timeline so the UI doesn't flash/reload.
             cancelScheduledStreamingFlush();
             pendingStreamingChunks.current.clear();
             if (debugFlashTimeout.current) {
@@ -261,7 +285,7 @@ export function useAgentStream(client: VertesiaClient, agentRunId: string): UseA
                 debugFlashTimeout.current = null;
             }
         };
-    }, [agentRunId, client.agents, flushStreamingChunks, cancelScheduledStreamingFlush]);
+    }, [agentRunId, streamNonce, client.agents, flushStreamingChunks, cancelScheduledStreamingFlush]);
 
     // Flush pending streaming chunks when tab becomes visible.
     useEffect(() => {
@@ -303,6 +327,7 @@ export function useAgentStream(client: VertesiaClient, agentRunId: string): UseA
         debugChunkFlash,
         addOptimisticMessage,
         removeOptimisticMessages,
+        reconnect,
         agentRunStatus,
         workflowRunId,
         serverFileUpdates,


### PR DESCRIPTION
## Summary
Reopening a completed agent conversation now keeps the message composer visible so the user can simply type and continue — no explicit "Continue Conversation" click required, and without reloading the timeline.

- **Composer stays available on terminal runs** — `ModernAgentConversation` shows the `MessageInput` instead of the "This Workflow is COMPLETED" banner whenever a conversation is terminal *and* continuable (interactive + a restart-capable host). Read-only hosts (no restart handler) keep the existing banner.
- **Seamless restart-on-send** — when a message is sent on a completed run, the component restarts the run (`client.agents.restart`), then delivers the message via the `UserInput` signal. Temporal buffers the signal until the resumed run is ready.
- **In-place stream reconnect (no reload/scroll jump)** — `useAgentStream` gains a `reconnect()` that re-opens the SSE stream for the same `agentRunId` without clearing the timeline. State is only reset when switching to a *different* conversation, and the effect cleanup no longer wipes messages. Re-delivered history is de-duped by timestamp and the optimistic user message is replaced by the server copy, so the new exchange appends at the bottom.
- **Removed the now-redundant "Continue Conversation" actions** — the header button and the ⋮ dropdown item are gone, along with the unused `useContinueWorkflow` helper and `onRestart` prop on `Header`. Clone / Cancel / copy / download actions are unchanged.

## Test Plan
- [x] `turbo build --filter=@vertesia/ui` (tsc typecheck + rollup) passes
- [ ] Open a completed conversation → composer is shown (no banner); type a message → run resumes and the reply streams in at the bottom with no reload or scroll jump
- [ ] A still-running conversation behaves exactly as before (message sent via signal, no restart)
- [ ] Read-only conversation views (no restart handler) still show the terminal status banner

### Notes
- `biome check` on the touched files reports only pre-existing `assist/source/organizeImports` diagnostics that are also present on `main`; no import reordering was done as part of this change to keep the diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>