### PR TITLE
feat(common): add modified_since to StartProjectReindexPayload

### DIFF
--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -414,6 +414,13 @@ export interface StartProjectReindexPayload {
     concurrency?: number;
     bulk_size_bytes?: number;
     bulk_concurrency?: number;
+    /**
+     * When set, reindex only documents whose `updated_at` is >= this ISO-8601
+     * datetime. Writes in-place into the live alias's current index (no new
+     * versioned target, no alias swap). Omit for a full reindex into a fresh
+     * versioned target. Matches the `modified_since` workflow param.
+     */
+    modified_since?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds an optional `modified_since?: string` (ISO-8601 datetime) field to `StartProjectReindexPayload`. When set, the reindex workflow processes only documents whose `updated_at` is >= the supplied time and writes in-place into the live alias's current index — no fresh versioned target, no alias swap. Omit for the existing full-reindex behavior.

Mirrors the `modified_since` parameter already supported by `fullProjectReindexWorkflow` in the studio repo; this exposes it through the public payload type so the client SDK and admin UI can plumb it through.

## Companion PR

This is the submodule half of [vertesia/studio#5367](https://github.com/vertesia/studio/pull/5367), which:
- Plumbs `modified_since` through `POST /reindex` in zeno-server
- Adds a date-picker modal to the admin reindex UI in composable-ui (full reindex stays the default — set a date for incremental)

The studio PR pins the submodule pointer to this branch tip.

## Backwards compatibility

Optional field, omitted in existing callers → full reindex (current behavior). No breaking change.

## Test plan

- [x] Already validated end-to-end on the studio-side branch deployment against a 16k-doc project: incremental + full-reindex paths both succeed, alias topology preserved correctly for each mode.
- [ ] Reviewer can grep for `modified_since` to confirm the field surfaces in generated openapi / client typings consumers in the parent repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)