### PR TITLE
fix(deps): bump tmp to >=0.2.6 (path traversal advisory)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,7 @@ overrides:
   '@hono/node-server@<1.19.10': ^1.19.14
   hono@<4.12.14: ^4.12.19
   serialize-javascript@<7.0.3: ^7.0.5
+  tmp@<0.2.6: ^0.2.6
   dompurify@<=3.3.3: ^3.4.5
   undici@>=6.0.0 <6.21.3: 7.25.0
   vite: ^8.0.14
@@ -359,8 +360,8 @@ importers:
         specifier: ^0.34.5
         version: 0.34.5
       tmp:
-        specifier: ^0.2.5
-        version: 0.2.5
+        specifier: ^0.2.6
+        version: 0.2.7
     devDependencies:
       '@types/tmp':
         specifier: ^0.2.6
@@ -928,8 +929,8 @@ importers:
         specifier: ^1.0.22
         version: 1.0.22
       tmp:
-        specifier: ^0.2.5
-        version: 0.2.5
+        specifier: ^0.2.6
+        version: 0.2.7
       tmp-promise:
         specifier: ^3.0.3
         version: 3.0.3
@@ -6751,8 +6752,8 @@ packages:
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
   toidentifier@1.0.1:
@@ -13881,9 +13882,9 @@ snapshots:
 
   tmp-promise@3.0.3:
     dependencies:
-      tmp: 0.2.5
+      tmp: 0.2.7
 
-  tmp@0.2.5: {}
+  tmp@0.2.7: {}
 
   toidentifier@1.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,6 +46,7 @@ overrides:
   "@hono/node-server@<1.19.10": "^1.19.14"
   "hono@<4.12.14": "^4.12.19"
   "serialize-javascript@<7.0.3": "^7.0.5"
+  "tmp@<0.2.6": "^0.2.6"
   "dompurify@<=3.3.3": "^3.4.5"
   "undici@>=6.0.0 <6.21.3": "7.25.0"
   vite: "$vite"


### PR DESCRIPTION
## Summary

- Force `tmp` to `>=0.2.6` via a pnpm override to resolve a high-severity path-traversal advisory in transitive `tmp@0.2.5`.

## Security advisory

`tmp`:
- **Severity**: High
- **Vulnerability**: `tmp` has path traversal via unsanitized `prefix`/`postfix` that enables directory escape.
- **Vulnerable range**: `< 0.2.6`
- **Fixed in**: `0.2.6` (lockfile resolves to `0.2.7`)

`tmp` is a transitive dependency (pulled in via several packages and `tmp-promise`); pinned through `pnpm-workspace.yaml` `overrides`.

## Test Plan
- [ ] CI build passes
- [ ] `tmp` resolves to `>=0.2.6` in `pnpm-lock.yaml` (verified locally: `0.2.7`)
- [ ] Dependabot alert resolved after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
