### PR TITLE
Add read-only auditor and support role UI support

### DIFF
--- a/packages/cli/src/profiles/oauth.ts
+++ b/packages/cli/src/profiles/oauth.ts
@@ -187,10 +187,7 @@ function getOAuthServerUrlCandidates(
         candidates.push(`${studioUrl.protocol}//${stsHost}`);
     }
     // dev branch services (studio-server-dev-*.api.dev1.vertesia.io) → shared dev1 STS
-    if (
-        studioUrl.hostname.endsWith('.api.dev1.vertesia.io') ||
-        studioUrl.hostname.endsWith('.ui.dev1.vertesia.io')
-    ) {
+    if (studioUrl.hostname.endsWith('.api.dev1.vertesia.io') || studioUrl.hostname.endsWith('.ui.dev1.vertesia.io')) {
         candidates.push('https://sts.dev1.vertesia.io');
     }
     return Array.from(new Set(candidates.map((candidate) => candidate.replace(/\/+$/, ''))));

--- a/packages/common/src/access-control.ts
+++ b/packages/common/src/access-control.ts
@@ -33,6 +33,8 @@ export enum Permission {
     manage_billing = 'account:billing',
     /** View cost and usage analytics */
     billing_read = 'billing:read',
+    /** View account and project audit events. */
+    audit_read = 'audit:read',
     account_member = 'account:member',
 
     content_read = 'content:read',

--- a/packages/common/src/access-control.ts
+++ b/packages/common/src/access-control.ts
@@ -23,6 +23,7 @@ export enum Permission {
 
     api_key_create = 'api_key:create',
     api_key_read = 'api_key:read',
+    api_key_secret_read = 'api_key:secret_read',
     api_key_update = 'api_key:update',
     api_key_delete = 'api_key:delete',
 
@@ -35,14 +36,18 @@ export enum Permission {
     account_member = 'account:member',
 
     content_read = 'content:read',
+    content_read_all = 'content:read_all',
     content_write = 'content:write',
     content_delete = 'content:delete',
     content_admin = 'content:admin', //manage schemas
     content_superadmin = 'content:superadmin', // list all objects and collections
 
+    workflow_read = 'workflow:read',
     workflow_run = 'workflow:run',
     workflow_admin = 'workflow:admin',
     workflow_superadmin = 'workflow:superadmin',
+
+    agent_run_read = 'agent_run:read',
 
     task_read = 'task:read',
     task_manage = 'task:manage',

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -20,6 +20,7 @@ export enum ProjectRoles {
     executor = 'executor', // can only read and execute interactions
     reader = 'reader', // can only read (browse)
     auditor = 'auditor', // can read all non-admin resources without mutation permissions
+    support = 'support', // Vertesia support read-only role
     billing = 'billing', // can only manage billings
     member = 'member', // can only access, but no specific permissions
     app_member = 'app_member', // used to mark an user have access to an application. does not provide any permission on its own

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -19,6 +19,7 @@ export enum ProjectRoles {
     consumer = 'consumer', // required permissions for users of micro apps
     executor = 'executor', // can only read and execute interactions
     reader = 'reader', // can only read (browse)
+    auditor = 'auditor', // can read all non-admin resources without mutation permissions
     billing = 'billing', // can only manage billings
     member = 'member', // can only access, but no specific permissions
     app_member = 'app_member', // used to mark an user have access to an application. does not provide any permission on its own

--- a/packages/ui/src/core/components/InputList.tsx
+++ b/packages/ui/src/core/components/InputList.tsx
@@ -14,6 +14,7 @@ interface InputListProps {
     delimiters?: string; // space and , by default
     placeholder?: string;
     autoFocus?: boolean;
+    disabled?: boolean;
 }
 export function InputList({
     value = [],
@@ -22,10 +23,12 @@ export function InputList({
     delimiters = ', ',
     placeholder,
     autoFocus,
+    disabled = false,
 }: InputListProps) {
     const [text, setText] = useState<string>('');
 
     const onBlur = (ev: React.FocusEvent<HTMLInputElement>) => {
+        if (disabled) return;
         const v = ev.currentTarget.value;
         if (v?.trim()) {
             onChange([...value, v.trim()]);
@@ -33,6 +36,7 @@ export function InputList({
         }
     };
     const onKeyDown = (ev: React.KeyboardEvent<HTMLInputElement>) => {
+        if (disabled) return;
         const v = ev.currentTarget.value;
         const isEmpty = !v.trim();
         const key = ev.key;
@@ -51,6 +55,7 @@ export function InputList({
     };
 
     const onPaste = (ev: React.ClipboardEvent<HTMLInputElement>) => {
+        if (disabled) return;
         const pastedText = ev.clipboardData.getData('text');
         if (pastedText) {
             ev.preventDefault();
@@ -77,6 +82,7 @@ export function InputList({
     };
 
     const _onClick = (index: number): void => {
+        if (disabled) return;
         if (value && value.length > 0) {
             value.splice(index, 1);
             onChange([...value]);
@@ -89,6 +95,7 @@ export function InputList({
                 className,
                 'w-full flex flex-wrap items-center gap-1 p-2 py-1.5',
                 'rounded-md text-sm rounded-md border border-input bg-background ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted focus-visible:outline-none focus-visible:ring-1 ring-inset focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+                disabled && 'opacity-50 cursor-not-allowed',
             )}
         >
             {value &&
@@ -101,7 +108,12 @@ export function InputList({
                             // biome-ignore lint/suspicious/noArrayIndexKey: list order is stable for this render
                             key={index}
                             onClick={() => _onClick(index)}
-                            className="cursor-pointer flex-shrink-0 hover:bg-destructive hover:text-destructive transition-colors"
+                            className={clsx(
+                                'flex-shrink-0 transition-colors',
+                                disabled
+                                    ? 'cursor-not-allowed'
+                                    : 'cursor-pointer hover:bg-destructive hover:text-destructive',
+                            )}
                             title={v}
                         >
                             <span className="break-all">{v}</span>
@@ -120,6 +132,7 @@ export function InputList({
                 onChange={setText}
                 placeholder={!value || value.length === 0 ? placeholder : ''}
                 autoFocus={autoFocus}
+                disabled={disabled}
             />
         </div>
     );

--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
@@ -314,31 +314,40 @@ function StartWorkflowView({
     const dragCounterRef = useRef(0);
 
     // Drag and drop handlers for file staging
-    const handleDragEnter = useCallback((e: React.DragEvent) => {
-        if (!canStageFiles) return;
-        e.preventDefault();
-        e.stopPropagation();
-        dragCounterRef.current++;
-        if (e.dataTransfer?.types?.includes('Files')) {
-            setIsDragOver(true);
-        }
-    }, [canStageFiles]);
+    const handleDragEnter = useCallback(
+        (e: React.DragEvent) => {
+            if (!canStageFiles) return;
+            e.preventDefault();
+            e.stopPropagation();
+            dragCounterRef.current++;
+            if (e.dataTransfer?.types?.includes('Files')) {
+                setIsDragOver(true);
+            }
+        },
+        [canStageFiles],
+    );
 
-    const handleDragOver = useCallback((e: React.DragEvent) => {
-        if (!canStageFiles) return;
-        e.preventDefault();
-        e.stopPropagation();
-    }, [canStageFiles]);
+    const handleDragOver = useCallback(
+        (e: React.DragEvent) => {
+            if (!canStageFiles) return;
+            e.preventDefault();
+            e.stopPropagation();
+        },
+        [canStageFiles],
+    );
 
-    const handleDragLeave = useCallback((e: React.DragEvent) => {
-        if (!canStageFiles) return;
-        e.preventDefault();
-        e.stopPropagation();
-        dragCounterRef.current--;
-        if (dragCounterRef.current === 0) {
-            setIsDragOver(false);
-        }
-    }, [canStageFiles]);
+    const handleDragLeave = useCallback(
+        (e: React.DragEvent) => {
+            if (!canStageFiles) return;
+            e.preventDefault();
+            e.stopPropagation();
+            dragCounterRef.current--;
+            if (dragCounterRef.current === 0) {
+                setIsDragOver(false);
+            }
+        },
+        [canStageFiles],
+    );
 
     const handleDrop = useCallback(
         (e: React.DragEvent) => {
@@ -1231,31 +1240,40 @@ function ModernAgentConversationInner({
     );
 
     // Drag and drop handlers for full-panel file upload
-    const handleDragEnter = useCallback((e: React.DragEvent) => {
-        if (!canUploadFiles) return;
-        e.preventDefault();
-        e.stopPropagation();
-        dragCounterRef.current++;
-        if (e.dataTransfer?.types?.includes('Files')) {
-            setIsDragOver(true);
-        }
-    }, [canUploadFiles]);
+    const handleDragEnter = useCallback(
+        (e: React.DragEvent) => {
+            if (!canUploadFiles) return;
+            e.preventDefault();
+            e.stopPropagation();
+            dragCounterRef.current++;
+            if (e.dataTransfer?.types?.includes('Files')) {
+                setIsDragOver(true);
+            }
+        },
+        [canUploadFiles],
+    );
 
-    const handleDragOver = useCallback((e: React.DragEvent) => {
-        if (!canUploadFiles) return;
-        e.preventDefault();
-        e.stopPropagation();
-    }, [canUploadFiles]);
+    const handleDragOver = useCallback(
+        (e: React.DragEvent) => {
+            if (!canUploadFiles) return;
+            e.preventDefault();
+            e.stopPropagation();
+        },
+        [canUploadFiles],
+    );
 
-    const handleDragLeave = useCallback((e: React.DragEvent) => {
-        if (!canUploadFiles) return;
-        e.preventDefault();
-        e.stopPropagation();
-        dragCounterRef.current--;
-        if (dragCounterRef.current === 0) {
-            setIsDragOver(false);
-        }
-    }, [canUploadFiles]);
+    const handleDragLeave = useCallback(
+        (e: React.DragEvent) => {
+            if (!canUploadFiles) return;
+            e.preventDefault();
+            e.stopPropagation();
+            dragCounterRef.current--;
+            if (dragCounterRef.current === 0) {
+                setIsDragOver(false);
+            }
+        },
+        [canUploadFiles],
+    );
 
     const handleDrop = useCallback(
         (e: React.DragEvent) => {

--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
@@ -113,6 +113,8 @@ interface ModernAgentConversationProps {
     onClone?: (newRun: AgentRun) => void;
     /** Called to show run details/internals modal */
     onShowDetails?: () => void;
+    /** Whether workflow control actions such as cancel should be shown. */
+    allowWorkflowControl?: boolean;
 
     // File upload props - passed through to MessageInput
     /** Called when files are dropped/pasted/selected */
@@ -288,6 +290,8 @@ function StartWorkflowView({
     // File upload props
     acceptedFileTypes,
     maxFiles = 5,
+    hideFileUpload = false,
+    allowWorkflowControl,
 }: ModernAgentConversationProps) {
     const { t } = useUITranslation();
     const resolvedPlaceholder = placeholder ?? t('agent.typeYourMessage');
@@ -303,6 +307,7 @@ function StartWorkflowView({
 
     // Staged files - stored locally until workflow starts
     const [stagedFiles, setStagedFiles] = useState<File[]>([]);
+    const canStageFiles = !hideFileUpload;
 
     // Drag and drop state
     const [isDragOver, setIsDragOver] = useState(false);
@@ -310,30 +315,34 @@ function StartWorkflowView({
 
     // Drag and drop handlers for file staging
     const handleDragEnter = useCallback((e: React.DragEvent) => {
+        if (!canStageFiles) return;
         e.preventDefault();
         e.stopPropagation();
         dragCounterRef.current++;
         if (e.dataTransfer?.types?.includes('Files')) {
             setIsDragOver(true);
         }
-    }, []);
+    }, [canStageFiles]);
 
     const handleDragOver = useCallback((e: React.DragEvent) => {
+        if (!canStageFiles) return;
         e.preventDefault();
         e.stopPropagation();
-    }, []);
+    }, [canStageFiles]);
 
     const handleDragLeave = useCallback((e: React.DragEvent) => {
+        if (!canStageFiles) return;
         e.preventDefault();
         e.stopPropagation();
         dragCounterRef.current--;
         if (dragCounterRef.current === 0) {
             setIsDragOver(false);
         }
-    }, []);
+    }, [canStageFiles]);
 
     const handleDrop = useCallback(
         (e: React.DragEvent) => {
+            if (!canStageFiles) return;
             e.preventDefault();
             e.stopPropagation();
             dragCounterRef.current = 0;
@@ -347,7 +356,7 @@ function StartWorkflowView({
                 });
             }
         },
-        [maxFiles],
+        [maxFiles, canStageFiles],
     );
 
     const handleFileInputChange = useCallback(
@@ -389,7 +398,10 @@ function StartWorkflowView({
             sessionStorage.removeItem('plan-panel-shown');
 
             toast({
-                title: stagedFiles.length > 0 ? t('agent.startingAgentUploading') : t('agent.startingAgent'),
+                title:
+                    canStageFiles && stagedFiles.length > 0
+                        ? t('agent.startingAgentUploading')
+                        : t('agent.startingAgent'),
                 status: 'info',
                 duration: 3000,
             });
@@ -405,7 +417,7 @@ function StartWorkflowView({
             }
 
             // If files are staged, add a note to the message so the agent knows files are coming
-            if (stagedFiles.length > 0) {
+            if (canStageFiles && stagedFiles.length > 0) {
                 const fileNames = stagedFiles.map((f) => f.name).join(', ');
                 messageContent = [
                     messageContent,
@@ -420,7 +432,7 @@ function StartWorkflowView({
 
                 // Upload staged files to the new run's artifact space and signal agent
                 const uploadedFiles: string[] = [];
-                if (stagedFiles.length > 0) {
+                if (canStageFiles && stagedFiles.length > 0) {
                     for (const file of stagedFiles) {
                         try {
                             const artifactPath = `files/${file.name}`;
@@ -507,7 +519,7 @@ function StartWorkflowView({
     if (startedAgentRunId) {
         return (
             <ModernAgentConversationInner
-                {...{ onClose, isModal, initialMessage, placeholder }}
+                {...{ onClose, isModal, initialMessage, placeholder, hideFileUpload, allowWorkflowControl }}
                 agentRunId={startedAgentRunId}
                 title={title}
             />
@@ -522,13 +534,13 @@ function StartWorkflowView({
                     'flex flex-col h-full w-full overflow-hidden border-0 relative',
                     fullWidth ? '' : 'max-w-4xl',
                 )}
-                onDragEnter={handleDragEnter}
-                onDragOver={handleDragOver}
-                onDragLeave={handleDragLeave}
-                onDrop={handleDrop}
+                onDragEnter={canStageFiles ? handleDragEnter : undefined}
+                onDragOver={canStageFiles ? handleDragOver : undefined}
+                onDragLeave={canStageFiles ? handleDragLeave : undefined}
+                onDrop={canStageFiles ? handleDrop : undefined}
             >
                 {/* Drag overlay for full-panel file drop */}
-                {isDragOver && (
+                {canStageFiles && isDragOver && (
                     <div className="absolute inset-0 flex items-center justify-center bg-info-background z-50 pointer-events-none rounded-lg">
                         <div className="text-info font-medium flex items-center gap-2 text-lg">
                             <UploadIcon className="size-6" />
@@ -538,14 +550,16 @@ function StartWorkflowView({
                 )}
 
                 {/* Hidden file input */}
-                <input
-                    ref={fileInputRef}
-                    type="file"
-                    multiple
-                    accept={acceptedFileTypes}
-                    onChange={handleFileInputChange}
-                    className="hidden"
-                />
+                {canStageFiles && (
+                    <input
+                        ref={fileInputRef}
+                        type="file"
+                        multiple
+                        accept={acceptedFileTypes}
+                        onChange={handleFileInputChange}
+                        className="hidden"
+                    />
+                )}
 
                 {/* Header */}
                 <div className="flex items-center justify-between py-2 px-3 border-b border-border bg-background">
@@ -591,7 +605,7 @@ function StartWorkflowView({
                 {/* Input Area */}
                 <div className="py-3 px-3 border-t border-border bg-background">
                     {/* Staged files display */}
-                    {stagedFiles.length > 0 && (
+                    {canStageFiles && stagedFiles.length > 0 && (
                         <div className="flex flex-wrap gap-2 mb-3">
                             {stagedFiles.map((file, index) => (
                                 <div
@@ -615,18 +629,20 @@ function StartWorkflowView({
                     )}
 
                     {/* Upload button row */}
-                    <div className="flex gap-2 mb-2">
-                        <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => fileInputRef.current?.click()}
-                            disabled={isSending || stagedFiles.length >= maxFiles}
-                            className="text-xs"
-                        >
-                            <UploadIcon className="size-3.5 me-1.5" />
-                            {t('agent.upload')}
-                        </Button>
-                    </div>
+                    {canStageFiles && (
+                        <div className="flex gap-2 mb-2">
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => fileInputRef.current?.click()}
+                                disabled={isSending || stagedFiles.length >= maxFiles}
+                                className="text-xs"
+                            >
+                                <UploadIcon className="size-3.5 me-1.5" />
+                                {t('agent.upload')}
+                            </Button>
+                        </div>
+                    )}
 
                     <div className="flex items-end gap-2">
                         <textarea
@@ -654,7 +670,7 @@ function StartWorkflowView({
                         </Button>
                     </div>
                     <div className="text-xs text-muted mt-2 text-center">
-                        {stagedFiles.length > 0
+                        {canStageFiles && stagedFiles.length > 0
                             ? t('agent.filesStagedCount', { count: stagedFiles.length })
                             : t('agent.enterToSend')}
                     </div>
@@ -677,6 +693,7 @@ function ModernAgentConversationInner({
     onRestart,
     onClone,
     onShowDetails,
+    allowWorkflowControl = true,
     // File upload props (onFilesSelected handled internally by handleFileUpload)
     uploadedFiles,
     onRemoveFile,
@@ -793,6 +810,7 @@ function ModernAgentConversationInner({
         serverFileUpdates,
         toast,
     );
+    const canUploadFiles = interactive && !hideFileUpload;
 
     // ────────────────────────────────────────────
     // Local state (UI-only concerns)
@@ -1033,11 +1051,11 @@ function ModernAgentConversationInner({
 
     // Expose handleFileUpload to external callers via ref
     useEffect(() => {
-        if (fileUploadRef) fileUploadRef.current = handleFileUpload;
+        if (fileUploadRef) fileUploadRef.current = canUploadFiles ? handleFileUpload : null;
         return () => {
             if (fileUploadRef) fileUploadRef.current = null;
         };
-    }, [fileUploadRef, handleFileUpload]);
+    }, [fileUploadRef, handleFileUpload, canUploadFiles]);
 
     // Notify parent when processingFiles changes
     useEffect(() => {
@@ -1214,30 +1232,34 @@ function ModernAgentConversationInner({
 
     // Drag and drop handlers for full-panel file upload
     const handleDragEnter = useCallback((e: React.DragEvent) => {
+        if (!canUploadFiles) return;
         e.preventDefault();
         e.stopPropagation();
         dragCounterRef.current++;
         if (e.dataTransfer?.types?.includes('Files')) {
             setIsDragOver(true);
         }
-    }, []);
+    }, [canUploadFiles]);
 
     const handleDragOver = useCallback((e: React.DragEvent) => {
+        if (!canUploadFiles) return;
         e.preventDefault();
         e.stopPropagation();
-    }, []);
+    }, [canUploadFiles]);
 
     const handleDragLeave = useCallback((e: React.DragEvent) => {
+        if (!canUploadFiles) return;
         e.preventDefault();
         e.stopPropagation();
         dragCounterRef.current--;
         if (dragCounterRef.current === 0) {
             setIsDragOver(false);
         }
-    }, []);
+    }, [canUploadFiles]);
 
     const handleDrop = useCallback(
         (e: React.DragEvent) => {
+            if (!canUploadFiles) return;
             e.preventDefault();
             e.stopPropagation();
             dragCounterRef.current = 0;
@@ -1248,7 +1270,7 @@ function ModernAgentConversationInner({
                 void handleFileUpload(filesArray);
             }
         },
-        [handleFileUpload],
+        [handleFileUpload, canUploadFiles],
     );
 
     // Stop/interrupt the active workflow
@@ -1281,11 +1303,11 @@ function ModernAgentConversationInner({
 
     // Expose stop handler to external callers via ref
     useEffect(() => {
-        if (stopRef) stopRef.current = !isCompleted ? handleStopWorkflow : null;
+        if (stopRef) stopRef.current = allowWorkflowControl && !isCompleted ? handleStopWorkflow : null;
         return () => {
             if (stopRef) stopRef.current = null;
         };
-    }, [stopRef, isCompleted, handleStopWorkflow]);
+    }, [stopRef, isCompleted, handleStopWorkflow, allowWorkflowControl]);
 
     // Notify parent when stopping state changes
     useEffect(() => {
@@ -1453,6 +1475,7 @@ function ModernAgentConversationInner({
                         onRestart={onRestart}
                         onClone={onClone}
                         onShowDetails={onShowDetails}
+                        allowWorkflowControl={allowWorkflowControl}
                         onExportPdf={exportConversationPdf}
                         isReceivingChunks={debugChunkFlash}
                     />
@@ -1521,7 +1544,7 @@ function ModernAgentConversationInner({
                         showInput && (
                             <MessageInput
                                 onSend={handleSendMessage}
-                                onStop={handleStopWorkflow}
+                                onStop={allowWorkflowControl ? handleStopWorkflow : undefined}
                                 disabled={isUploading}
                                 isSending={isSending || isUploading}
                                 isStopping={isStopping}
@@ -1529,7 +1552,7 @@ function ModernAgentConversationInner({
                                 isCompleted={isCompleted}
                                 activeTaskCount={getActiveTaskCount()}
                                 placeholder={placeholder ?? 'Type your message...'}
-                                onFilesSelected={handleFileUpload}
+                                onFilesSelected={canUploadFiles ? handleFileUpload : undefined}
                                 uploadedFiles={uploadedFiles}
                                 onRemoveFile={onRemoveFile}
                                 acceptedFileTypes={acceptedFileTypes}
@@ -1540,7 +1563,7 @@ function ModernAgentConversationInner({
                                 selectedDocuments={selectedDocuments}
                                 onRemoveDocument={onRemoveDocument}
                                 hideObjectLinking={hideObjectLinking}
-                                hideFileUpload={hideFileUpload}
+                                hideFileUpload={!canUploadFiles}
                                 className={inputContainerClassName}
                                 inputClassName={inputClassName}
                             />
@@ -1560,16 +1583,16 @@ function ModernAgentConversationInner({
                     ref={conversationLayoutRef}
                     className={cn(
                         'flex flex-col lg:flex-row gap-2 w-full h-full relative overflow-hidden',
-                        isDragOver && 'ring-2 ring-blue-400 ring-inset',
+                        canUploadFiles && isDragOver && 'ring-2 ring-blue-400 ring-inset',
                         className,
                     )}
-                    onDragEnter={handleDragEnter}
-                    onDragOver={handleDragOver}
-                    onDragLeave={handleDragLeave}
-                    onDrop={handleDrop}
+                    onDragEnter={canUploadFiles ? handleDragEnter : undefined}
+                    onDragOver={canUploadFiles ? handleDragOver : undefined}
+                    onDragLeave={canUploadFiles ? handleDragLeave : undefined}
+                    onDrop={canUploadFiles ? handleDrop : undefined}
                 >
                     {/* Drag overlay for full-panel file drop */}
-                    {isDragOver && (
+                    {canUploadFiles && isDragOver && (
                         <div className="absolute inset-0 flex items-center justify-center bg-blue-100/80 dark:bg-blue-900/40 z-50 pointer-events-none rounded-lg">
                             <div className="text-blue-600 dark:text-blue-400 font-medium flex items-center gap-2 text-lg">
                                 <UploadIcon className="size-6" />

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/Header.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/Header.tsx
@@ -39,6 +39,8 @@ export interface HeaderProps {
     onExportPdf?: () => void;
     /** Called to show run details/internals modal */
     onShowDetails?: () => void;
+    /** Whether workflow control actions such as cancel should be shown. */
+    allowWorkflowControl?: boolean;
     /** Called after a restart succeeds — receives the new AgentRun */
     onRestart?: (newRun: AgentRun) => void;
     /** Called after a clone succeeds — receives the new AgentRun */
@@ -67,6 +69,7 @@ export default function Header({
     resetWorkflow,
     onExportPdf,
     onShowDetails,
+    allowWorkflowControl = true,
     onRestart,
     onClone,
     isReceivingChunks = false,
@@ -164,6 +167,7 @@ export default function Header({
                         resetWorkflow={resetWorkflow}
                         onExportPdf={onExportPdf}
                         onShowDetails={onShowDetails}
+                        allowWorkflowControl={allowWorkflowControl}
                         onRestart={onRestart}
                         onClone={onClone}
                     />
@@ -212,6 +216,7 @@ function MoreDropdown({
     resetWorkflow,
     onExportPdf,
     onShowDetails,
+    allowWorkflowControl = true,
     onRestart,
     onClone,
 }: {
@@ -225,6 +230,7 @@ function MoreDropdown({
     resetWorkflow?: () => void;
     onExportPdf?: () => void;
     onShowDetails?: () => void;
+    allowWorkflowControl?: boolean;
     onRestart?: (newRun: AgentRun) => void;
     onClone?: (newRun: AgentRun) => void;
 }) {
@@ -356,7 +362,7 @@ function MoreDropdown({
                         <GitFork className="size-3.5 text-muted" /> {t('agent.cloneConversation')}
                     </MenuItem>
                 )}
-                {!isTerminal && (
+                {allowWorkflowControl && !isTerminal && (
                     <MenuItem onClick={cancelWorkflow} variant="destructive">
                         <XIcon className="size-3.5" /> {t('agent.cancelWorkflow')}
                     </MenuItem>

--- a/packages/ui/src/features/permissions/SecureButton.tsx
+++ b/packages/ui/src/features/permissions/SecureButton.tsx
@@ -9,8 +9,7 @@ export function SecureButton({ permission, isDisabled, title, children, ...other
     const perms = useUserPermissions();
     const hasPermission = perms.hasPermission(permission);
     if (!hasPermission) {
-        isDisabled = true;
-        title = 'You do not have permission to perform this action';
+        return null;
     }
     return (
         <Button isDisabled={isDisabled} title={title} {...others}>

--- a/packages/ui/src/features/store/collections/SelectCollection.tsx
+++ b/packages/ui/src/features/store/collections/SelectCollection.tsx
@@ -161,7 +161,7 @@ export function SelectCollection({
         : !!selectedCollection;
 
     const renderTrailingIcon = () => {
-        if (showClearOption) {
+        if (showClearOption && !disabled) {
             return (
                 <Button
                     variant="unstyled"

--- a/packages/ui/src/features/store/objects/components/ContentOverview.tsx
+++ b/packages/ui/src/features/store/objects/components/ContentOverview.tsx
@@ -166,8 +166,9 @@ interface ContentOverviewProps {
     object: ContentObject;
     loadText?: boolean;
     refetch?: () => Promise<unknown>;
+    canEditProperties?: boolean;
 }
-export function ContentOverview({ object, loadText, refetch }: ContentOverviewProps) {
+export function ContentOverview({ object, loadText, refetch, canEditProperties = true }: ContentOverviewProps) {
     const toast = useToast();
     const { t } = useUITranslation();
 
@@ -200,6 +201,7 @@ export function ContentOverview({ object, loadText, refetch }: ContentOverviewPr
                     object={object}
                     refetch={refetch ?? (() => Promise.resolve())}
                     handleCopyContent={handleCopyContent}
+                    canEditProperties={canEditProperties}
                 />
             </ResizablePanel>
             <ResizableHandle withHandle />
@@ -220,10 +222,12 @@ function PropertiesPanel({
     object,
     refetch,
     handleCopyContent,
+    canEditProperties,
 }: {
     object: ContentObject;
     refetch: () => Promise<unknown>;
     handleCopyContent: (content: string, type: 'text' | 'properties') => Promise<void>;
+    canEditProperties: boolean;
 }) {
     const { t } = useUITranslation();
     const [viewCode, setViewCode] = useState(false);
@@ -272,15 +276,18 @@ function PropertiesPanel({
                                 <Copy className="size-4" />
                             </Button>
                         )}
-                        <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={handleOpenPropertiesModal}
-                            title="Edit properties"
-                            className="flex items-center gap-2"
-                        >
-                            <SquarePen className="size-4" />
-                        </Button>
+                        {canEditProperties && (
+                            <SecureButton
+                                permission={Permission.content_write}
+                                variant="ghost"
+                                size="sm"
+                                onClick={handleOpenPropertiesModal}
+                                title="Edit properties"
+                                className="flex items-center gap-2"
+                            >
+                                <SquarePen className="size-4" />
+                            </SecureButton>
+                        )}
                     </div>
                 </div>
 

--- a/packages/ui/src/features/store/objects/selection/SelectionActions.tsx
+++ b/packages/ui/src/features/store/objects/selection/SelectionActions.tsx
@@ -15,8 +15,16 @@ import type { ObjectsActionSpec } from './ObjectsActionSpec';
 
 interface SelectionActionsProps {
     type?: ContentObjectTypeItem;
+    allowMutations?: boolean;
+    allowDelete?: boolean;
+    allowWorkflowRun?: boolean;
 }
-export function SelectionActions({ type }: SelectionActionsProps) {
+export function SelectionActions({
+    type,
+    allowMutations = true,
+    allowDelete = true,
+    allowWorkflowRun = true,
+}: SelectionActionsProps) {
     const selection = useDocumentSelection();
     const size = selection.size();
     const plural = size > 1 ? 's' : '';
@@ -41,13 +49,22 @@ export function SelectionActions({ type }: SelectionActionsProps) {
                         </Button>
                     </div>
                 )}
-                <SelectionActionsPopover selection={selection}>
-                    <Button variant="ghost" alt="More action" size="sm">
-                        <EllipsisVertical size={16} />
-                    </Button>
+                <SelectionActionsPopover
+                    selection={selection}
+                    allowMutations={allowMutations}
+                    allowDelete={allowDelete}
+                    allowWorkflowRun={allowWorkflowRun}
+                >
+                    {(actions) =>
+                        actions.length > 0 ? (
+                            <Button variant="ghost" alt="More action" size="sm">
+                                <EllipsisVertical size={16} />
+                            </Button>
+                        ) : null
+                    }
                 </SelectionActionsPopover>
                 {/* StartWorkflowButton must be inside the context */}
-                {hasSelection && <ActionsWrapper selection={selection} />}
+                {hasSelection && allowWorkflowRun && <ActionsWrapper selection={selection} />}
             </div>
         </ObjectsActionContextProvider>
     );
@@ -118,20 +135,36 @@ function optionLayout(option: ObjectsActionSpec) {
 }
 
 interface SelectionActionsPopoverProps {
-    children: React.ReactNode;
+    children: (actions: ObjectsActionSpec[]) => React.ReactNode;
     selection: DocumentSelection;
 }
-function SelectionActionsPopover({ selection, children }: SelectionActionsPopoverProps) {
+function SelectionActionsPopover({
+    selection,
+    children,
+    allowMutations = true,
+    allowDelete = true,
+    allowWorkflowRun = true,
+}: SelectionActionsPopoverProps & Required<Pick<SelectionActionsProps, 'allowMutations' | 'allowDelete' | 'allowWorkflowRun'>>) {
     const context = useObjectsActionContext();
     const executeAction = (action: ObjectsActionSpec) => {
         context.run(action.id);
     };
+    const actions = getAvailableActions(context.actions, selection, {
+        allowMutations,
+        allowDelete,
+        allowWorkflowRun,
+    });
+    const trigger = children(actions);
+
+    if (!trigger) {
+        return null;
+    }
 
     return (
         <Popover hover>
-            <PopoverTrigger>{children}</PopoverTrigger>
+            <PopoverTrigger>{trigger}</PopoverTrigger>
             <PopoverContent className="p-0 w-50" align="end" sideOffset={6}>
-                <PopoverBody executeAction={executeAction} selection={selection} />
+                <PopoverBody executeAction={executeAction} actions={actions} />
             </PopoverContent>
         </Popover>
     );
@@ -139,24 +172,48 @@ function SelectionActionsPopover({ selection, children }: SelectionActionsPopove
 
 interface PopoverBodyProps {
     executeAction: (action: ObjectsActionSpec) => void;
-    selection: DocumentSelection;
+    actions: ObjectsActionSpec[];
 }
-function PopoverBody({ executeAction, selection }: PopoverBodyProps) {
-    const context = useObjectsActionContext();
-
+function PopoverBody({ executeAction, actions }: PopoverBodyProps) {
     const _executeAction = (action: ObjectsActionSpec) => {
         executeAction(action);
     };
 
-    const _selection = selection?.hasSelection()
-        ? context.actions.filter((action: ObjectsActionSpec) => !action.hideInList)
-        : [ExportPropertiesAction];
-
     return (
         <div className="rounded-md shadow-md py-2">
             <div className="px-1 text-sm">
-                <SelectList options={_selection} optionLayout={optionLayout} onChange={_executeAction} noCheck />
+                <SelectList options={actions} optionLayout={optionLayout} onChange={_executeAction} noCheck />
             </div>
         </div>
     );
+}
+
+function getAvailableActions(
+    actions: ObjectsActionSpec[],
+    selection: DocumentSelection,
+    permissions: Required<Pick<SelectionActionsProps, 'allowMutations' | 'allowDelete' | 'allowWorkflowRun'>>,
+): ObjectsActionSpec[] {
+    if (!selection?.hasSelection()) {
+        return [ExportPropertiesAction];
+    }
+
+    return actions.filter((action: ObjectsActionSpec) => {
+        if (action.hideInList) {
+            return false;
+        }
+        if (action.id === 'startWorkflow') {
+            return permissions.allowWorkflowRun;
+        }
+        if (action.id === 'delete' || action.id === 'deleteFromCollections') {
+            return permissions.allowDelete;
+        }
+        if (
+            action.id === 'changeType' ||
+            action.id === 'addToCollection' ||
+            action.id === 'removeFromCollection'
+        ) {
+            return permissions.allowMutations;
+        }
+        return true;
+    });
 }

--- a/packages/ui/src/features/store/objects/selection/SelectionActions.tsx
+++ b/packages/ui/src/features/store/objects/selection/SelectionActions.tsx
@@ -144,7 +144,8 @@ function SelectionActionsPopover({
     allowMutations = true,
     allowDelete = true,
     allowWorkflowRun = true,
-}: SelectionActionsPopoverProps & Required<Pick<SelectionActionsProps, 'allowMutations' | 'allowDelete' | 'allowWorkflowRun'>>) {
+}: SelectionActionsPopoverProps &
+    Required<Pick<SelectionActionsProps, 'allowMutations' | 'allowDelete' | 'allowWorkflowRun'>>) {
     const context = useObjectsActionContext();
     const executeAction = (action: ObjectsActionSpec) => {
         context.run(action.id);
@@ -207,11 +208,7 @@ function getAvailableActions(
         if (action.id === 'delete' || action.id === 'deleteFromCollections') {
             return permissions.allowDelete;
         }
-        if (
-            action.id === 'changeType' ||
-            action.id === 'addToCollection' ||
-            action.id === 'removeFromCollection'
-        ) {
+        if (action.id === 'changeType' || action.id === 'addToCollection' || action.id === 'removeFromCollection') {
             return permissions.allowMutations;
         }
         return true;

--- a/packages/ui/src/widgets/json-view/JSONCode.tsx
+++ b/packages/ui/src/widgets/json-view/JSONCode.tsx
@@ -1,11 +1,6 @@
-import { useTheme } from '@vertesia/ui/core';
-import { MonacoEditor } from '../monacoEditor/MonacoEditor';
-import { useMemo } from 'react';
+import { useMemo, type ReactNode } from 'react';
 
 export function JSONCode({ data, className }: { data: unknown; className?: string }) {
-    const { theme } = useTheme();
-
-    // Convert data to formatted JSON string
     const jsonString = useMemo(() => {
         try {
             return JSON.stringify(data, null, 2);
@@ -14,18 +9,62 @@ export function JSONCode({ data, className }: { data: unknown; className?: strin
             return '{}';
         }
     }, [data]);
+    const lines = useMemo(() => jsonString.split('\n'), [jsonString]);
 
     return (
-        <div className={`h-full pb-2 mb-2 ${className || ''}`}>
-            <MonacoEditor
-                value={jsonString}
-                language="json"
-                theme={theme === 'dark' ? 'vs-dark' : 'vs'}
-                options={{
-                    readOnly: true,
-                    domReadOnly: true,
-                }}
-            />
-        </div>
+        <pre
+            className={`h-full overflow-auto rounded-md border bg-background p-3 font-mono text-xs leading-5 text-foreground ${className || ''}`}
+        >
+            <code>
+                {lines.map((line, index) => (
+                    // biome-ignore lint/suspicious/noArrayIndexKey: static formatted text lines
+                    <span key={index}>
+                        {renderJsonLine(line)}
+                        {index < lines.length - 1 ? '\n' : null}
+                    </span>
+                ))}
+            </code>
+        </pre>
     );
+}
+
+const JSON_TOKEN_PATTERN =
+    /("(?:\\.|[^"\\])*"(?=\s*:))|("(?:\\.|[^"\\])*")|\b(true|false|null)\b|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)/g;
+
+function renderJsonLine(line: string) {
+    JSON_TOKEN_PATTERN.lastIndex = 0;
+    const parts: ReactNode[] = [];
+    let cursor = 0;
+    let match = JSON_TOKEN_PATTERN.exec(line);
+
+    while (match !== null) {
+        if (match.index > cursor) {
+            parts.push(line.slice(cursor, match.index));
+        }
+
+        const [token, key, stringValue, literal, numberValue] = match;
+        const className = key
+            ? 'text-info'
+            : stringValue
+              ? 'text-success'
+              : literal
+                ? 'text-primary'
+                : numberValue
+                  ? 'text-attention'
+                  : undefined;
+
+        parts.push(
+            <span key={`${match.index}-${token}`} className={className}>
+                {token}
+            </span>,
+        );
+        cursor = match.index + token.length;
+        match = JSON_TOKEN_PATTERN.exec(line);
+    }
+
+    if (cursor < line.length) {
+        parts.push(line.slice(cursor));
+    }
+
+    return parts.length ? parts : line;
 }


### PR DESCRIPTION
## Summary
- Add auditor/support role and read-permission enum support in shared access-control types.
- Hide guarded UI actions in reusable components when users do not have mutation or execution permissions.
- Keep agent conversation output usable in read-only contexts, including conflict resolution with the latest completed-conversation continuation behavior.
- Improve read-only JSON rendering and related role-session OAuth handling.

## Test Plan
- `../node_modules/.bin/biome lint packages/common/src/access-control.ts packages/common/src/project.ts packages/cli/src/profiles/oauth.ts`
- `../node_modules/.bin/biome lint packages/ui/src/features/agent/chat/ModernAgentOutput/Header.tsx packages/ui/src/features/agent/chat/ModernAgentConversation.tsx packages/ui/src/features/agent/chat/hooks/useAgentStream.ts packages/ui/src/features/agent/chat/ModernAgentConversation.test.tsx packages/ui/src/features/agent/chat/hooks/useAgentStream.test.tsx`
- `pnpm --prefix composableai/packages/common run typecheck:test`
- `pnpm --prefix composableai/packages/common run test`
- `pnpm --prefix composableai/packages/ui run typecheck:test`
- `pnpm --prefix composableai/packages/ui run test -- ModernAgentConversation useAgentStream`
- `pnpm --prefix composableai/packages/ui run check:rtl-classes`
- `pnpm --prefix composableai/packages/cli run build`
