### PR TITLE
fix: re-stage Biome fixes when pre-commit hook hits unfixable errors

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -49,5 +49,19 @@ if ! git diff --quiet -- "${staged_files[@]}"; then
     exit 1
 fi
 
+# Run Biome, but don't let a nonzero exit (unfixable error-level diagnostics)
+# abort the script before we re-stage. Biome applies its safe --write fixes to
+# the working tree even when it also reports an unfixable error, so we must
+# always re-stage those fixes; otherwise they'd be lost and the next commit
+# attempt would trip the partial-staging guard above.
+set +e
 "${BIOME_CMD[@]}" check --write --staged --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error
+biome_status=$?
+set -e
+
+# Re-stage whatever Biome fixed, regardless of its exit status.
 git add -- "${staged_files[@]}"
+
+# Surface remaining unfixable errors by failing the commit (fixes are now staged,
+# so the user can address the error and re-commit without losing formatting work).
+exit "$biome_status"


### PR DESCRIPTION
## Summary
The pre-commit hook runs `biome check --write` under `set -e`. When Biome applies its safe `--write` fixes **and** also reports an unfixable error-level diagnostic, it exits non-zero — which aborted the script before the `git add` re-stage step. The result: Biome's fixes landed in the working tree but were never staged, the commit was aborted, and the next commit attempt then tripped the partial-staging guard.

This change captures Biome's exit status without aborting (`set +e`/`set -e`), **always** re-stages the fixed files, then exits with that status so genuine unfixable errors still block the commit (with the formatting fixes already staged, so they aren't lost).

## Test Plan
- [x] `bash -n .githooks/pre-commit` passes.
- [ ] Stage a file with both a fixable format issue and an unfixable error-level lint diagnostic; confirm the commit is blocked **and** the format fix is staged (previously the fix was lost).
- [ ] Stage a file with only fixable issues; confirm the commit succeeds with fixes staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>