### PR TITLE
fix: explicit module resolution subpath

### DIFF
--- a/packages/api-fetch-client/package.json
+++ b/packages/api-fetch-client/package.json
@@ -12,9 +12,11 @@
     "outDir": "lib"
   },
   "exports": {
-    "types": "./lib/types/index.d.ts",
-    "import": "./lib/esm/index.js",
-    "require": "./lib/cjs/index.js"
+        ".": {
+        "types": "./lib/types/index.d.ts",
+        "import": "./lib/esm/index.js",
+        "require": "./lib/cjs/index.js"
+        }
   },
   "scripts": {
     "test": "ESBK_TSCONFIG_PATH=./test/tsconfig.json pnpm exec mocha -r tsx --exit ./test/**/*.ts",

--- a/packages/api-fetch-client/package.json
+++ b/packages/api-fetch-client/package.json
@@ -12,11 +12,11 @@
     "outDir": "lib"
   },
   "exports": {
-        ".": {
+    ".": {
         "types": "./lib/types/index.d.ts",
         "import": "./lib/esm/index.js",
         "require": "./lib/cjs/index.js"
-        }
+    }
   },
   "scripts": {
     "test": "ESBK_TSCONFIG_PATH=./test/tsconfig.json pnpm exec mocha -r tsx --exit ./test/**/*.ts",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -15,9 +15,11 @@
     "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
   },
   "exports": {
-    "types": "./lib/types/index.d.ts",
-    "import": "./lib/esm/index.js",
-    "require": "./lib/cjs/index.js"
+    ".": {
+      "types": "./lib/types/index.d.ts",
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
+    }
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^28.0.3",

--- a/packages/converters/package.json
+++ b/packages/converters/package.json
@@ -15,9 +15,11 @@
         "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
     },
     "exports": {
-        "types": "./lib/types/index.d.ts",
-        "import": "./lib/esm/index.js",
-        "require": "./lib/cjs/index.js"
+        ".": {
+            "types": "./lib/types/index.d.ts",
+            "import": "./lib/esm/index.js",
+            "require": "./lib/cjs/index.js"
+        }
     },
     "devDependencies": {
         "@types/tmp": "^0.2.6",

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -15,9 +15,11 @@
     "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
   },
   "exports": {
-    "types": "./lib/types/index.d.ts",
-    "import": "./lib/esm/index.js",
-    "require": "./lib/cjs/index.js"
+    ".": {
+      "types": "./lib/types/index.d.ts",
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
+    }
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^28.0.3",

--- a/packages/memory-commands/package.json
+++ b/packages/memory-commands/package.json
@@ -30,9 +30,11 @@
     "outDir": "lib"
   },
   "exports": {
-    "types": "./lib/types/index.d.ts",
-    "import": "./lib/esm/index.js",
-    "require": "./lib/cjs/index.js"
+    ".": {
+      "types": "./lib/types/index.d.ts",
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
+    }
   },
   "repository": {
     "type": "git",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -36,9 +36,11 @@
     "outDir": "lib"
   },
   "exports": {
-    "types": "./lib/types/index.d.ts",
-    "import": "./lib/esm/index.js",
-    "require": "./lib/cjs/index.js"
+    ".": {
+      "types": "./lib/types/index.d.ts",
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
+    }
   },
   "repository": {
     "type": "git",

--- a/packages/tools-sdk/package.json
+++ b/packages/tools-sdk/package.json
@@ -15,9 +15,11 @@
     "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
   },
   "exports": {
-    "types": "./lib/types/index.d.ts",
-    "import": "./lib/esm/index.js",
-    "require": "./lib/cjs/index.js"
+    ".": {
+      "types": "./lib/types/index.d.ts",
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
+    }
   },
   "bin": {
     "tools-sdk-copy-assets": "./lib/esm/copy-assets.js"


### PR DESCRIPTION
This is for compatibility with:
moduleResolution: Bundler

Still works with 
moduleResolution: nodenext

"." exports is the default correct form but sometimes root works as well.
https://nodejs.org/api/packages.html#exports-sugar
More robust to just use "."