### PR TITLE
Expose OAuth client scope metadata

### DIFF
--- a/packages/client/src/OAuthClientsApi.ts
+++ b/packages/client/src/OAuthClientsApi.ts
@@ -3,6 +3,7 @@ import type {
     CreateOAuthClientPayload,
     OAuthClient,
     OAuthClientCreateResponse,
+    OAuthClientScopeMetadata,
     SuccessResponse,
     UpdateOAuthClientPayload,
 } from '@vertesia/common';
@@ -18,6 +19,10 @@ export default class OAuthClientsApi extends ApiTopic {
 
     retrieve(clientId: string): Promise<OAuthClient> {
         return this.get(`/${clientId}`);
+    }
+
+    scopeMetadata(): Promise<OAuthClientScopeMetadata> {
+        return this.get('/scope-metadata');
     }
 
     create(payload: CreateOAuthClientPayload): Promise<OAuthClientCreateResponse> {

--- a/packages/common/src/oauth-scopes.ts
+++ b/packages/common/src/oauth-scopes.ts
@@ -24,10 +24,6 @@ export function getOAuthPermissionScopes(): Permission[] {
     return [...OAUTH_PERMISSION_SCOPES];
 }
 
-export function getSupportedOAuthScopes(): string[] {
-    return [...OAUTH_STANDARD_SCOPES, ...getOAuthPermissionScopes()];
-}
-
 export function isOAuthStandardScope(scope: string): scope is OAuthStandardScope {
     return OAUTH_STANDARD_SCOPE_SET.has(scope);
 }

--- a/packages/common/src/oauth-server.ts
+++ b/packages/common/src/oauth-server.ts
@@ -49,6 +49,10 @@ export interface OAuthClientCreateResponse extends OAuthClient {
     client_secret?: string;
 }
 
+export interface OAuthClientScopeMetadata {
+    supported_scopes: string[];
+}
+
 export interface OAuthGrant {
     grant_id: string;
     client_id: string;


### PR DESCRIPTION
## Summary
- Add an OAuth client scope metadata response type.
- Add `OAuthClientsApi.scopeMetadata()` for callers to retrieve server-provided supported scopes.
- Remove the public `getSupportedOAuthScopes()` helper so supported-scope policy can be owned by the server.

## Test Plan
- `pnpm --prefix composableai/packages/common lint`
- `pnpm --prefix composableai/packages/common build`
- `pnpm --prefix composableai/packages/common test`
- `pnpm --prefix composableai/packages/common typecheck:test`
- `pnpm --prefix composableai/packages/client lint`
- `pnpm --prefix composableai/packages/client build`