### PR TITLE
fix: reset sign-in state when backing out of the blocked/sign-up screen

### DIFF
--- a/packages/ui/src/shell/login/SigninScreen.tsx
+++ b/packages/ui/src/shell/login/SigninScreen.tsx
@@ -19,6 +19,7 @@ import {
     type ProviderId,
     readLastSuccessfulLogin,
     readPendingSignin,
+    resetSignInState,
     writeLastSuccessfulLogin,
 } from './signInUtils';
 
@@ -152,12 +153,19 @@ function SigninScreenImpl({
     );
 
     const goBackToFresh = useCallback(() => {
+        // Clear the in-memory mirror of the cleared record so the returning view
+        // can't render (and onProviderClicked can't read a stale tenant) before
+        // a reload re-reads storage.
+        setStoredSession(null);
         setEmail('');
         setTenant(undefined);
         setMode('email');
-        // Backing out of signup/blocked leaves a Firebase session that has no Vertesia user; clear it.
-        void signOut();
-    }, [signOut]);
+        // Backing out of blocked/signup must reset the flow: forget the
+        // remembered + pending state and sign out the live (but Vertesia-less)
+        // Firebase session. Otherwise a reload or the next auth-state change
+        // re-runs the invite check and lands the user back on blocked.
+        void resetSignInState();
+    }, []);
 
     // Submits the signup form to /auth/signup, then redirects into the app.
     const onSignup = (data: SignupData, fbToken: string) => {

--- a/packages/ui/src/shell/login/SigninScreen.tsx
+++ b/packages/ui/src/shell/login/SigninScreen.tsx
@@ -152,18 +152,16 @@ function SigninScreenImpl({
         [trackEvent, storedSession?.tenantName, tenant],
     );
 
-    const goBackToFresh = useCallback(() => {
-        // Clear the in-memory mirror of the cleared record so the returning view
-        // can't render (and onProviderClicked can't read a stale tenant) before
-        // a reload re-reads storage.
-        setStoredSession(null);
+    // "Use a different email" out of the blocked/signup screen. The user reached it
+    // as a valid Firebase user with no Vertesia account, so a partial reset isn't
+    // enough: unless we also clear the persisted records and sign out of Firebase,
+    // the leftover session re-runs the invite check on the next auth change or
+    // reload and lands them back on blocked.
+    const startOver = useCallback(() => {
+        setStoredSession(null); // drop the in-memory mirror too — resetSignInState only clears storage
         setEmail('');
         setTenant(undefined);
         setMode('email');
-        // Backing out of blocked/signup must reset the flow: forget the
-        // remembered + pending state and sign out the live (but Vertesia-less)
-        // Firebase session. Otherwise a reload or the next auth-state change
-        // re-runs the invite check and lands the user back on blocked.
         void resetSignInState();
     }, []);
 
@@ -193,11 +191,11 @@ function SigninScreenImpl({
             <SignInTenantBlockedStep
                 email={email || storedSession?.email || ''}
                 tenantName={tenant?.label || tenant?.name || storedSession?.tenantName || undefined}
-                onBack={goBackToFresh}
+                onBack={startOver}
             />
         );
     } else if (mode === 'signup' && !localStorage.getItem('tenantName')) {
-        content = <SignupForm onSignup={onSignup} goBack={goBackToFresh} />;
+        content = <SignupForm onSignup={onSignup} goBack={startOver} />;
     } else if (mode === 'tenant' && tenant) {
         content = (
             <SignInTenantStep

--- a/packages/ui/src/shell/login/signInUtils.ts
+++ b/packages/ui/src/shell/login/signInUtils.ts
@@ -82,25 +82,9 @@ export function clearPendingSignin(): void {
 }
 
 /**
- * Resets the new sign-in flow when the user backs out of the blocked/signup
- * screen ("use a different email"). These are the two halves of the "user keeps
- * landing back on blocked" bug:
- *
- * 1. The flow's persisted state — the last-successful-login record and the
- *    in-flight pending entry. If the blocked account was the last good login,
- *    leaving the record means a reload re-opens the returning view for that same
- *    account and walks the user straight back into blocked.
- * 2. The live Firebase session. A blocked customer is a *valid* Firebase user
- *    (the IdP login succeeded; only the Vertesia invite check failed), and
- *    UserSession.logout() only signs out of Firebase when a Vertesia token
- *    exists — which it never does here. Left alone, the next onAuthStateChanged
- *    (same tab, or after a reload — Firebase persistence survives it) re-runs the
- *    invite check and re-blocks.
- *
- * Tenant routing (auth.tenantId and the legacy tenantName key) is deliberately
- * NOT touched here: startSignIn()/startSignInWithoutTenant() re-resolve and
- * set-or-clear both immediately before every signInWithRedirect, so there is no
- * stale value left to repair.
+ * Clears the persisted sign-in records (last-successful-login and pending) and
+ * signs out of Firebase. Best-effort: sign-out errors (e.g. no active session)
+ * are swallowed.
  */
 export async function resetSignInState(): Promise<void> {
     clearLastSuccessfulLogin();

--- a/packages/ui/src/shell/login/signInUtils.ts
+++ b/packages/ui/src/shell/login/signInUtils.ts
@@ -1,6 +1,7 @@
 import { getFirebaseAuth, setFirebaseTenant } from '@vertesia/ui/session';
 import {
     type AuthProvider,
+    signOut as firebaseSignOut,
     GithubAuthProvider,
     GoogleAuthProvider,
     OAuthProvider,
@@ -77,6 +78,37 @@ export function clearPendingSignin(): void {
         sessionStorage.removeItem(PENDING_SIGNIN_KEY);
     } catch {
         // ignore
+    }
+}
+
+/**
+ * Resets the new sign-in flow when the user backs out of the blocked/signup
+ * screen ("use a different email"). These are the two halves of the "user keeps
+ * landing back on blocked" bug:
+ *
+ * 1. The flow's persisted state — the last-successful-login record and the
+ *    in-flight pending entry. If the blocked account was the last good login,
+ *    leaving the record means a reload re-opens the returning view for that same
+ *    account and walks the user straight back into blocked.
+ * 2. The live Firebase session. A blocked customer is a *valid* Firebase user
+ *    (the IdP login succeeded; only the Vertesia invite check failed), and
+ *    UserSession.logout() only signs out of Firebase when a Vertesia token
+ *    exists — which it never does here. Left alone, the next onAuthStateChanged
+ *    (same tab, or after a reload — Firebase persistence survives it) re-runs the
+ *    invite check and re-blocks.
+ *
+ * Tenant routing (auth.tenantId and the legacy tenantName key) is deliberately
+ * NOT touched here: startSignIn()/startSignInWithoutTenant() re-resolve and
+ * set-or-clear both immediately before every signInWithRedirect, so there is no
+ * stale value left to repair.
+ */
+export async function resetSignInState(): Promise<void> {
+    clearLastSuccessfulLogin();
+    clearPendingSignin();
+    try {
+        await firebaseSignOut(getFirebaseAuth());
+    } catch {
+        // best-effort: no active session, or auth not initialized
     }
 }
 

--- a/packages/ui/src/shell/login/signInUtils.ts
+++ b/packages/ui/src/shell/login/signInUtils.ts
@@ -38,7 +38,7 @@ export function writeLastSuccessfulLogin(s: LastSuccessfulLogin): void {
     try {
         localStorage.setItem(LAST_SUCCESSFUL_LOGIN_KEY, JSON.stringify(s));
     } catch {
-        // localStorage unavailable — returning view just won't surface next time
+        // localStorage unavailable — the record is not persisted
     }
 }
 
@@ -158,7 +158,7 @@ export async function startSignIn(
 ): Promise<{ ok: true } | { ok: false; reason: 'no-email' }> {
     if (!email) return { ok: false, reason: 'no-email' };
 
-    // If the email maps to a tenant, use the tenant's provider (overrides the button pick); else use the picked provider.
+    // A tenant-mapped email uses the tenant's provider (overriding `provider`); otherwise use `provider`.
     const tenant = await setFirebaseTenant(email);
     const auth = getFirebaseAuth();
     let effectiveIdp = provider;
@@ -180,7 +180,7 @@ export async function startSignIn(
     return { ok: true };
 }
 
-/** Sign in with a provider directly, with no email/tenant resolution (e.g. SignInModal). */
+/** Starts a provider sign-in directly, skipping email/tenant resolution and clearing any tenant routing. */
 export function startSignInWithoutTenant(provider: ProviderId, redirectTo?: string): void {
     const auth = getFirebaseAuth();
     localStorage.removeItem('tenantName');


### PR DESCRIPTION
## Summary

Backing out of the blocked or sign-up screen ("use a different email") now fully resets the sign-in flow: it clears the stored last-successful-login and pending records and signs out the lingering Firebase session. Previously that state was left behind, so the next auth check bounced the user straight back to the blocked screen.

## Test Plan

- [ ] On the blocked screen, click "Use a different email" → land on a fresh email step (no bounce-back); a page reload stays on the fresh step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
