### PR TITLE
Remove API key secret scope from OAuth permissions

### DIFF
--- a/packages/common/src/oauth-scopes.ts
+++ b/packages/common/src/oauth-scopes.ts
@@ -9,6 +9,7 @@ export const OAUTH_STANDARD_SCOPES = [OAUTH_SCOPE_OPENID, OAUTH_SCOPE_PROFILE, O
 export type OAuthStandardScope = (typeof OAUTH_STANDARD_SCOPES)[number];
 
 const NON_OAUTH_PERMISSION_SCOPES = new Set<Permission>([
+    Permission.api_key_secret_read,
     Permission.manage_billing,
     Permission.billing_read,
     Permission.iam_impersonate,


### PR DESCRIPTION
## Summary
- Exclude `api_key:secret_read` from the OAuth permission scope list.
- Keep the underlying platform permission available for non-OAuth authorization paths.

## Test Plan
- [x] `pnpm --prefix composableai/packages/common lint`
- [x] `pnpm --prefix composableai/packages/common build`
- [x] `pnpm --prefix composableai/packages/common test`
- [x] `pnpm --prefix composableai/packages/client build`