### PR TITLE
feat: Support GS URIs for Gemini

### DIFF
--- a/packages/client/src/store/FilesApi.ts
+++ b/packages/client/src/store/FilesApi.ts
@@ -3,6 +3,8 @@ import {
     BulkUploadUrlsPayload,
     BulkUploadUrlsResponse,
     DeleteFileResult,
+    EnsureBucketReadAccessPayload,
+    EnsureBucketReadAccessResponse,
     FileBucketResponse,
     FileListResponse,
     FileMetadataResponse,
@@ -73,6 +75,11 @@ export class FilesApi extends ApiTopic {
      */
     getOrCreateBucket(): Promise<FileBucketResponse> {
         return this.post("/bucket");
+    }
+
+    ensureBucketReadAccess(principal: string): Promise<EnsureBucketReadAccessResponse> {
+        const payload: EnsureBucketReadAccessPayload = { principal };
+        return this.post("/bucket/read-access", { payload });
     }
 
     list(prefix: string): Promise<FileListResponse> {

--- a/packages/client/src/store/FilesApi.ts
+++ b/packages/client/src/store/FilesApi.ts
@@ -1,5 +1,6 @@
 import { ApiTopic, ClientBase } from "@vertesia/api-fetch-client";
 import {
+    BucketReadAccessStatusResponse,
     BulkUploadUrlsPayload,
     BulkUploadUrlsResponse,
     DeleteFileResult,
@@ -80,6 +81,10 @@ export class FilesApi extends ApiTopic {
     ensureBucketReadAccess(principal: string): Promise<EnsureBucketReadAccessResponse> {
         const payload: EnsureBucketReadAccessPayload = { principal };
         return this.post("/bucket/read-access", { payload });
+    }
+
+    getBucketReadAccessStatus(principal: string): Promise<BucketReadAccessStatusResponse> {
+        return this.get("/bucket/read-access", { query: { principal } });
     }
 
     list(prefix: string): Promise<FileListResponse> {

--- a/packages/common/src/environment.ts
+++ b/packages/common/src/environment.ts
@@ -88,6 +88,19 @@ export interface VertexAIEnvironmentSettings {
     bucket_access_principal?: string;
 }
 
+/**
+ * Returns the configured Vertex AI bucket access principal for an environment, or undefined.
+ * Only Vertex AI environments expose this setting; the value is trimmed and empty strings
+ * are treated as unset so callers get a single, normalized representation.
+ */
+export function getVertexBucketAccessPrincipal(
+    env: { provider?: SupportedProviders; settings?: Record<string, unknown> | VertexAIEnvironmentSettings } | undefined,
+): string | undefined {
+    if (!env || env.provider !== SupportedProviders.vertexai) return undefined;
+    const principal = (env.settings as VertexAIEnvironmentSettings | undefined)?.bucket_access_principal;
+    return typeof principal === 'string' && principal.trim().length > 0 ? principal.trim() : undefined;
+}
+
 export interface ExecutionEnvironment {
     id: string;
     name: string;

--- a/packages/common/src/environment.ts
+++ b/packages/common/src/environment.ts
@@ -84,6 +84,10 @@ export interface MediatorEnvConfig {
     model_options?: TextFallbackOptions;
 }
 
+export interface VertexAIEnvironmentSettings {
+    bucket_access_principal?: string;
+}
+
 export interface ExecutionEnvironment {
     id: string;
     name: string;
@@ -103,7 +107,7 @@ export interface ExecutionEnvironment {
      * Additional provider-specific settings passed through to the driver.
      * For example, custom headers for Apigee-proxied endpoints.
      */
-    settings?: Record<string, unknown>;
+    settings?: Record<string, unknown> | VertexAIEnvironmentSettings;
     account: string;
     allowed_projects?: string[];
     created_by: string,

--- a/packages/common/src/store/store.ts
+++ b/packages/common/src/store/store.ts
@@ -726,6 +726,16 @@ export interface GetFileUrlResponse {
     path: string;
 }
 
+export interface EnsureBucketReadAccessPayload {
+    principal: string;
+}
+
+export interface EnsureBucketReadAccessResponse {
+    bucket: string;
+    principal: string;
+    granted: boolean;
+}
+
 export interface FileMetadataResponse {
     name: string;
     size: number;

--- a/packages/common/src/store/store.ts
+++ b/packages/common/src/store/store.ts
@@ -736,6 +736,12 @@ export interface EnsureBucketReadAccessResponse {
     granted: boolean;
 }
 
+export interface BucketReadAccessStatusResponse {
+    bucket: string;
+    principal: string;
+    hasAccess: boolean;
+}
+
 export interface FileMetadataResponse {
     name: string;
     size: number;


### PR DESCRIPTION
llumiverse PR:
* https://github.com/vertesia/llumiverse/pull/436

## SDK support for Vertex AI bucket read-access and environment settings

### Summary
Adds the shared types, client method, and helper needed to grant an external IAM principal read
access to a project storage bucket, and to configure that principal on Vertex AI environments.

### Changes
- **`@vertesia/common`**:
  - `EnsureBucketReadAccessPayload` (`{ principal }`) and `EnsureBucketReadAccessResponse`
    (`{ bucket, principal, granted }`) in the store types.
  - `VertexAIEnvironmentSettings` interface with an optional `bucket_access_principal`, and
    `ExecutionEnvironment.settings` widened to `Record<string, unknown> | VertexAIEnvironmentSettings`.
  - `getVertexBucketAccessPrincipal(env)` helper: returns the trimmed principal only for Vertex AI
    environments, treating empty strings as unset (single normalized accessor for callers).
- **`@vertesia/client`**: `FilesApi.ensureBucketReadAccess(principal)` → `POST /bucket/read-access`.
- Bump the `llumiverse` submodule pointer.