### PR TITLE
Clean up UI console noise

### DIFF
--- a/packages/ui/src/core/components/FormItem.tsx
+++ b/packages/ui/src/core/components/FormItem.tsx
@@ -38,7 +38,7 @@ function joinIds(...ids: Array<string | undefined | false | null>): string | und
 
 function canShowDevWarning(): boolean {
     try {
-        return Env.isDev;
+        return Env.isLocalDev;
     } catch {
         return false;
     }

--- a/packages/ui/src/core/components/SidePanel.tsx
+++ b/packages/ui/src/core/components/SidePanel.tsx
@@ -149,7 +149,7 @@ export function SidePanel({
 
 function CloseButton({ onClose }: { onClose: () => void }) {
     return (
-        <Button alt="Close panel" variant="ghost" onClick={onClose}>
+        <Button aria-label="Close panel" title="Close panel" variant="ghost" onClick={onClose}>
             <X className="size-6" aria-hidden="true" />
         </Button>
     );

--- a/packages/ui/src/core/components/shadcn/modal/dialog.tsx
+++ b/packages/ui/src/core/components/shadcn/modal/dialog.tsx
@@ -88,7 +88,8 @@ export function Modal({
                             <DialogClose onClick={() => handleOpenChange(false)} asChild autoFocus={false}>
                                 <Button
                                     variant="outline"
-                                    alt="Close"
+                                    aria-label="Close"
+                                    title="Close"
                                     className="data-[state=open]:bg-accent opacity-70 hover:opacity-100 rounded-sm focus:outline-none focus:ring-2 focus:ring-ring ring-offset-background focus:ring-offset-2 data-[state=open]:text-muted-foreground transition-opacity disabled:pointer-events-none"
                                 >
                                     <X className="size-4" />

--- a/packages/ui/src/core/components/shadcn/theme/ThemeSwitcher.tsx
+++ b/packages/ui/src/core/components/shadcn/theme/ThemeSwitcher.tsx
@@ -17,7 +17,8 @@ export function ModeOption({ option, current, setTheme, icon, alt }: ModeOptionP
             variant={current === option ? 'secondary' : 'outline'}
             size="sm"
             onClick={() => setTheme(option)}
-            alt={alt}
+            aria-label={alt}
+            title={alt}
         >
             {icon}
         </Button>

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageInput.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageInput.tsx
@@ -528,7 +528,8 @@ export default function MessageInput({
                             className="rounded-full"
                             disabled={!isCompleted}
                             onClick={() => setIsObjectModalOpen(true)}
-                            alt={t('agent.linkObject')}
+                            aria-label={t('agent.linkObject')}
+                            title={t('agent.linkObject')}
                         >
                             <PaperclipIcon className="size-4" />
                         </Button>

--- a/packages/ui/src/features/magic-pdf/AnnotatedImageSlider.tsx
+++ b/packages/ui/src/features/magic-pdf/AnnotatedImageSlider.tsx
@@ -255,7 +255,13 @@ export function AnnotatedImageSlider({ className, currentPage, onChange }: Annot
     return (
         <div ref={ref} className={clsx('flex flex-col items-stretch gap-y-2', className)}>
             <div className="relative flex items-center justify-center px-2 h-9">
-                <Button variant="ghost" size="xs" onClick={goPrev} alt={t('pdf.previousPage')}>
+                <Button
+                    variant="ghost"
+                    size="xs"
+                    onClick={goPrev}
+                    aria-label={t('pdf.previousPage')}
+                    title={t('pdf.previousPage')}
+                >
                     <ChevronsUp className="size-4" />
                 </Button>
                 <div className="absolute start-2 flex items-center gap-x-1">
@@ -302,7 +308,13 @@ export function AnnotatedImageSlider({ className, currentPage, onChange }: Annot
                 ))}
             </div>
             <div className="flex items-center justify-center h-9">
-                <Button variant="ghost" size="xs" onClick={goNext} alt={t('pdf.nextPage')}>
+                <Button
+                    variant="ghost"
+                    size="xs"
+                    onClick={goNext}
+                    aria-label={t('pdf.nextPage')}
+                    title={t('pdf.nextPage')}
+                >
                     <ChevronsDown className="size-4" />
                 </Button>
             </div>

--- a/packages/ui/src/features/magic-pdf/DownloadPopover.tsx
+++ b/packages/ui/src/features/magic-pdf/DownloadPopover.tsx
@@ -30,7 +30,13 @@ export function DownloadPopover({ object }: DownloadPopoverProps) {
     // For markdown processor, only one download option - render simple button
     if (processorType === 'markdown') {
         return (
-            <Button variant="ghost" size="xs" onClick={() => onDownload('document.md')} alt={t('pdf.download')}>
+            <Button
+                variant="ghost"
+                size="xs"
+                onClick={() => onDownload('document.md')}
+                aria-label={t('pdf.download')}
+                title={t('pdf.download')}
+            >
                 <Download className="size-4" />
             </Button>
         );
@@ -40,7 +46,7 @@ export function DownloadPopover({ object }: DownloadPopoverProps) {
     return (
         <Popover>
             <PopoverTrigger>
-                <Button variant="ghost" size="xs" alt={t('pdf.download')}>
+                <Button variant="ghost" size="xs" aria-label={t('pdf.download')} title={t('pdf.download')}>
                     <Download className="size-4" />
                 </Button>
             </PopoverTrigger>

--- a/packages/ui/src/features/magic-pdf/MagicPdfView.tsx
+++ b/packages/ui/src/features/magic-pdf/MagicPdfView.tsx
@@ -94,7 +94,13 @@ export function MagicPdfView({ objectId, onClose }: MagicPdfViewProps) {
                 {/* Header matching the main view layout */}
                 <div className="flex h-9 items-center justify-end shrink-0 bg-sidebar px-2 border-b border-sidebar-border">
                     {onClose && (
-                        <Button variant="ghost" size="xs" onClick={onClose} alt={t('pdf.close')}>
+                        <Button
+                            variant="ghost"
+                            size="xs"
+                            onClick={onClose}
+                            aria-label={t('pdf.close')}
+                            title={t('pdf.close')}
+                        >
                             <X className="size-4" />
                         </Button>
                     )}
@@ -157,7 +163,13 @@ function MagicPdfViewImpl({ object, onClose }: _MagicPdfViewProps) {
                         </span>
                         <div className="flex items-center gap-x-2">
                             {!!onClose && (
-                                <Button variant="ghost" size="xs" onClick={onClose} alt={t('pdf.close')}>
+                                <Button
+                                    variant="ghost"
+                                    size="xs"
+                                    onClick={onClose}
+                                    aria-label={t('pdf.close')}
+                                    title={t('pdf.close')}
+                                >
                                     <X className="size-4" />
                                 </Button>
                             )}
@@ -195,7 +207,13 @@ function MagicPdfViewImpl({ object, onClose }: _MagicPdfViewProps) {
                     <span className="text-xs text-muted-foreground">{t('pdf.pageOf', { pageNumber, totalPages })}</span>
                     <div className="flex items-center gap-x-2">
                         {!!onClose && (
-                            <Button variant="ghost" size="xs" onClick={onClose} alt={t('pdf.close')}>
+                            <Button
+                                variant="ghost"
+                                size="xs"
+                                onClick={onClose}
+                                aria-label={t('pdf.close')}
+                                title={t('pdf.close')}
+                            >
                                 <X className="size-4" />
                             </Button>
                         )}

--- a/packages/ui/src/features/pdf-viewer/PdfPageSlider.tsx
+++ b/packages/ui/src/features/pdf-viewer/PdfPageSlider.tsx
@@ -308,7 +308,13 @@ export function PdfPageSlider({
     return (
         <div ref={ref} className={clsx('flex flex-col items-stretch', compact ? 'gap-y-1' : 'gap-y-2', className)}>
             <div className={clsx('relative flex items-center justify-center px-2', compact ? 'h-6' : 'h-9')}>
-                <Button variant="ghost" size="xs" onClick={goPrev} alt={t('pdf.previousPage')}>
+                <Button
+                    variant="ghost"
+                    size="xs"
+                    onClick={goPrev}
+                    aria-label={t('pdf.previousPage')}
+                    title={t('pdf.previousPage')}
+                >
                     <ChevronsUp className="size-4" />
                 </Button>
                 <div className="absolute start-2 flex items-center gap-x-1">
@@ -378,7 +384,13 @@ export function PdfPageSlider({
                 />
             </div>
             <div className={clsx('flex items-center justify-center', compact ? 'h-6' : 'h-9')}>
-                <Button variant="ghost" size="xs" onClick={goNext} alt={t('pdf.nextPage')}>
+                <Button
+                    variant="ghost"
+                    size="xs"
+                    onClick={goNext}
+                    aria-label={t('pdf.nextPage')}
+                    title={t('pdf.nextPage')}
+                >
                     <ChevronsDown className="size-4" />
                 </Button>
             </div>
@@ -454,18 +466,33 @@ function ZoomControls({ zoom, onZoomIn, onZoomOut, onFitToView, canZoomIn, canZo
     const { t } = useUITranslation();
     return (
         <div className="flex items-center gap-x-0.5">
-            <Button variant="ghost" size="xs" onClick={onZoomOut} isDisabled={!canZoomOut} alt={t('pdf.zoomOut')}>
+            <Button
+                variant="ghost"
+                size="xs"
+                onClick={onZoomOut}
+                isDisabled={!canZoomOut}
+                aria-label={t('pdf.zoomOut')}
+                title={t('pdf.zoomOut')}
+            >
                 <Minus />
             </Button>
             <span className="text-xs text-muted-foreground min-w-[32px] text-center">{zoom}%</span>
-            <Button variant="ghost" size="xs" onClick={onZoomIn} isDisabled={!canZoomIn} alt={t('pdf.zoomIn')}>
+            <Button
+                variant="ghost"
+                size="xs"
+                onClick={onZoomIn}
+                isDisabled={!canZoomIn}
+                aria-label={t('pdf.zoomIn')}
+                title={t('pdf.zoomIn')}
+            >
                 <Plus />
             </Button>
             <Button
                 variant="ghost"
                 size="xs"
                 onClick={onFitToView}
-                alt={t('pdf.fitToWidth')}
+                aria-label={t('pdf.fitToWidth')}
+                title={t('pdf.fitToWidth')}
                 className={zoom === DEFAULT_ZOOM ? 'text-muted-foreground/40' : undefined}
             >
                 <Maximize />

--- a/packages/ui/src/features/pdf-viewer/SimplePdfViewer.tsx
+++ b/packages/ui/src/features/pdf-viewer/SimplePdfViewer.tsx
@@ -100,7 +100,8 @@ export function SimplePdfViewer({ object, url, source, className }: SimplePdfVie
                         variant="ghost"
                         size="xs"
                         onClick={() => setIsFullscreen(false)}
-                        alt={t('pdf.closeFullscreen')}
+                        aria-label={t('pdf.closeFullscreen')}
+                        title={t('pdf.closeFullscreen')}
                     >
                         <X className="size-4" />
                     </Button>

--- a/packages/ui/src/features/store/objects/components/ContentDispositionButton.tsx
+++ b/packages/ui/src/features/store/objects/components/ContentDispositionButton.tsx
@@ -33,7 +33,12 @@ export function ContentDispositionButton({ onUpdate }: Readonly<ContentDispositi
     };
 
     return (
-        <Button variant="outline" onClick={updateView} alt={isGridView ? t('misc.tableView') : t('misc.thumbnailView')}>
+        <Button
+            variant="outline"
+            onClick={updateView}
+            aria-label={isGridView ? t('misc.tableView') : t('misc.thumbnailView')}
+            title={isGridView ? t('misc.tableView') : t('misc.thumbnailView')}
+        >
             {isGridView ? <TableProperties /> : <LayoutGrid />}
         </Button>
     );

--- a/packages/ui/src/features/store/objects/components/ContentOverview.tsx
+++ b/packages/ui/src/features/store/objects/components/ContentOverview.tsx
@@ -248,7 +248,8 @@ function PropertiesPanel({
                         <Button
                             variant={`${viewCode ? 'ghost' : 'primary'}`}
                             size="sm"
-                            alt={t('store.previewProperties')}
+                            aria-label={t('store.previewProperties')}
+                            title={t('store.previewProperties')}
                             onClick={() => setViewCode(!viewCode)}
                         >
                             Properties
@@ -256,7 +257,8 @@ function PropertiesPanel({
                         <Button
                             variant={`${viewCode ? 'primary' : 'ghost'}`}
                             size="sm"
-                            alt={t('store.viewInJsonFormat')}
+                            aria-label={t('store.viewInJsonFormat')}
+                            title={t('store.viewInJsonFormat')}
                             onClick={() => setViewCode(!viewCode)}
                         >
                             JSON
@@ -423,7 +425,8 @@ function DataPanel({
                             <Button
                                 variant={currentPanel === PanelView.Image ? 'primary' : 'ghost'}
                                 size="sm"
-                                alt={t('store.viewImage')}
+                                aria-label={t('store.viewImage')}
+                                title={t('store.viewImage')}
                                 onClick={() => setCurrentPanel(PanelView.Image)}
                             >
                                 Image
@@ -433,7 +436,8 @@ function DataPanel({
                             <Button
                                 variant={currentPanel === PanelView.Video ? 'primary' : 'ghost'}
                                 size="sm"
-                                alt={t('store.viewVideo')}
+                                aria-label={t('store.viewVideo')}
+                                title={t('store.viewVideo')}
                                 onClick={() => setCurrentPanel(PanelView.Video)}
                             >
                                 Video
@@ -443,7 +447,8 @@ function DataPanel({
                             <Button
                                 variant={currentPanel === PanelView.Audio ? 'primary' : 'ghost'}
                                 size="sm"
-                                alt={t('store.viewAudio')}
+                                aria-label={t('store.viewAudio')}
+                                title={t('store.viewAudio')}
                                 onClick={() => setCurrentPanel(PanelView.Audio)}
                             >
                                 Audio
@@ -453,7 +458,8 @@ function DataPanel({
                             <Button
                                 variant={currentPanel === PanelView.Transcript ? 'primary' : 'ghost'}
                                 size="sm"
-                                alt={t('store.viewTranscript')}
+                                aria-label={t('store.viewTranscript')}
+                                title={t('store.viewTranscript')}
                                 onClick={() => setCurrentPanel(PanelView.Transcript)}
                             >
                                 Transcript
@@ -462,7 +468,8 @@ function DataPanel({
                         <Button
                             variant={currentPanel === PanelView.Text ? 'primary' : 'ghost'}
                             size="sm"
-                            alt={t('store.viewText')}
+                            aria-label={t('store.viewText')}
+                            title={t('store.viewText')}
                             onClick={() => setCurrentPanel(PanelView.Text)}
                         >
                             Text
@@ -471,7 +478,8 @@ function DataPanel({
                             <Button
                                 variant={currentPanel === PanelView.Pdf ? 'primary' : 'ghost'}
                                 size="sm"
-                                alt={t('store.viewPdf')}
+                                aria-label={t('store.viewPdf')}
+                                title={t('store.viewPdf')}
                                 onClick={() => setCurrentPanel(PanelView.Pdf)}
                             >
                                 PDF
@@ -481,7 +489,8 @@ function DataPanel({
                             <Button
                                 variant={currentPanel === PanelView.Pdf ? 'primary' : 'ghost'}
                                 size="sm"
-                                alt={t('store.viewAsPdf')}
+                                aria-label={t('store.viewAsPdf')}
+                                title={t('store.viewAsPdf')}
                                 onClick={() => {
                                     setCurrentPanel(PanelView.Pdf);
                                     if (!pdfRendition && !officePdfUrl && !officePdfConverting) {
@@ -688,7 +697,14 @@ function TextActions({ object, text, fullText, handleCopyContent, onToggleEdit, 
                     </>
                 )}
                 {isDownloading ? (
-                    <Button variant="ghost" size="sm" disabled className="flex items-center gap-2" alt="download">
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        disabled
+                        className="flex items-center gap-2"
+                        aria-label="download"
+                        title="download"
+                    >
                         <Spinner size="sm" />
                     </Button>
                 ) : (
@@ -699,7 +715,8 @@ function TextActions({ object, text, fullText, handleCopyContent, onToggleEdit, 
                                 size="sm"
                                 disabled={!text}
                                 className="flex items-center gap-2"
-                                alt="download"
+                                aria-label="download"
+                                title="download"
                             >
                                 <Download className="size-4" />
                             </Button>

--- a/packages/ui/src/features/store/objects/components/SelectDocument.tsx
+++ b/packages/ui/src/features/store/objects/components/SelectDocument.tsx
@@ -90,7 +90,7 @@ function SelectDocumentImpl({ onRowClick, selectedIds }: Readonly<SelectDocument
             <div className="flex justify-between items-center flex-shrink-0">
                 <DocumentsFacetsNav facets={facets} search={facetSearch} />
                 <div className="flex items-center gap-2">
-                    <Button variant="outline" onClick={handleRefetch} alt="Refresh">
+                    <Button variant="outline" onClick={handleRefetch} aria-label="Refresh" title="Refresh">
                         <RefreshCw size={16} />
                     </Button>
                     <ContentDispositionButton onUpdate={setIsGridView} />

--- a/packages/ui/src/features/store/objects/components/VectorSearchWidget.tsx
+++ b/packages/ui/src/features/store/objects/components/VectorSearchWidget.tsx
@@ -141,7 +141,8 @@ export function VectorSearchWidget({ onChange, isLoading, refresh, searchTypes }
             <Button
                 variant="ghost"
                 onClick={() => setShowSettings(true)}
-                alt={t('store.semanticSearchSettings')}
+                aria-label={t('store.semanticSearchSettings')}
+                title={t('store.semanticSearchSettings')}
                 className="ms-1"
             >
                 <Settings size={18} />
@@ -194,7 +195,8 @@ export function VectorSearchWidget({ onChange, isLoading, refresh, searchTypes }
                 isLoading={isLoading}
                 onClick={fireSearch}
                 isDisabled={!isReady}
-                alt={t('store.semanticSearch')}
+                aria-label={t('store.semanticSearch')}
+                title={t('store.semanticSearch')}
             >
                 {t('store.search')}
             </Button>

--- a/packages/ui/src/features/store/objects/layout/renderers.tsx
+++ b/packages/ui/src/features/store/objects/layout/renderers.tsx
@@ -135,7 +135,8 @@ const renderers: Record<
                     {displayValue}
                     <Button
                         variant="ghost"
-                        alt="Preview Object"
+                        aria-label="Preview Object"
+                        title="Preview Object"
                         onClick={(e) => {
                             e.stopPropagation();
                             onClick?.(objectId);
@@ -176,7 +177,8 @@ const renderers: Record<
                     {displayValue}
                     <Button
                         variant="ghost"
-                        alt="Preview Object"
+                        aria-label="Preview Object"
+                        title="Preview Object"
                         onClick={(e) => {
                             e.stopPropagation();
                             onClick?.(objectId);

--- a/packages/ui/src/features/store/objects/selection/SelectionActions.tsx
+++ b/packages/ui/src/features/store/objects/selection/SelectionActions.tsx
@@ -56,7 +56,7 @@ export function SelectionActions({
                 >
                     {(actions) =>
                         actions.length > 0 ? (
-                            <Button variant="ghost" alt="More action" size="sm">
+                            <Button variant="ghost" aria-label="More action" title="More action" size="sm">
                                 <EllipsisVertical size={16} />
                             </Button>
                         ) : null

--- a/packages/ui/src/features/store/types/SelectContentTypeModal.tsx
+++ b/packages/ui/src/features/store/types/SelectContentTypeModal.tsx
@@ -110,10 +110,14 @@ export function SelectContentTypeModal({
                 )}
             </ModalBody>
             <ModalFooter>
-                <Button variant="ghost" onClick={handleClose} alt={t('modal.cancel')}>
+                <Button variant="ghost" onClick={handleClose} aria-label={t('modal.cancel')} title={t('modal.cancel')}>
                     {t('modal.cancel')}
                 </Button>
-                <Button onClick={handleConfirm} alt={t('store.confirmSelection')}>
+                <Button
+                    onClick={handleConfirm}
+                    aria-label={t('store.confirmSelection')}
+                    title={t('store.confirmSelection')}
+                >
                     {t('modal.confirm')}
                 </Button>
             </ModalFooter>

--- a/packages/ui/src/features/user/UserInfo.test.tsx
+++ b/packages/ui/src/features/user/UserInfo.test.tsx
@@ -32,10 +32,7 @@ describe('UserInfo', () => {
         vi.clearAllMocks();
     });
 
-    it('renders a missing API key as an unknown principal and caches the 404', async () => {
-        const error = Object.assign(new Error('Not Found'), { status: 404 });
-        retrieveApiKey.mockRejectedValueOnce(error);
-
+    it('renders an API key principal without fetching the key document', () => {
         render(
             <I18nProvider lng="en">
                 <UserInfo userRef="apikey:missing-key-for-test" showTitle />
@@ -43,11 +40,9 @@ describe('UserInfo', () => {
             </I18nProvider>,
         );
 
-        await waitFor(() => {
-            expect(screen.getAllByText('Unknown User')).toHaveLength(2);
-        });
+        expect(screen.getAllByText('Private Key ~r-test')).toHaveLength(2);
         expect(screen.queryByText('Failed to fetch the apikey')).toBeNull();
-        expect(retrieveApiKey).toHaveBeenCalledTimes(1);
+        expect(retrieveApiKey).not.toHaveBeenCalled();
     });
 
     it('renders a missing user as an unknown principal and caches the 404', async () => {

--- a/packages/ui/src/features/user/UserInfo.tsx
+++ b/packages/ui/src/features/user/UserInfo.tsx
@@ -1,4 +1,4 @@
-import { type ApiKey, PrincipalType, type User, type UserGroup } from '@vertesia/common';
+import { PrincipalType, type User, type UserGroup } from '@vertesia/common';
 import { Avatar, errorMessage, Popover, PopoverContent, PopoverTrigger, Table, useFetch } from '@vertesia/ui/core';
 import { useUITranslation } from '@vertesia/ui/i18n';
 import { useUserSession } from '@vertesia/ui/session';
@@ -7,7 +7,6 @@ import type { ReactNode } from 'react';
 
 const USER_CACHE: Record<string, Promise<User>> = {};
 const GROUP_CACHE: Record<string, Promise<UserGroup>> = {};
-const APIKEY_CACHE: Record<string, Promise<ApiKey>> = {};
 
 function isNotFoundError(error: unknown) {
     return typeof error === 'object' && error !== null && 'status' in error && error.status === 404;
@@ -51,19 +50,6 @@ export function useFetchGroupInfo(groupId: string) {
     return useFetch(() => cachedFetch(GROUP_CACHE, groupId, () => client.iam.groups.retrieve(groupId)), {
         deps: [groupId],
         condition: () => !!groupId,
-    });
-}
-
-/**
- * Fetch the API key information given a key ID.
- * @param keyId
- */
-export function useFetchApiKeyInfo(keyId: string) {
-    const { client } = useUserSession();
-
-    return useFetch(() => cachedFetch(APIKEY_CACHE, keyId, () => client.apikeys.retrieve(keyId)), {
-        deps: [keyId],
-        condition: () => !!keyId,
     });
 }
 
@@ -185,20 +171,19 @@ function AgentAvatar({
     const { t } = useUITranslation();
     // Fetch user info - must call hooks unconditionally per React rules
     const shouldFetchUser = onBehalfOfType === 'user' && onBehalfOfId;
-    const shouldFetchApiKey = onBehalfOfType === 'apikey' && onBehalfOfId;
+    const apiKeyId = onBehalfOfType === 'apikey' ? onBehalfOfId : undefined;
+    const isApiKeyPrincipal = !!apiKeyId;
 
     const userResult = useFetchUserInfo(onBehalfOfId || '');
-    const apiKeyResult = useFetchApiKeyInfo(onBehalfOfId || '');
 
     // Only use the data if we should fetch it
     const user = shouldFetchUser ? userResult.data : undefined;
-    const apiKey = shouldFetchApiKey ? apiKeyResult.data : undefined;
 
     // Determine title and description
     const shortenedAgentId = agentId.slice(-6);
     const title = user
         ? t('user.agentOnBehalfOf')
-        : apiKey
+        : isApiKeyPrincipal
           ? t('user.agentOnBehalfOfApiKey')
           : `${t('user.serviceAccount')}~${shortenedAgentId}`;
     const _title = isScheduleAgent ? t('user.schedule', { title }) : title;
@@ -214,13 +199,13 @@ function AgentAvatar({
                     </div>
                 </div>
             )}
-            {apiKey && (
+            {isApiKeyPrincipal && (
                 <div>
-                    <div className="font-medium">{apiKey.name}</div>
-                    <div className="text-xs text-muted-foreground">Key ID: {apiKey.id}</div>
+                    <div className="font-medium">{t('user.privateKey')}</div>
+                    <div className="text-xs text-muted-foreground">Key ID: {apiKeyId}</div>
                 </div>
             )}
-            {!user && !apiKey && (
+            {!user && !isApiKeyPrincipal && (
                 <>
                     <div>{t('user.serviceAccountDescription')}</div>
                     <div className="text-gray-800 dark:text-gray-500 text-sm">
@@ -249,7 +234,7 @@ function AgentAvatar({
                             className="border-2 border-white dark:border-gray-800"
                         />
                     )}
-                    {apiKey && (
+                    {isApiKeyPrincipal && (
                         <Avatar
                             name="API"
                             color="bg-gray-400"
@@ -260,7 +245,11 @@ function AgentAvatar({
                 </div>
                 {showTitle && (
                     <div className="text-sm font-semibold truncate">
-                        {user ? `Agent      (${user.name || user.email})` : apiKey ? `Agent (${apiKey.name})` : title}
+                        {user
+                            ? `Agent (${user.name || user.email})`
+                            : apiKeyId
+                              ? `Agent (${t('user.privateKey')} ~${apiKeyId.slice(-6)})`
+                              : title}
                     </div>
                 )}
             </div>
@@ -529,18 +518,6 @@ interface ApiKeyAvatarProps extends InfoProps {
 }
 export function ApiKeyAvatar({ keyId, showTitle = false, size = 'md' }: ApiKeyAvatarProps) {
     const { t } = useUITranslation();
-    const { data, error } = useFetchApiKeyInfo(keyId);
-
-    if (error) {
-        if (isNotFoundError(error)) {
-            return <MissingPrincipalAvatar showTitle={showTitle} size={size} color="bg-pink-500" />;
-        }
-        return <ErrorAvatar title={t('user.failedToFetchApiKey')} error={error} showTitle={showTitle} size={size} />;
-    }
-
-    if (!data) {
-        return <AvatarPlaceholder />;
-    }
 
     const title = t('user.privateKey');
     const avatar = <Avatar name={'PK'} color="bg-pink-500" size={size} />;
@@ -548,15 +525,7 @@ export function ApiKeyAvatar({ keyId, showTitle = false, size = 'md' }: ApiKeyAv
         <Table className="dark:bg-gray-800 dark:text-gray-200 table-fixed w-full">
             <tr>
                 <td className="font-semibold w-20">{t('user.key')}</td>
-                <td className="truncate max-w-0">{data?.name}</td>
-            </tr>
-            <tr>
-                <td className="font-semibold w-20">{t('user.account')}</td>
-                <td className="truncate max-w-0">{data?.account}</td>
-            </tr>
-            <tr>
-                <td className="font-semibold w-20">{t('user.project')}</td>
-                <td className="truncate max-w-0">{data?.project.name}</td>
+                <td className="truncate max-w-0">{keyId}</td>
             </tr>
         </Table>
     );
@@ -565,11 +534,7 @@ export function ApiKeyAvatar({ keyId, showTitle = false, size = 'md' }: ApiKeyAv
         <UserPopoverPanel title={title} description={description}>
             <div className="flex flex-row items-center gap-2">
                 {avatar}
-                {showTitle && (
-                    <div className="text-sm font-semibold">
-                        {data?.name || data?.account || data?.project.name || t('user.unknown')}
-                    </div>
-                )}
+                {showTitle && <div className="text-sm font-semibold">{`${title} ~${keyId.slice(-6)}`}</div>}
             </div>
         </UserPopoverPanel>
     );

--- a/packages/ui/src/session/UserSession.ts
+++ b/packages/ui/src/session/UserSession.ts
@@ -98,9 +98,12 @@ class UserSession {
         this.isLoading = false;
         this.client.withAuthCallback(() => this.authCallback);
         this.authToken = jwtDecode(token) as unknown as AuthTokenPayload;
-        console.log(
-            `Logging in as ${this.authToken?.name} with account ${this.authToken?.account.name} (${this.authToken?.account.id}, and project ${this.authToken?.project?.name} (${this.authToken?.project?.id})`,
-        );
+        Env.logger.debug('User session login completed', {
+            vertesia: {
+                account_id: this.authToken.account.id,
+                project_id: this.authToken.project?.id,
+            },
+        });
 
         //store selected account in local storage
         localStorage.setItem(LastSelectedAccountId_KEY, this.authToken.account.id);
@@ -123,12 +126,12 @@ class UserSession {
     }
 
     logout() {
-        console.log('Logging out');
+        Env.logger.debug('Logging out');
 
         if (shouldRedirectToCentralAuth()) {
             // Redirect to central auth for logout
             // Central auth will handle Firebase logout
-            console.log('Using central auth logout');
+            Env.logger.debug('Using central auth logout');
             this.authError = undefined;
             this.isLoading = false;
             this.authToken = undefined;
@@ -143,7 +146,7 @@ class UserSession {
             location.replace(logoutUrl.toString());
         } else {
             // Use Firebase logout directly
-            console.log('Using Firebase logout');
+            Env.logger.debug('Using Firebase logout');
             const wasLoggedIn = !!this.authToken;
             if (this.authToken) {
                 void getFirebaseAuth().signOut();
@@ -229,7 +232,7 @@ class UserSession {
 
     async fetchOnboardingStatus(): Promise<boolean> {
         if (this.onboardingComplete) {
-            console.log('Onboarding already completed');
+            Env.logger.debug('Onboarding already completed');
             return false;
         }
         const previousStatus = this.onboardingComplete;

--- a/packages/ui/src/session/UserSessionProvider.tsx
+++ b/packages/ui/src/session/UserSessionProvider.tsx
@@ -36,13 +36,11 @@ export function UserSessionProvider({ children, loadOnboardingStatus = true }: U
     authFlowRef.current = () => {
         // Make this effect idempotent - only run auth flow once
         if (hasInitiatedAuthRef.current) {
-            console.log('Auth: skipping duplicate auth flow initiation');
             return;
         }
         hasInitiatedAuthRef.current = true;
 
-        console.log('Auth: starting auth flow');
-        Env.logger.info('Starting auth flow');
+        Env.logger.debug('Starting auth flow');
         const currentUrl = new URL(window.location.href);
         const selectedAccount =
             currentUrl.searchParams.get('a') ?? localStorage.getItem(LastSelectedAccountId_KEY) ?? undefined;
@@ -50,9 +48,7 @@ export function UserSessionProvider({ children, loadOnboardingStatus = true }: U
             currentUrl.searchParams.get('p') ??
             localStorage.getItem(`${LastSelectedProjectId_KEY}-${selectedAccount}`) ??
             undefined;
-        console.log('Auth: selected account', selectedAccount);
-        console.log('Auth: selected project', selectedProject);
-        Env.logger.info('Selected account and project', {
+        Env.logger.debug('Selected account and project', {
             vertesia: {
                 account_id: selectedAccount,
                 project_id: selectedProject,
@@ -84,7 +80,13 @@ export function UserSessionProvider({ children, loadOnboardingStatus = true }: U
                 .catch((err) => {
                     // Don't redirect to central auth for UserNotFoundError - let signup flow handle it
                     if (err instanceof UserNotFoundError) {
-                        console.log('User not found - will trigger signup flow', err);
+                        Env.logger.debug('User not found - will trigger signup flow', {
+                            vertesia: {
+                                account_id: selectedAccount,
+                                project_id: selectedProject,
+                                email: err.email,
+                            },
+                        });
                         session.isLoading = false;
                         session.authError = err;
                         setSession(session.clone());
@@ -122,20 +124,14 @@ export function UserSessionProvider({ children, loadOnboardingStatus = true }: U
         } else {
             // If the current host is not in the Firebase allowlist, central auth owns sign-in.
             if (!session.isLoggedIn()) {
-                console.log('Auth: not logged in & no token/state');
-                Env.logger.info('Not logged in & no token/state', {
+                Env.logger.debug('Not logged in & no token/state', {
                     vertesia: {
                         account_id: selectedAccount,
                         project_id: selectedProject,
                     },
                 });
                 if (shouldRedirectToCentralAuth()) {
-                    console.log(
-                        'Auth: host is not in Firebase auth allowlist, redirecting to central auth with selection',
-                        selectedAccount,
-                        selectedProject,
-                    );
-                    Env.logger.info('Redirecting to central auth with selection', {
+                    Env.logger.debug('Redirecting to central auth with selection', {
                         vertesia: {
                             account_id: selectedAccount,
                             project_id: selectedProject,
@@ -144,8 +140,7 @@ export function UserSessionProvider({ children, loadOnboardingStatus = true }: U
                     redirectToCentralAuth();
                     return; // Don't register onAuthStateChanged listener when redirecting
                 } else {
-                    console.log('Auth: host is in Firebase auth allowlist');
-                    Env.logger.info('Host is in Firebase auth allowlist', {
+                    Env.logger.debug('Host is in Firebase auth allowlist', {
                         vertesia: {
                             account_id: selectedAccount,
                             project_id: selectedProject,
@@ -157,8 +152,7 @@ export function UserSessionProvider({ children, loadOnboardingStatus = true }: U
 
         return onAuthStateChanged(getFirebaseAuth(), async (firebaseUser) => {
             if (firebaseUser) {
-                console.log('Auth: successful login with firebase');
-                Env.logger.info('Successful login with firebase', {
+                Env.logger.debug('Successful login with firebase', {
                     vertesia: {
                         account_id: selectedAccount,
                         project_id: selectedProject,
@@ -191,8 +185,7 @@ export function UserSessionProvider({ children, loadOnboardingStatus = true }: U
                     });
             } else {
                 // anonymous user
-                console.log('Auth: using anonymous user');
-                Env.logger.info('Using anonymous user', {
+                Env.logger.debug('Using anonymous user', {
                     vertesia: {
                         account_id: selectedAccount,
                         project_id: selectedProject,

--- a/packages/ui/src/session/auth/composable.ts
+++ b/packages/ui/src/session/auth/composable.ts
@@ -24,8 +24,7 @@ export async function fetchComposableToken(
     ttl?: number,
     retryCount = 0,
 ): Promise<string> {
-    console.log(`Getting/refreshing composable token for account ${accountId} and project ${projectId} `);
-    Env.logger.info('Getting/refreshing composable token', {
+    Env.logger.debug('Getting/refreshing composable token', {
         vertesia: {
             account_id: accountId,
             project_id: projectId,
@@ -35,14 +34,13 @@ export async function fetchComposableToken(
 
     const idToken = await getIdToken(); //get from firebase
     if (!idToken) {
-        console.log('No id token found - using cookie auth');
+        Env.logger.debug('No id token found - using cookie auth');
         throw new Error('No id token found');
     }
 
     // Use STS endpoint - either configured or default to sts.vertesia.io
     const stsEndpoint = Env.endpoints.sts;
-    console.log('Using STS for token generation:', stsEndpoint);
-    Env.logger.info('Using STS for token generation', {
+    Env.logger.debug('Using STS for token generation', {
         vertesia: {
             account_id: accountId,
             project_id: projectId,
@@ -81,8 +79,7 @@ export async function fetchComposableToken(
 
         if (idToken && stsRes?.status === 404) {
             // User not found in token-server - call ensure-user endpoint
-            console.log('404: User not found - calling ensure-user endpoint');
-            Env.logger.info('404: User not found - calling ensure-user endpoint', {
+            Env.logger.debug('404: User not found - calling ensure-user endpoint', {
                 vertesia: {
                     account_id: accountId,
                     project_id: projectId,
@@ -100,8 +97,7 @@ export async function fetchComposableToken(
 
             if (ensureResponse.status === 412) {
                 // No invite - trigger signup
-                console.log('412: No invite found - signup required');
-                Env.logger.info('412: No invite found - signup required', {
+                Env.logger.debug('412: No invite found - signup required', {
                     vertesia: {
                         account_id: accountId,
                         project_id: projectId,
@@ -139,8 +135,7 @@ export async function fetchComposableToken(
             }
 
             // User created/exists - retry token generation
-            console.log('User ensured - retrying token generation');
-            Env.logger.info('User ensured - retrying token generation', {
+            Env.logger.debug('User ensured - retrying token generation', {
                 vertesia: {
                     account_id: accountId,
                     project_id: projectId,
@@ -150,8 +145,7 @@ export async function fetchComposableToken(
         }
 
         if (idToken && stsRes?.status === 412) {
-            console.log("412: auth succeeded but user doesn't exist - signup required", stsRes?.status);
-            Env.logger.error("412: auth succeeded but user doesn't exist - signup required", {
+            Env.logger.warn("412: auth succeeded but user doesn't exist - signup required", {
                 vertesia: {
                     account_id: accountId,
                     project_id: projectId,
@@ -194,7 +188,6 @@ export async function fetchComposableToken(
                 throw new Error('Access denied - user may not have access to any accounts');
             }
 
-            console.log('403: Access denied - clearing cached account and retrying without account scope');
             Env.logger.warn('403: Access denied - clearing cached account and retrying', {
                 vertesia: {
                     account_id: accountId,
@@ -229,8 +222,6 @@ export async function fetchComposableToken(
         }
 
         const { token } = await stsRes.json();
-        console.log('Successfully got token from STS');
-        Env.logger.info('Successfully got token from STS');
         return token;
     } catch (error) {
         if (error instanceof UserNotFoundError || error instanceof STSError) {

--- a/packages/ui/src/session/auth/firebase.ts
+++ b/packages/ui/src/session/auth/firebase.ts
@@ -43,17 +43,17 @@ export function getFirebaseAuth(): Auth {
 
 export async function setFirebaseTenant(tenantEmail?: string) {
     if (!tenantEmail) {
-        console.log('No tenant name or email specified, skipping tenant setup');
+        Env.logger.debug('No tenant name or email specified, skipping tenant setup');
         return;
     }
 
     if (!Env.firebase) {
-        console.log('Firebase configuration is not available in the environment');
+        Env.logger.debug('Firebase configuration is not available in the environment');
         return;
     }
 
     try {
-        if (tenantEmail) console.log(`Resolving tenant ID from email: ${tenantEmail}`);
+        Env.logger.debug('Resolving tenant ID from email');
 
         // Add retry logic with exponential backoff
         let retries = 3;
@@ -105,7 +105,7 @@ export async function setFirebaseTenant(tenantEmail?: string) {
                     const auth = getFirebaseAuth();
                     auth.tenantId = data.firebaseTenantId;
                     Env.firebase.providerType = data.provider ?? 'oidc';
-                    console.log(`Tenant ID set to ${auth.tenantId}`);
+                    Env.logger.debug('Firebase tenant ID set');
                     return data;
                 } else {
                     console.error(`Invalid response format, missing tenantId for ${tenantEmail}`);
@@ -139,7 +139,7 @@ export async function getFirebaseAuthToken(refresh?: boolean) {
         return user
             .getIdToken(refresh)
             .then((token) => {
-                Env.logger.info('Got Firebase token', {
+                Env.logger.debug('Got Firebase token', {
                     vertesia: {
                         user_email: user.email,
                         user_name: user.displayName,
@@ -163,7 +163,7 @@ export async function getFirebaseAuthToken(refresh?: boolean) {
                 return null;
             });
     } else {
-        Env.logger.warn('No user found');
+        Env.logger.debug('No user found');
         return Promise.resolve(null);
     }
 }

--- a/packages/ui/src/session/useUXTracking.tsx
+++ b/packages/ui/src/session/useUXTracking.tsx
@@ -1,11 +1,12 @@
 import type { AuthTokenPayload } from '@vertesia/common';
 import { Env } from '@vertesia/ui/env';
 import { logEvent } from 'firebase/analytics';
+import { useCallback } from 'react';
 import { getFirebaseAnalytics } from './auth/firebase';
 
 export function useUXTracking() {
     //identify user in monitoring and UX systems
-    const tagUserSession = async (user?: AuthTokenPayload) => {
+    const tagUserSession = useCallback(async (user?: AuthTokenPayload) => {
         const signupData = window.localStorage.getItem('composableSignupData');
         if (!user) {
             console.error('No user found -- skipping tagging');
@@ -15,17 +16,13 @@ export function useUXTracking() {
         if (signupData) {
             window.localStorage.removeItem('composableSignupData');
         }
-    };
+    }, []);
 
     //send event to analytics and UX systems
-    const trackEvent = (eventName: string, eventProperties?: Record<string, unknown>) => {
-        if (!Env.isProd) {
-            console.debug('track event', eventName, eventProperties);
-        }
-
+    const trackEvent = useCallback((eventName: string, eventProperties?: Record<string, unknown>) => {
         //GA via firebase
         logEvent(getFirebaseAnalytics(), eventName, { ...eventProperties, debug_mode: !Env.isProd });
-    };
+    }, []);
 
     return {
         tagUserSession,

--- a/packages/ui/src/shell/login/InviteAcceptModal.tsx
+++ b/packages/ui/src/shell/login/InviteAcceptModal.tsx
@@ -19,15 +19,12 @@ export function InviteAcceptModal() {
                     // Filter out legacy invites that do not have account data
                     const notLegacyInvites = invites.filter((i) => i.data.account);
                     if (notLegacyInvites.length === 0) {
-                        console.log('No valid invites found, closing modal');
                         return;
                     }
                     // If we have valid invites, show the modal
-                    console.log('Found valid invites', notLegacyInvites.length);
                     setShowModal(true);
                     setInvites(notLegacyInvites);
                 } else {
-                    console.log('No invites found, closing modal');
                     setShowModal(false);
                 }
             })

--- a/packages/ui/src/shell/login/SignupForm.tsx
+++ b/packages/ui/src/shell/login/SignupForm.tsx
@@ -98,7 +98,6 @@ export default function SignupForm({ onSignup, goBack }: SignupFormProps) {
         window.localStorage.setItem('composableSignupData', JSON.stringify(signupData));
 
         const fbToken = await getFirebaseAuth().currentUser?.getIdToken();
-        console.log('Got firebase token', getFirebaseAuth(), fbToken);
         if (!fbToken) {
             console.error('No firebase token found');
             return;

--- a/packages/ui/src/widgets/form/Form.tsx
+++ b/packages/ui/src/widgets/form/Form.tsx
@@ -180,7 +180,7 @@ function ListItem({ list, object, onDelete, disabled }: ListItemProps) {
     return (
         <div className="flex gap-2 w-full">
             <div className="flex-1">{renderItemProperty(object, editor)}</div>
-            <Button variant="ghost" onClick={onDelete} disabled={disabled} alt="Delete">
+            <Button variant="ghost" onClick={onDelete} disabled={disabled} aria-label="Delete" title="Delete">
                 <Trash2 className="size-4 text-destructive" />
             </Button>
         </div>

--- a/packages/ui/src/widgets/json-view/JSONSwitcher.tsx
+++ b/packages/ui/src/widgets/json-view/JSONSwitcher.tsx
@@ -14,7 +14,8 @@ export function JSONSwitcher({
             <Button
                 variant={viewCode ? 'ghost' : 'primary'}
                 size="sm"
-                alt="Preview properties"
+                aria-label="Preview properties"
+                title="Preview properties"
                 onClick={() => setViewCode(false)}
             >
                 {title}
@@ -22,7 +23,8 @@ export function JSONSwitcher({
             <Button
                 variant={viewCode ? 'primary' : 'ghost'}
                 size="sm"
-                alt="View in JSON format"
+                aria-label="View in JSON format"
+                title="View in JSON format"
                 onClick={() => setViewCode(true)}
             >
                 JSON


### PR DESCRIPTION
## Summary
- Reduce default-visible auth, session, and browser SDK diagnostic noise in UI packages.
- Replace deprecated button tooltip call sites with accessible labels plus visual titles.
- Render API key principals without fetching key documents, avoiding noisy 404s for missing or revoked keys.
- Keep FormItem developer wiring warnings scoped to local development.

## Test Plan
- [x] pnpm --prefix composableai/packages/ui lint
- [x] pnpm --prefix composableai/packages/ui test
- [x] pnpm --prefix composableai/packages/ui build
