### PR TITLE
fix(common): guard withDSLWorkflowSpecDiscriminator against a nullish spec

### DIFF
--- a/packages/common/src/store/dsl-workflow.ts
+++ b/packages/common/src/store/dsl-workflow.ts
@@ -307,8 +307,10 @@ export interface DSLWorkflowSpecWithActivities extends DSLWorkflowSpecBase {
  */
 export type DSLWorkflowSpec = DSLWorkflowSpecWithSteps | DSLWorkflowSpecWithActivities;
 
-export function withDSLWorkflowSpecDiscriminator(spec: DSLWorkflowSpecBase): DSLWorkflowSpec {
-    if ('steps' in spec && spec.steps) {
+export function withDSLWorkflowSpecDiscriminator(spec: DSLWorkflowSpecBase | undefined): DSLWorkflowSpec {
+    // Guard against a nullish spec: the `in` operator throws a cryptic
+    // "Cannot use 'in' operator to search for 'steps' in undefined" TypeError on undefined/null.
+    if (spec && 'steps' in spec && spec.steps) {
         return { ...spec, spec_format: 'steps' } as DSLWorkflowSpecWithSteps;
     }
     return { ...spec, spec_format: 'activities' } as DSLWorkflowSpecWithActivities;


### PR DESCRIPTION
## Summary
- `withDSLWorkflowSpecDiscriminator` called `'steps' in spec` directly, which throws `TypeError: Cannot use 'in' operator to search for 'steps' in undefined` when invoked with an `undefined`/`null` spec.
- Callers can legitimately pass an undefined spec (e.g. workflows that have no DSL definition), so the parameter type is widened to `DSLWorkflowSpecBase | undefined` and the `in` check is guarded with a nullish check. The return type is unchanged, so existing callers are unaffected.

## Test Plan
- [x] `@vertesia/common` builds with the widened signature (return type stable; dependent callers compile unchanged).
- [x] `biome check` clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
