### PR TITLE
fix(build): clean lib + tsbuildinfo for composite tsmod packages

### DIFF
--- a/packages/api-fetch-client/package.json
+++ b/packages/api-fetch-client/package.json
@@ -20,7 +20,7 @@
         "test": "ESBK_TSCONFIG_PATH=./test/tsconfig.json pnpm exec mocha -r tsx --exit ./test/**/*.ts",
         "lint": "biome lint src",
         "typecheck:test": "tsc -p test/tsconfig.json --noEmit",
-        "build": "pnpm exec tsmod build",
+        "build": "pnpm exec rimraf ./lib ./tsconfig.tsbuildinfo && pnpm exec tsmod build",
         "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
     },
     "repository": {

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -14,7 +14,7 @@
         "lint": "biome lint src",
         "test": "vitest run",
         "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
-        "build": "pnpm exec tsmod build && pnpm exec rollup -c",
+        "build": "pnpm exec rimraf ./lib ./tsconfig.tsbuildinfo && pnpm exec tsmod build && pnpm exec rollup -c",
         "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
     },
     "exports": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -11,7 +11,7 @@
     "license": "Apache-2.0",
     "scripts": {
         "lint": "biome lint src",
-        "build": "pnpm exec tsmod build && pnpm exec rollup -c",
+        "build": "pnpm exec rimraf ./lib ./tsconfig.tsbuildinfo && pnpm exec tsmod build && pnpm exec rollup -c",
         "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo",
         "test": "vitest run",
         "typecheck:test": "tsc -p tsconfig.test.json --noEmit"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -13,7 +13,7 @@
         "lint": "biome lint src",
         "test": "vitest run",
         "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
-        "build": "pnpm exec tsmod build && pnpm exec rollup -c",
+        "build": "pnpm exec rimraf ./lib ./tsconfig.tsbuildinfo && pnpm exec tsmod build && pnpm exec rollup -c",
         "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
     },
     "exports": {

--- a/packages/converters/package.json
+++ b/packages/converters/package.json
@@ -13,7 +13,7 @@
         "lint": "biome lint src",
         "test": "vitest run",
         "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
-        "build": "pnpm exec tsmod build --esm",
+        "build": "pnpm exec rimraf ./lib ./tsconfig.tsbuildinfo && pnpm exec tsmod build --esm",
         "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
     },
     "exports": {

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -13,7 +13,7 @@
         "lint": "biome lint src",
         "test": "vitest run",
         "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
-        "build": "pnpm exec tsmod build && pnpm exec rollup -c",
+        "build": "pnpm exec rimraf ./lib ./tsconfig.tsbuildinfo && pnpm exec tsmod build && pnpm exec rollup -c",
         "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
     },
     "exports": {

--- a/packages/memory-commands/package.json
+++ b/packages/memory-commands/package.json
@@ -11,7 +11,7 @@
     "license": "Apache-2.0",
     "scripts": {
         "lint": "biome lint src",
-        "build": "pnpm exec tsmod build",
+        "build": "pnpm exec rimraf ./lib ./tsconfig.tsbuildinfo && pnpm exec tsmod build",
         "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
     },
     "devDependencies": {

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -11,7 +11,7 @@
     "license": "Apache-2.0",
     "scripts": {
         "lint": "biome lint src",
-        "build": "pnpm exec tsmod build",
+        "build": "pnpm exec rimraf ./lib ./tsconfig.tsbuildinfo && pnpm exec tsmod build",
         "test": "vitest run",
         "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
     },

--- a/packages/tools-sdk/package.json
+++ b/packages/tools-sdk/package.json
@@ -13,7 +13,7 @@
         "lint": "biome lint src",
         "test": "vitest run",
         "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
-        "build": "pnpm exec tsmod build",
+        "build": "pnpm exec rimraf ./lib ./tsconfig.tsbuildinfo && pnpm exec tsmod build",
         "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
     },
     "exports": {

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -15,7 +15,7 @@
         "lint": "biome lint src",
         "test": "vitest run",
         "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
-        "build": "pnpm exec tsmod build && node ./bin/bundle-workflows.mjs lib/esm/workflows.js lib/workflows-bundle.js",
+        "build": "pnpm exec rimraf ./lib ./tsconfig.tsbuildinfo && pnpm exec tsmod build && node ./bin/bundle-workflows.mjs lib/esm/workflows.js lib/workflows-bundle.js",
         "clean": "rm -rf ./lib tsconfig.tsbuildinfo"
     },
     "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

Packages that compile with TypeScript project references (`composite: true`) keep an incremental-build cache in `tsconfig.tsbuildinfo`. When a CI/build cache restores a **stale** `lib/` + `tsbuildinfo` from an earlier commit, the incremental build can skip re-emitting newly-added declarations — producing a package that's missing recent exports.

Concretely, a downstream package failed to typecheck with:
```
Module '@vertesia/common' has no exported member 'TransientToken'.
Module '@vertesia/common' has no exported member 'UserInviteTokenData'.
```
even though `@vertesia/common` exports them — because the cached `@vertesia/common` type output was stale and the incremental build didn't regenerate it.

## Fix

Prepend `rimraf ./lib ./tsconfig.tsbuildinfo` to the `build` script of every package that builds via `tsmod`/`tsc -b` with `composite: true` but didn't already clean first — so each rebuild starts from a clean slate and stale incremental state can't survive a cache restore. (`@vertesia/fusion-ux`, `@vertesia/ui`, and `tools-admin-ui` already did this.)

Packages updated: `common`, `client`, `api-fetch-client`, `build-tools`, `converters`, `json`, `memory-commands`, `memory`, `tools-sdk`, `workflow`.

## Why this doesn't hurt caching
Turbo caches at the **task** level (keyed on inputs, restoring outputs). On a cache **hit** the build script never runs, so the `rimraf` + recompile don't happen. It only runs on a cache **miss** — i.e. an actual rebuild, where a clean compile is exactly what's wanted. Removing `tsbuildinfo` only disables TypeScript's intra-build incremental (sub-second for these packages); it does not affect Turbo/remote caching.

## Verification
- `turbo build --force` → **19/19 successful**.
- Reproduced the stale state (planted a bogus `lib/` + `tsbuildinfo`) and confirmed the build wipes it and re-emits correct declarations.

> A matching change covers the at-risk `@llumiverse/*` packages (core/common/drivers) in vertesia/llumiverse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>