### PR TITLE
fix(client): byte-encode signed-URL upload stream chunks (fix 'Received non-Uint8Array chunk')

### DIFF
--- a/packages/client/src/store/signed-url.test.ts
+++ b/packages/client/src/store/signed-url.test.ts
@@ -114,10 +114,10 @@ describe('fetchSignedUrl', () => {
         // produces (NodeStreamSource wraps text bodies this way). `new Response(stream).blob()`
         // rejects these under undici with "Received non-Uint8Array chunk"; the helper must
         // encode them to bytes instead.
-        const stream = new ReadableStream({
+        const stream = new ReadableStream<string>({
             start(controller) {
-                controller.enqueue('hello ' as unknown as Uint8Array);
-                controller.enqueue('world' as unknown as Uint8Array);
+                controller.enqueue('hello ');
+                controller.enqueue('world');
                 controller.close();
             },
         });
@@ -138,9 +138,9 @@ describe('fetchSignedUrl', () => {
             return Promise.resolve(response(200, 'ok'));
         });
 
-        const stream = new ReadableStream({
+        const stream = new ReadableStream<string | Uint8Array>({
             start(controller) {
-                controller.enqueue('a' as unknown as Uint8Array);
+                controller.enqueue('a');
                 controller.enqueue(new TextEncoder().encode('b'));
                 controller.close();
             },
@@ -156,9 +156,9 @@ describe('fetchSignedUrl', () => {
     });
 
     it('throws on an object-mode stream chunk instead of silently corrupting the upload', async () => {
-        const stream = new ReadableStream({
+        const stream = new ReadableStream<unknown>({
             start(controller) {
-                controller.enqueue({ not: 'bytes' } as unknown as Uint8Array);
+                controller.enqueue({ not: 'bytes' });
                 controller.close();
             },
         });

--- a/packages/client/src/store/signed-url.test.ts
+++ b/packages/client/src/store/signed-url.test.ts
@@ -103,6 +103,58 @@ describe('fetchSignedUrl', () => {
         expect(bodies[0]).toBe(bodies[1]);
     });
 
+    it('buffers a string-chunk ReadableStream body without throwing (regression: non-Uint8Array chunk)', async () => {
+        const bodies: unknown[] = [];
+        fetchMock.mockImplementation((_url: string, init: RequestInit) => {
+            bodies.push(init.body);
+            return Promise.resolve(response(200, 'ok'));
+        });
+
+        // A web stream that yields *string* chunks — what `Readable.toWeb(Readable.from(text))`
+        // produces (NodeStreamSource wraps text bodies this way). `new Response(stream).blob()`
+        // rejects these under undici with "Received non-Uint8Array chunk"; the helper must
+        // encode them to bytes instead.
+        const stream = new ReadableStream({
+            start(controller) {
+                controller.enqueue('hello ' as unknown as Uint8Array);
+                controller.enqueue('world' as unknown as Uint8Array);
+                controller.close();
+            },
+        });
+
+        const res = await runAllTimers(
+            fetchSignedUrl('https://storage/x', { method: 'PUT', body: stream as unknown as BodyInit }),
+        );
+
+        expect(res.status).toBe(200);
+        expect(bodies[0]).toBeInstanceOf(Blob);
+        expect(await (bodies[0] as Blob).text()).toBe('hello world');
+    });
+
+    it('buffers a mixed-chunk ReadableStream body, encoding strings and keeping bytes', async () => {
+        const bodies: unknown[] = [];
+        fetchMock.mockImplementation((_url: string, init: RequestInit) => {
+            bodies.push(init.body);
+            return Promise.resolve(response(200, 'ok'));
+        });
+
+        const stream = new ReadableStream({
+            start(controller) {
+                controller.enqueue('a' as unknown as Uint8Array);
+                controller.enqueue(new TextEncoder().encode('b'));
+                controller.close();
+            },
+        });
+
+        const res = await runAllTimers(
+            fetchSignedUrl('https://storage/x', { method: 'PUT', body: stream as unknown as BodyInit }),
+        );
+
+        expect(res.status).toBe(200);
+        expect(bodies[0]).toBeInstanceOf(Blob);
+        expect(await (bodies[0] as Blob).text()).toBe('ab');
+    });
+
     it('honors a numeric Retry-After header when scheduling the retry', async () => {
         fetchMock
             .mockResolvedValueOnce(response(503, 'slow down', { 'retry-after': '2' }))

--- a/packages/client/src/store/signed-url.test.ts
+++ b/packages/client/src/store/signed-url.test.ts
@@ -155,6 +155,21 @@ describe('fetchSignedUrl', () => {
         expect(await (bodies[0] as Blob).text()).toBe('ab');
     });
 
+    it('throws on an object-mode stream chunk instead of silently corrupting the upload', async () => {
+        const stream = new ReadableStream({
+            start(controller) {
+                controller.enqueue({ not: 'bytes' } as unknown as Uint8Array);
+                controller.close();
+            },
+        });
+
+        await expect(
+            fetchSignedUrl('https://storage/x', { method: 'PUT', body: stream as unknown as BodyInit }),
+        ).rejects.toThrow(TypeError);
+        // The bad body is rejected before any network call is attempted.
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
     it('honors a numeric Retry-After header when scheduling the retry', async () => {
         fetchMock
             .mockResolvedValueOnce(response(503, 'slow down', { 'retry-after': '2' }))

--- a/packages/client/src/store/signed-url.test.ts
+++ b/packages/client/src/store/signed-url.test.ts
@@ -168,6 +168,7 @@ describe('fetchSignedUrl', () => {
         ).rejects.toThrow(TypeError);
         // The bad body is rejected before any network call is attempted.
         expect(fetchMock).not.toHaveBeenCalled();
+        expect(stream.locked).toBe(false);
     });
 
     it('honors a numeric Retry-After header when scheduling the retry', async () => {

--- a/packages/client/src/store/signed-url.ts
+++ b/packages/client/src/store/signed-url.ts
@@ -121,12 +121,16 @@ async function toReplayableBody(body: BodyInit | null | undefined): Promise<Body
                 if (done) {
                     break;
                 }
-                if (value != null) {
-                    parts.push(chunkToBlobPart(value));
-                }
+                // Normalize every chunk (a stray null/undefined is rejected by
+                // chunkToBlobPart) so a malformed stream fails loudly instead of
+                // silently uploading a truncated body.
+                parts.push(chunkToBlobPart(value));
             }
-        } finally {
             reader.releaseLock();
+        } catch (err) {
+            // Signal the producer to stop and release its resources before propagating.
+            await reader.cancel(err).catch(() => undefined);
+            throw err;
         }
         return new Blob(parts);
     }

--- a/packages/client/src/store/signed-url.ts
+++ b/packages/client/src/store/signed-url.ts
@@ -65,18 +65,66 @@ function backoffMs(attempt: number, baseDelayMs: number, maxDelayMs: number, res
     return Math.floor(Math.random() * capped);
 }
 
+const textEncoder = new TextEncoder();
+
+/**
+ * Normalize one `ReadableStream` chunk to a byte-backed `BlobPart`.
+ *
+ * A web stream produced from a Node `Readable.from(<string>)` (e.g. via
+ * `Readable.toWeb`, which `NodeStreamSource` uses) yields *string* chunks. Buffering
+ * such a stream with `new Response(stream).blob()` throws under undici with
+ * "TypeError: Received non-Uint8Array chunk", which breaks every signed-URL upload of
+ * a text/JSON body (extracted text previews, agent artifacts, tool storage). Encoding
+ * chunks ourselves keeps both string and binary bodies uploadable.
+ */
+function chunkToBlobPart(chunk: unknown): BlobPart {
+    if (typeof chunk === 'string') {
+        return textEncoder.encode(chunk);
+    }
+    if (chunk instanceof Blob) {
+        return chunk;
+    }
+    if (chunk instanceof ArrayBuffer) {
+        return new Uint8Array(chunk);
+    }
+    // Covers Uint8Array and every other typed-array / DataView view.
+    if (ArrayBuffer.isView(chunk)) {
+        return new Uint8Array(chunk.buffer as ArrayBuffer, chunk.byteOffset, chunk.byteLength);
+    }
+    // Unknown chunk type — fall back to its string representation.
+    return textEncoder.encode(String(chunk));
+}
+
 /**
  * Buffer a `ReadableStream` body into a `Blob` so the request can be safely
  * replayed across retries. Other body types (`Blob`/`File`, `ArrayBuffer`,
  * typed arrays, strings, `URLSearchParams`) are already replayable and pass
  * through unchanged.
+ *
+ * The stream is drained manually (rather than `new Response(stream).blob()`) so that
+ * string chunks are encoded to bytes — see {@link chunkToBlobPart}.
  */
 async function toReplayableBody(body: BodyInit | null | undefined): Promise<BodyInit | undefined> {
     if (body == null) {
         return undefined;
     }
     if (typeof ReadableStream !== 'undefined' && body instanceof ReadableStream) {
-        return await new Response(body).blob();
+        const reader = (body as ReadableStream<unknown>).getReader();
+        const parts: BlobPart[] = [];
+        try {
+            for (;;) {
+                const { done, value } = await reader.read();
+                if (done) {
+                    break;
+                }
+                if (value != null) {
+                    parts.push(chunkToBlobPart(value));
+                }
+            }
+        } finally {
+            reader.releaseLock();
+        }
+        return new Blob(parts);
     }
     return body;
 }

--- a/packages/client/src/store/signed-url.ts
+++ b/packages/client/src/store/signed-url.ts
@@ -126,11 +126,12 @@ async function toReplayableBody(body: BodyInit | null | undefined): Promise<Body
                 // silently uploading a truncated body.
                 parts.push(chunkToBlobPart(value));
             }
-            reader.releaseLock();
         } catch (err) {
             // Signal the producer to stop and release its resources before propagating.
             await reader.cancel(err).catch(() => undefined);
             throw err;
+        } finally {
+            reader.releaseLock();
         }
         return new Blob(parts);
     }

--- a/packages/client/src/store/signed-url.ts
+++ b/packages/client/src/store/signed-url.ts
@@ -91,8 +91,12 @@ function chunkToBlobPart(chunk: unknown): BlobPart {
     if (ArrayBuffer.isView(chunk)) {
         return new Uint8Array(chunk.buffer as ArrayBuffer, chunk.byteOffset, chunk.byteLength);
     }
-    // Unknown chunk type — fall back to its string representation.
-    return textEncoder.encode(String(chunk));
+    // Fail loud rather than uploading e.g. "[object Object]" from an accidental
+    // object-mode stream — silently corrupting the stored content is worse than a clear error.
+    throw new TypeError(
+        `Unsupported signed-URL upload chunk of type "${typeof chunk}"; ` +
+            `body streams must yield string or binary (Uint8Array/ArrayBuffer/DataView/Blob) chunks.`,
+    );
 }
 
 /**


### PR DESCRIPTION
## Summary

The signed-URL transfer helper (`fetchSignedUrl` / `toReplayableBody` in `packages/client/src/store/signed-url.ts`), which retries transient storage failures, buffers a `ReadableStream` body so it can be replayed across retries. It did this with `new Response(stream).blob()`, which under undici throws `TypeError: Received non-Uint8Array chunk` when the stream yields **string** chunks.

That happens for any text/JSON body uploaded as a stream — e.g. a Node `Readable.from(<string>)` converted to a web stream via `Readable.toWeb`, which is exactly how `NodeStreamSource` (the `@vertesia/client/node` source) wraps text content. The result was that **every signed-URL upload of a text body failed** before a single byte was sent.

### Fix
`toReplayableBody` now drains the stream manually and normalizes each chunk to bytes via a new `chunkToBlobPart` helper, then builds the replayable `Blob`:
- `string` → UTF-8 encoded
- `Blob` / `ArrayBuffer` / `Uint8Array` / any typed-array / `DataView` → bytes
- any other (e.g. an accidental object-mode stream) → **throws `TypeError`** rather than silently uploading `"[object Object]"`

Binary streams are unaffected, and the buffered `Blob` is still created once and reused across retries.

## Test Plan
- [x] `cd packages/client && pnpm build` — passes
- [x] `pnpm exec vitest run src/store/signed-url.test.ts` — **11/11 pass**
- [x] `pnpm exec biome check` on the changed files — clean
- [x] Added regression tests: string-chunk stream, mixed string+bytes stream, and object-mode-chunk rejection. Verified in the same runtime that the previous `new Response(stream).blob()` throws `Received non-Uint8Array chunk` on string chunks (and that `Readable.from(<string>)` yields string chunks), so the tests genuinely guard the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>