### PR TITLE
fix(workflow): resolve intake object by id so a superseded revision isn't lost

### DIFF
--- a/.github/bin/update-pnpm-lock.sh
+++ b/.github/bin/update-pnpm-lock.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -euo pipefail
+
+# Required environment variables
+PR_NUMBER=${PR_NUMBER}
+GITHUB_TOKEN=${GITHUB_TOKEN}
+GITHUB_REPOSITORY=${GITHUB_REPOSITORY}
+
+# Extract PR details
+pr_json=$(gh pr view "$PR_NUMBER" --json headRefName,baseRefName)
+PR_BRANCH=$(jq -r '.headRefName' <<< "$pr_json")
+BASE_REF=$(jq -r '.baseRefName' <<< "$pr_json")
+
+git config --global user.email "github-actions[bot]@users.noreply.github.com"
+git config --global user.name "github-actions[bot]"
+
+if [[ -n "${GITHUB_TOKEN:-}" && -n "${GITHUB_REPOSITORY:-}" ]]; then
+  git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+fi
+
+# Fetch branches
+git fetch origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
+git fetch origin "$PR_BRANCH:refs/remotes/origin/$PR_BRANCH"
+
+# Checkout the PR branch
+git checkout -B "$PR_BRANCH" "origin/$PR_BRANCH"
+
+# Merge the base branch into the PR branch. pnpm-lock.yaml conflicts are
+# deterministic: accept one side temporarily, then regenerate the lockfile.
+if ! GIT_MERGE_AUTOEDIT=no git merge --no-edit "origin/$BASE_REF"; then
+  mapfile -t conflicted_files < <(git diff --name-only --diff-filter=U)
+  if [[ "${#conflicted_files[@]}" -ne 1 || "${conflicted_files[0]}" != "pnpm-lock.yaml" ]]; then
+    echo "Merge conflict detected outside pnpm-lock.yaml; skipping lockfile repair." >&2
+    printf 'Unresolved conflicts:\n' >&2
+    printf '  %s\n' "${conflicted_files[@]}" >&2
+    git merge --abort || true
+    exit 2
+  fi
+
+  echo "Only pnpm-lock.yaml conflicted; regenerating it from merged manifests."
+  git checkout --ours pnpm-lock.yaml
+fi
+
+# Use the package manager version declared by the checked-out PR branch.
+PACKAGE_MANAGER=$(node -p "require('./package.json').packageManager || ''")
+if [[ "$PACKAGE_MANAGER" != pnpm@* ]]; then
+  echo "package.json must declare packageManager as pnpm@<version>" >&2
+  exit 1
+fi
+corepack enable
+corepack prepare "$PACKAGE_MANAGER" --activate
+pnpm --version
+
+# Run pnpm install to update the lockfile with the same pnpm version/config as CI.
+pnpm install --lockfile-only
+
+# Commit the merge and/or updated lockfile.
+git add pnpm-lock.yaml
+if [[ -f .git/MERGE_HEAD ]]; then
+  git commit --no-edit
+elif ! git diff --cached --quiet; then
+  git commit -m "chore: update lockfile"
+fi
+
+ahead_count=$(git rev-list --count "origin/$PR_BRANCH"..HEAD)
+if [[ "$ahead_count" == "0" ]]; then
+  echo "No merge or lockfile changes to push."
+  exit 0
+fi
+
+# Push the changes
+git push origin "$PR_BRANCH"
+
+echo "Updated lockfile pushed to branch $PR_BRANCH."

--- a/.github/workflows/automerge-llumiverse.yaml
+++ b/.github/workflows/automerge-llumiverse.yaml
@@ -42,7 +42,9 @@ jobs:
 
           {
             echo "should_merge=false"
+            echo "should_repair_lock=false"
             echo "pr_url="
+            echo "pr_number="
           } >> "$GITHUB_OUTPUT"
 
           prs_json="$(gh pr list \
@@ -118,11 +120,6 @@ jobs:
             echo "Skipping PR #$pr_number: missing workflow:update-llumiverse label."
             exit 0
           fi
-          if [[ "$merge_state" == "DIRTY" ]]; then
-            echo "Skipping PR #$pr_number: PR has merge conflicts."
-            exit 0
-          fi
-
           if ! jq -e '.[0].files | all(.changeType == "MODIFIED")' <<< "$prs_json" >/dev/null; then
             echo "Skipping PR #$pr_number: PR includes non-modified file changes."
             jq -r '.[0].files[] | select(.changeType != "MODIFIED") | "- \(.changeType) \(.path)"' <<< "$prs_json"
@@ -150,6 +147,16 @@ jobs:
             ))
           ' <<< "$prs_json" >/dev/null; then
             echo "Skipping PR #$pr_number: PR contains commits not authored by the sync workflow."
+            exit 0
+          fi
+
+          if [[ "$merge_state" == "DIRTY" ]]; then
+            echo "PR #$pr_number has merge conflicts; attempting pnpm-lock-only repair."
+            {
+              echo "should_repair_lock=true"
+              echo "pr_url=$pr_url"
+              echo "pr_number=$pr_number"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -197,7 +204,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Generate automerge token
-        if: steps.eligibility.outputs.should_merge == 'true'
+        if: steps.eligibility.outputs.should_merge == 'true' || steps.eligibility.outputs.should_repair_lock == 'true'
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
@@ -206,6 +213,46 @@ jobs:
           permission-actions: read
           permission-contents: write
           permission-pull-requests: write
+
+      - name: Checkout PR branch for pnpm lock repair
+        if: steps.eligibility.outputs.should_repair_lock == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+          submodules: false
+          persist-credentials: false
+
+      - name: Init submodules for pnpm workspace
+        if: steps.eligibility.outputs.should_repair_lock == 'true'
+        run: git submodule update --init --recursive --depth=1
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        if: steps.eligibility.outputs.should_repair_lock == 'true'
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        if: steps.eligibility.outputs.should_repair_lock == 'true'
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Repair pnpm lock conflict
+        if: steps.eligibility.outputs.should_repair_lock == 'true'
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.eligibility.outputs.pr_number }}
+        run: |
+          set +e
+          .github/bin/update-pnpm-lock.sh
+          status="$?"
+          set -e
+          if [[ "$status" == "2" ]]; then
+            echo "PR conflict is not pnpm-lock.yaml-only; leaving it for manual resolution."
+            exit 0
+          fi
+          exit "$status"
 
       - name: Approve and merge eligible llumiverse sync PR
         if: steps.eligibility.outputs.should_merge == 'true'

--- a/.github/workflows/renovate-automerge.yaml
+++ b/.github/workflows/renovate-automerge.yaml
@@ -41,7 +41,9 @@ jobs:
 
           {
             echo "should_merge=false"
+            echo "should_repair_lock=false"
             echo "pr_url="
+            echo "pr_number="
           } >> "$GITHUB_OUTPUT"
 
           prs_json="$(gh pr list \
@@ -114,11 +116,6 @@ jobs:
             echo "Skipping PR #$pr_number: missing dependencies label."
             exit 0
           fi
-          if [[ "$merge_state" == "DIRTY" ]]; then
-            echo "Skipping PR #$pr_number: PR has merge conflicts."
-            exit 0
-          fi
-
           if ! jq -e '.[0].files | all(.changeType == "MODIFIED")' <<< "$prs_json" >/dev/null; then
             echo "Skipping PR #$pr_number: PR includes non-modified file changes."
             jq -r '.[0].files[] | select(.changeType != "MODIFIED") | "- \(.changeType) \(.path)"' <<< "$prs_json"
@@ -158,6 +155,16 @@ jobs:
             ))
           ' <<< "$prs_json" >/dev/null; then
             echo "Skipping PR #$pr_number: PR contains commits not authored by Renovate or the lockfile repair workflow."
+            exit 0
+          fi
+
+          if [[ "$merge_state" == "DIRTY" ]]; then
+            echo "PR #$pr_number has merge conflicts; attempting pnpm-lock-only repair."
+            {
+              echo "should_repair_lock=true"
+              echo "pr_url=$pr_url"
+              echo "pr_number=$pr_number"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -205,7 +212,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Generate automerge token
-        if: steps.eligibility.outputs.should_merge == 'true'
+        if: steps.eligibility.outputs.should_merge == 'true' || steps.eligibility.outputs.should_repair_lock == 'true'
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
@@ -214,6 +221,46 @@ jobs:
           permission-actions: read
           permission-contents: write
           permission-pull-requests: write
+
+      - name: Checkout PR branch for pnpm lock repair
+        if: steps.eligibility.outputs.should_repair_lock == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+          submodules: false
+          persist-credentials: false
+
+      - name: Init submodules for pnpm workspace
+        if: steps.eligibility.outputs.should_repair_lock == 'true'
+        run: git submodule update --init --recursive --depth=1
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        if: steps.eligibility.outputs.should_repair_lock == 'true'
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        if: steps.eligibility.outputs.should_repair_lock == 'true'
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Repair pnpm lock conflict
+        if: steps.eligibility.outputs.should_repair_lock == 'true'
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.eligibility.outputs.pr_number }}
+        run: |
+          set +e
+          .github/bin/update-pnpm-lock.sh
+          status="$?"
+          set -e
+          if [[ "$status" == "2" ]]; then
+            echo "PR conflict is not pnpm-lock.yaml-only; leaving it for manual resolution."
+            exit 0
+          fi
+          exit "$status"
 
       - name: Approve and merge eligible Renovate PR
         if: steps.eligibility.outputs.should_merge == 'true'

--- a/packages/workflow/src/activities/extractDocumentText.ts
+++ b/packages/workflow/src/activities/extractDocumentText.ts
@@ -54,12 +54,24 @@ async function extractFromObject(
     objectId: string,
     objectIds: string[],
 ): Promise<TextExtractionResult> {
-    const r = await client.objects.find({
-        query: { _id: objectId },
-        limit: 1,
-        select: '+text',
-    });
-    const doc = r[0] as ContentObject;
+    // Fetch the exact revision by id rather than `find({_id, revision.head:true})`.
+    // `find` filters to HEAD revisions, so if a newer revision is created while this
+    // intake is in flight (e.g. an update with `createRevision: true`), the original
+    // revision this workflow was queued for becomes non-head and `find` returns empty —
+    // failing intake with a spurious "not found" even though the revision still exists.
+    // A direct GET by id resolves the specific revision regardless of head.
+    let doc: ContentObject;
+    try {
+        doc = (await client.objects.retrieve(objectId, '+text')) as ContentObject;
+    } catch (err: unknown) {
+        const status =
+            err && typeof err === 'object' && 'status' in err ? (err as { status?: number }).status : undefined;
+        if (status === 404) {
+            log.error(`Document ${objectId} not found`);
+            throw new DocumentNotFoundError(`Document ${objectId} not found`, objectIds);
+        }
+        throw err;
+    }
     if (!doc) {
         log.error(`Document ${objectId} not found`);
         throw new DocumentNotFoundError(`Document ${objectId} not found`, objectIds);


### PR DESCRIPTION
## Summary

`extractDocumentText` (object mode) resolved the object with
`objects.find({ query: { _id }, ..., select: '+text' })`. The `/find` endpoint filters to
**HEAD revisions** (`revision.head: true`), so if a newer revision is created while this
activity is in flight, the revision the workflow was queued for becomes non-head and the
`find` returns empty — the activity then throws `DocumentNotFoundError` even though the
revision still exists. The result is spurious intake failures (and the superseded revision
never gets its text extracted/indexed).

Switch to a direct fetch by id:

```ts
doc = await client.objects.retrieve(objectId, '+text'); // GET /:id — not HEAD-filtered
```

`GET /:id` does a plain lookup by id, so it resolves the exact revision regardless of which
one is currently head. A genuine `404` is still mapped to `DocumentNotFoundError`; non-404
errors are rethrown unchanged (no longer masked as "not found").

## Test Plan
- [x] `pnpm --filter @vertesia/workflow build` — workflow bundle builds
- [x] `pnpm exec biome check` on the changed file — clean
- [x] Behaviour is exercised end-to-end by the downstream revision/indexing integration tests
      (a property-only revision created before its parent finished processing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>