### PR TITLE
fix: better ImageMagic memory handling

### DIFF
--- a/packages/workflow/src/activities/renditions/generateImageRendition.ts
+++ b/packages/workflow/src/activities/renditions/generateImageRendition.ts
@@ -1,5 +1,6 @@
 import { log } from "@temporalio/activity";
 import { DSLActivityExecutionPayload, DSLActivitySpec } from "@vertesia/common";
+import fs from "fs";
 import { setupActivity } from "../../dsl/setup/ActivityContext.js";
 import { DocumentNotFoundError, WorkflowParamNotFoundError } from "../../errors.js";
 import { saveBlobToTempFile } from "../../utils/blobs.js";
@@ -72,40 +73,47 @@ export async function generateImageRendition(
         );
     }
 
-    //array of rendition files to upload
-    let renditionPages: string[] = [];
+    let imageFile: string | undefined;
 
-    const imageFile = await saveBlobToTempFile(
-        client,
-        inputObject.content.source,
-    );
-    log.debug(`Image ${objectId} copied to ${imageFile}`);
-    renditionPages.push(imageFile);
-
-
-    //IF no etag, log and use use object id as etag
-    if (!inputObject.content.etag) {
-        log.warn(`Document ${objectId} has no etag, using object id as etag`);
-    }
-    const contentEtag = inputObject.content.etag ?? inputObject.id;
-
-    const uploaded = await uploadRenditionPages(
-        client,
-        contentEtag,
-        [imageFile],
-        params,
-    );
-
-    if (!uploaded || !uploaded.length || !uploaded[0]) {
-        log.error(`Failed to upload rendition for ${objectId}`, { uploaded });
-        throw new Error(
-            `Failed to upload rendition for ${objectId} - upload object is empty`,
+    try {
+        imageFile = await saveBlobToTempFile(
+            client,
+            inputObject.content.source,
         );
-    }
+        log.debug(`Image ${objectId} copied to ${imageFile}`);
 
-    return {
-        uploads: uploaded.map((u) => u),
-        format: params.format,
-        status: "success",
-    };
+        //IF no etag, log and use use object id as etag
+        if (!inputObject.content.etag) {
+            log.warn(`Document ${objectId} has no etag, using object id as etag`);
+        }
+        const contentEtag = inputObject.content.etag ?? inputObject.id;
+
+        const uploaded = await uploadRenditionPages(
+            client,
+            contentEtag,
+            [imageFile],
+            params,
+        );
+
+        if (!uploaded || !uploaded.length || !uploaded[0]) {
+            log.error(`Failed to upload rendition for ${objectId}`, { uploaded });
+            throw new Error(
+                `Failed to upload rendition for ${objectId} - upload object is empty`,
+            );
+        }
+
+        return {
+            uploads: uploaded.map((u) => u),
+            format: params.format,
+            status: "success",
+        };
+    } finally {
+        if (imageFile) {
+            try {
+                await fs.promises.unlink(imageFile);
+            } catch (err) {
+                log.warn(`Failed to clean temporary image file for ${objectId}`, { err });
+            }
+        }
+    }
 }

--- a/packages/workflow/src/conversion/image.ts
+++ b/packages/workflow/src/conversion/image.ts
@@ -75,11 +75,11 @@ export async function imageResizer(
 
         log.debug(`Resizing image using ImageMagick: ${inputPath} -> ${outputPath}`);
 
-        const command = `convert`
-        let args = [inputPath];
+        const command = "convert";
+        const args = ["-define", `jpeg:size=${max_hw * 3}x${max_hw * 3}`];
 
-        // Add JPEG shrink-on-load optimization
-        args.push("-define", `jpeg:size=${max_hw * 3}x${max_hw * 3}`);
+        // Add input after JPEG shrink-on-load optimization so ImageMagick can apply it while decoding.
+        args.push(inputPath);
 
         // Remove metadata
         args.push("-strip");

--- a/packages/workflow/src/utils/renditions.ts
+++ b/packages/workflow/src/utils/renditions.ts
@@ -68,7 +68,7 @@ export async function uploadRenditionPages(
                 ? params.outputPath
                 : `${params.outputPath}/${String(i).padStart(4, "0")}.${params.format}`)
             : getRenditionPagePath(contentEtag, params, i);
-        let resizedImagePath = null;
+        let resizedImagePath: string | undefined;
 
         try {
             log.debug(`Resizing image for ${contentEtag} page ${i}`, {
@@ -126,6 +126,14 @@ export async function uploadRenditionPages(
                 error: err,
             });
             return Promise.reject(`Upload failed: ${err.message}`);
+        } finally {
+            if (resizedImagePath) {
+                try {
+                    fs.unlinkSync(resizedImagePath);
+                } catch (err) {
+                    log.warn(`Failed to clean resized rendition file for ${contentEtag} page ${i}`, { err });
+                }
+            }
         }
     }));
 


### PR DESCRIPTION
## Summary
- Clean downloaded source image temp files after image rendition generation.
- Clean resized ImageMagick output files after upload.
- Reduce repeated local temp/cache pressure during large image rendition workflows.

## Test Plan
- `pnpm --dir composableai/packages/workflow build`
- Image conversion tests: 5 passed