### PR TITLE
feat: allow multiple new line keyboard combos to send message

### DIFF
--- a/packages/ui/src/core/utils/index.ts
+++ b/packages/ui/src/core/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './a11y.js';
 export * from './cn.js';
 export * from './errorMessage.js';
+export * from './textarea.js';

--- a/packages/ui/src/core/utils/textarea.ts
+++ b/packages/ui/src/core/utils/textarea.ts
@@ -1,0 +1,15 @@
+/**
+ * Splice "\n" at the caret in a controlled textarea, then restore the caret
+ * position after React re-renders with the new value. Used for the modifier+Enter
+ * combos (Cmd/Ctrl/Alt+Enter) that browsers don't natively turn into a newline.
+ */
+export function insertNewlineAtCursor(textarea: HTMLTextAreaElement, onChange?: (text: string) => void): void {
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const value = textarea.value;
+    const next = `${value.slice(0, start)}\n${value.slice(end)}`;
+    onChange?.(next);
+    requestAnimationFrame(() => {
+        textarea.selectionStart = textarea.selectionEnd = start + 1;
+    });
+}

--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
@@ -12,6 +12,7 @@ import { FusionFragmentProvider } from '@vertesia/fusion-ux';
 import {
     Button,
     cn,
+    insertNewlineAtCursor,
     MessageBox,
     Modal,
     ModalBody,
@@ -505,11 +506,19 @@ function StartWorkflowView({
     };
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-        if (e.key === 'Enter' && !e.shiftKey) {
+        if (e.key !== 'Enter') return;
+        const hasModifier = e.metaKey || e.ctrlKey || e.altKey || e.shiftKey;
+        if (!hasModifier) {
+            // Plain Enter sends.
             e.preventDefault();
             void startWorkflowWithMessage();
+            return;
         }
-        // Shift+Enter allows newline (default textarea behavior)
+        // Shift+Enter inserts \n natively; Cmd/Ctrl/Alt+Enter do not in most browsers.
+        if (!e.shiftKey) {
+            e.preventDefault();
+            insertNewlineAtCursor(e.currentTarget, setInputValue);
+        }
     };
 
     // Auto-resize textarea as content grows

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageInput.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageInput.tsx
@@ -1,5 +1,15 @@
 import { type ContentObjectItem, type ConversationFile, FileProcessingStatus } from '@vertesia/common';
-import { Button, cn, Modal, ModalBody, ModalTitle, Spinner, Textarea, VTooltip } from '@vertesia/ui/core';
+import {
+    Button,
+    cn,
+    insertNewlineAtCursor,
+    Modal,
+    ModalBody,
+    ModalTitle,
+    Spinner,
+    Textarea,
+    VTooltip,
+} from '@vertesia/ui/core';
 import { useUITranslation } from '@vertesia/ui/i18n';
 import {
     Activity,
@@ -256,15 +266,23 @@ export default function MessageInput({
     const lastEscapeRef = useRef<number>(0);
 
     const keyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-        if (e.key === 'Enter' && !e.shiftKey) {
-            e.preventDefault();
-            const hasMessage = value.trim().length > 0;
-
-            if (hasMessage) {
-                // If there's a message, send it (this will interrupt + send message via UserInput signal)
-                handleSend();
+        if (e.key === 'Enter') {
+            const hasModifier = e.metaKey || e.ctrlKey || e.altKey || e.shiftKey;
+            if (!hasModifier) {
+                // Plain Enter sends. Enter with no text does nothing (don't stop, don't send).
+                e.preventDefault();
+                if (value.trim().length > 0) {
+                    // If there's a message, send it (this will interrupt + send message via UserInput signal)
+                    handleSend();
+                }
+                return;
             }
-            // Enter with no text does nothing (don't stop, don't send)
+            // Shift+Enter inserts \n natively; Cmd/Ctrl/Alt+Enter do not in most browsers.
+            if (!e.shiftKey) {
+                e.preventDefault();
+                insertNewlineAtCursor(e.currentTarget, setValue);
+            }
+            return;
         }
 
         // Double Escape to stop the agent
@@ -278,7 +296,6 @@ export default function MessageInput({
                 lastEscapeRef.current = now;
             }
         }
-        // Shift+Enter allows newline (default textarea behavior)
     };
 
     // Auto-resize textarea as content grows


### PR DESCRIPTION
## Summary
- In the agent conversation message inputs, plain **Enter** sends the message.
- Any **Enter held with a modifier** (Shift, Ctrl, Alt, or Cmd/Meta) inserts a newline instead.

## Test Plan
- [x] `@vertesia/ui` builds (tsc + rollup) and Biome passes on the changed files
- [ ] Manually verify Enter sends and each modifier+Enter adds a newline in the agent chat composer

🤖 Generated with [Claude Code](https://claude.com/claude-code)