### PR TITLE
fix: harden plugin template app shell

### DIFF
--- a/templates/plugin-template/index.html
+++ b/templates/plugin-template/index.html
@@ -25,16 +25,60 @@
       } catch (_e) {}
     })();
   </script>
-  <script type="importmap">
-      {
-        "imports": {
-          "react": "https://esm.sh/react@19.1.2",
-          "react-dom": "https://esm.sh/react-dom@19.1.2",
-          "react-dom/client": "https://esm.sh/react-dom@19.1.2/client",
-          "react/jsx-runtime": "https://esm.sh/react@19.1.2/jsx-runtime"
+  <!-- vertesia-react-importmap -->
+  <script>
+    (() => {
+      const reloadParam = '__vertesia_reload';
+      const storageKey = 'vertesia:stale-asset-reload';
+
+      function isLocalDevHost() {
+        return ['localhost', '127.0.0.1', '0.0.0.0', '::1'].includes(window.location.hostname);
+      }
+
+      function reloadOnce() {
+        if (isLocalDevHost()) return;
+
+        try {
+          const url = new URL(window.location.href);
+          const reloadKey = window.location.origin + window.location.pathname;
+          const alreadyRetried =
+            url.searchParams.has(reloadParam) || window.sessionStorage.getItem(storageKey) === reloadKey;
+
+          if (alreadyRetried) return;
+
+          window.sessionStorage.setItem(storageKey, reloadKey);
+          url.searchParams.set(reloadParam, String(Date.now()));
+          window.location.replace(url.toString());
+        } catch (error) {
+          console.error('Failed to recover from stale asset load:', error);
         }
       }
-    </script>
+
+      window.addEventListener('vite:preloadError', (event) => {
+        if (typeof event.preventDefault === 'function') event.preventDefault();
+        reloadOnce();
+      });
+
+      window.addEventListener(
+        'error',
+        (event) => {
+          if (event.target && (event.target.tagName === 'SCRIPT' || event.target.tagName === 'LINK')) {
+            reloadOnce();
+          }
+        },
+        true,
+      );
+
+      window.addEventListener('load', () => {
+        try {
+          const url = new URL(window.location.href);
+          if (!url.searchParams.has(reloadParam)) return;
+          url.searchParams.delete(reloadParam);
+          window.history.replaceState(window.history.state, document.title, url.pathname + url.search + url.hash);
+        } catch (_error) {}
+      });
+    })();
+  </script>
 </head>
 
 <body>

--- a/templates/plugin-template/index.html
+++ b/templates/plugin-template/index.html
@@ -26,59 +26,7 @@
     })();
   </script>
   <!-- vertesia-react-importmap -->
-  <script>
-    (() => {
-      const reloadParam = '__vertesia_reload';
-      const storageKey = 'vertesia:stale-asset-reload';
-
-      function isLocalDevHost() {
-        return ['localhost', '127.0.0.1', '0.0.0.0', '::1'].includes(window.location.hostname);
-      }
-
-      function reloadOnce() {
-        if (isLocalDevHost()) return;
-
-        try {
-          const url = new URL(window.location.href);
-          const reloadKey = window.location.origin + window.location.pathname;
-          const alreadyRetried =
-            url.searchParams.has(reloadParam) || window.sessionStorage.getItem(storageKey) === reloadKey;
-
-          if (alreadyRetried) return;
-
-          window.sessionStorage.setItem(storageKey, reloadKey);
-          url.searchParams.set(reloadParam, String(Date.now()));
-          window.location.replace(url.toString());
-        } catch (error) {
-          console.error('Failed to recover from stale asset load:', error);
-        }
-      }
-
-      window.addEventListener('vite:preloadError', (event) => {
-        if (typeof event.preventDefault === 'function') event.preventDefault();
-        reloadOnce();
-      });
-
-      window.addEventListener(
-        'error',
-        (event) => {
-          if (event.target && (event.target.tagName === 'SCRIPT' || event.target.tagName === 'LINK')) {
-            reloadOnce();
-          }
-        },
-        true,
-      );
-
-      window.addEventListener('load', () => {
-        try {
-          const url = new URL(window.location.href);
-          if (!url.searchParams.has(reloadParam)) return;
-          url.searchParams.delete(reloadParam);
-          window.history.replaceState(window.history.state, document.title, url.pathname + url.search + url.hash);
-        } catch (_error) {}
-      });
-    })();
-  </script>
+  <!-- vertesia-stale-asset-recovery -->
 </head>
 
 <body>

--- a/templates/plugin-template/vercel.json
+++ b/templates/plugin-template/vercel.json
@@ -20,10 +20,24 @@
     },
     {
       "source": "/app",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": ".*text/html.*"
+        }
+      ],
       "destination": "/app/index.html"
     },
     {
       "source": "/app/(.*)",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": ".*text/html.*"
+        }
+      ],
       "destination": "/app/index.html"
     }
   ],
@@ -42,6 +56,38 @@
         {
           "key": "Access-Control-Allow-Headers",
           "value": "Content-Type, Authorization"
+        }
+      ]
+    },
+    {
+      "source": "/app",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": ".*text/html.*"
+        }
+      ],
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache, no-store, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/app/(.*)",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": ".*text/html.*"
+        }
+      ],
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache, no-store, max-age=0, must-revalidate"
         }
       ]
     }

--- a/templates/plugin-template/vite.config.ts
+++ b/templates/plugin-template/vite.config.ts
@@ -201,6 +201,7 @@ function defineAppConfig({ command }: ConfigEnv): UserConfig {
     // Vercel dev proxies to the framework dev server over HTTP — HTTPS would break that.
     const useHttps = !process.env.VERCEL;
     const base = command === 'build' ? '/app/' : '/';
+    const isVercelBuild = command === 'build' && process.env.VERCEL === '1';
 
     return {
         base, // Dev serves the admin UI at /; Vercel serves built app assets from /app/.
@@ -208,7 +209,7 @@ function defineAppConfig({ command }: ConfigEnv): UserConfig {
             tailwindcss(),
             react(),
             reactImportMapPlugin(),
-            staleAssetRecoveryPlugin(command === 'build'),
+            staleAssetRecoveryPlugin(isVercelBuild),
             // HTTPS is required for Firebase auth but must be disabled under vercel dev
             ...(useHttps ? [basicSsl()] : []),
             // serve lib/plugin.js content in dev mode

--- a/templates/plugin-template/vite.config.ts
+++ b/templates/plugin-template/vite.config.ts
@@ -35,6 +35,7 @@ const VERTESIA_UI_PATH = '';
 const CONFIG__inlineCss = false;
 const REACT_IMPORT_MAP_PLACEHOLDER = '<!-- vertesia-react-importmap -->';
 const nodeRequire = createRequire(import.meta.url);
+let cachedReactImportMapHtml: string | undefined;
 
 function getPackageVersion(packageName: string): string {
     const packageJsonPath = nodeRequire.resolve(`${packageName}/package.json`);
@@ -46,8 +47,18 @@ function getPackageVersion(packageName: string): string {
 }
 
 function getReactImportMapHtml(): string {
+    if (cachedReactImportMapHtml) {
+        return cachedReactImportMapHtml;
+    }
+
     const reactVersion = getPackageVersion('react');
     const reactDomVersion = getPackageVersion('react-dom');
+    if (reactVersion !== reactDomVersion) {
+        throw new Error(
+            `React import map requires react and react-dom versions to match; got ${reactVersion} and ${reactDomVersion}`,
+        );
+    }
+
     const imports = {
         react: `https://esm.sh/react@${reactVersion}`,
         'react-dom': `https://esm.sh/react-dom@${reactDomVersion}`,
@@ -56,9 +67,10 @@ function getReactImportMapHtml(): string {
         'react/jsx-dev-runtime': `https://esm.sh/react@${reactVersion}/jsx-dev-runtime`,
     };
 
-    return `<script type="importmap">
+    cachedReactImportMapHtml = `<script type="importmap">
 ${JSON.stringify({ imports }, null, 2)}
   </script>`;
+    return cachedReactImportMapHtml;
 }
 
 function reactImportMapPlugin(): Plugin {

--- a/templates/plugin-template/vite.config.ts
+++ b/templates/plugin-template/vite.config.ts
@@ -34,6 +34,7 @@ const VERTESIA_UI_PATH = '';
  */
 const CONFIG__inlineCss = false;
 const REACT_IMPORT_MAP_PLACEHOLDER = '<!-- vertesia-react-importmap -->';
+const STALE_ASSET_RECOVERY_PLACEHOLDER = '<!-- vertesia-stale-asset-recovery -->';
 const nodeRequire = createRequire(import.meta.url);
 let cachedReactImportMapHtml: string | undefined;
 
@@ -82,6 +83,65 @@ function reactImportMapPlugin(): Plugin {
                 return html.replace(REACT_IMPORT_MAP_PLACEHOLDER, importMapHtml);
             }
             return html.replace('</head>', `  ${importMapHtml}\n</head>`);
+        },
+    };
+}
+
+function getStaleAssetRecoveryHtml(): string {
+    return `<script>
+    (() => {
+      const reloadParam = '__vertesia_reload';
+      const storageKey = 'vertesia:stale-asset-reload';
+
+      function reloadOnce() {
+        try {
+          const url = new URL(window.location.href);
+          const reloadKey = window.location.origin + window.location.pathname;
+          const alreadyRetried =
+            url.searchParams.has(reloadParam) || window.sessionStorage.getItem(storageKey) === reloadKey;
+
+          if (alreadyRetried) return;
+
+          window.sessionStorage.setItem(storageKey, reloadKey);
+          url.searchParams.set(reloadParam, String(Date.now()));
+          window.location.replace(url.toString());
+        } catch (error) {
+          console.error('Failed to recover from stale asset load:', error);
+        }
+      }
+
+      window.addEventListener('vite:preloadError', (event) => {
+        if (typeof event.preventDefault === 'function') event.preventDefault();
+        reloadOnce();
+      });
+
+      window.addEventListener(
+        'error',
+        (event) => {
+          if (event.target && (event.target.tagName === 'SCRIPT' || event.target.tagName === 'LINK')) {
+            reloadOnce();
+          }
+        },
+        true,
+      );
+
+      window.addEventListener('load', () => {
+        try {
+          const url = new URL(window.location.href);
+          if (!url.searchParams.has(reloadParam)) return;
+          url.searchParams.delete(reloadParam);
+          window.history.replaceState(window.history.state, document.title, url.pathname + url.search + url.hash);
+        } catch (_error) {}
+      });
+    })();
+  </script>`;
+}
+
+function staleAssetRecoveryPlugin(enabled: boolean): Plugin {
+    return {
+        name: 'vertesia-stale-asset-recovery',
+        transformIndexHtml(html) {
+            return html.replace(STALE_ASSET_RECOVERY_PLACEHOLDER, enabled ? getStaleAssetRecoveryHtml() : '');
         },
     };
 }
@@ -148,6 +208,7 @@ function defineAppConfig({ command }: ConfigEnv): UserConfig {
             tailwindcss(),
             react(),
             reactImportMapPlugin(),
+            staleAssetRecoveryPlugin(command === 'build'),
             // HTTPS is required for Firebase auth but must be disabled under vercel dev
             ...(useHttps ? [basicSsl()] : []),
             // serve lib/plugin.js content in dev mode

--- a/templates/plugin-template/vite.config.ts
+++ b/templates/plugin-template/vite.config.ts
@@ -226,6 +226,10 @@ function defineAppConfig({ command }: ConfigEnv): UserConfig {
         },
         // for authentication with Firebase
         server: {
+            // Bind IPv4 loopback so Vite detects an existing 127.0.0.1 listener and falls through.
+            host: '127.0.0.1',
+            port: 5173,
+            strictPort: false,
             proxy: {
                 '/__/auth': {
                     target: 'https://dengenlabs.firebaseapp.com',

--- a/templates/plugin-template/vite.config.ts
+++ b/templates/plugin-template/vite.config.ts
@@ -1,8 +1,10 @@
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import tailwindcss from '@tailwindcss/vite';
 import { vertesiaPluginBuilder } from '@vertesia/plugin-builder';
 import basicSsl from '@vitejs/plugin-basic-ssl';
 import react from '@vitejs/plugin-react';
-import { type ConfigEnv, defineConfig, type UserConfig } from 'vite';
+import { type ConfigEnv, defineConfig, type Plugin, type UserConfig } from 'vite';
 import serveStatic from 'vite-plugin-serve-static';
 import { apiServerPlugin } from './vite-api-server.js';
 
@@ -31,6 +33,46 @@ const VERTESIA_UI_PATH = '';
  * If you use shadow dom isolation for the plugin you must set this to false.
  */
 const CONFIG__inlineCss = false;
+const REACT_IMPORT_MAP_PLACEHOLDER = '<!-- vertesia-react-importmap -->';
+const nodeRequire = createRequire(import.meta.url);
+
+function getPackageVersion(packageName: string): string {
+    const packageJsonPath = nodeRequire.resolve(`${packageName}/package.json`);
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as { version?: string };
+    if (!packageJson.version) {
+        throw new Error(`Unable to resolve ${packageName} package version`);
+    }
+    return packageJson.version;
+}
+
+function getReactImportMapHtml(): string {
+    const reactVersion = getPackageVersion('react');
+    const reactDomVersion = getPackageVersion('react-dom');
+    const imports = {
+        react: `https://esm.sh/react@${reactVersion}`,
+        'react-dom': `https://esm.sh/react-dom@${reactDomVersion}`,
+        'react-dom/client': `https://esm.sh/react-dom@${reactDomVersion}/client`,
+        'react/jsx-runtime': `https://esm.sh/react@${reactVersion}/jsx-runtime`,
+        'react/jsx-dev-runtime': `https://esm.sh/react@${reactVersion}/jsx-dev-runtime`,
+    };
+
+    return `<script type="importmap">
+${JSON.stringify({ imports }, null, 2)}
+  </script>`;
+}
+
+function reactImportMapPlugin(): Plugin {
+    return {
+        name: 'vertesia-react-import-map',
+        transformIndexHtml(html) {
+            const importMapHtml = getReactImportMapHtml();
+            if (html.includes(REACT_IMPORT_MAP_PLACEHOLDER)) {
+                return html.replace(REACT_IMPORT_MAP_PLACEHOLDER, importMapHtml);
+            }
+            return html.replace('</head>', `  ${importMapHtml}\n</head>`);
+        },
+    };
+}
 
 /**
  * Vite configuration to build the plugin as a library or as a standalone application or to run the application in dev mode.
@@ -93,6 +135,7 @@ function defineAppConfig({ command }: ConfigEnv): UserConfig {
         plugins: [
             tailwindcss(),
             react(),
+            reactImportMapPlugin(),
             // HTTPS is required for Firebase auth but must be disabled under vercel dev
             ...(useHttps ? [basicSsl()] : []),
             // serve lib/plugin.js content in dev mode


### PR DESCRIPTION
## Summary
- Generate the plugin template's React import map from the installed `react` and `react-dom` package versions during Vite HTML transforms.
- Add one-shot stale asset recovery for the standalone plugin app while skipping local dev hosts.
- Restrict Vercel `/app` SPA rewrites and no-store headers to HTML navigation requests so missing asset requests do not receive `index.html`.

## Test Plan
- [x] `pnpm --prefix composableai/templates/plugin-template build`
- [x] `pnpm --prefix composableai/templates/plugin-template exec biome lint vite.config.ts`
- [x] `git -C composableai diff --check`
