### PR TITLE
Feat: preview icons across table

### DIFF
--- a/packages/ui/src/core/components/SidePanel.tsx
+++ b/packages/ui/src/core/components/SidePanel.tsx
@@ -106,7 +106,7 @@ export function SidePanel({
                                             // biome-ignore lint/a11y/useAriaPropsSupportedByRole: aria-label kept for AT users; div has no semantic role because separator/slider would require valuenow/min/max
                                             <div
                                                 aria-label="Resize panel"
-                                                className={`absolute ${dragHandleClass} top-0 bottom-0 w-3 cursor-ew-resize hover:bg-indigo-500 transition-colors flex items-center justify-center`}
+                                                className={`absolute ${dragHandleClass} top-0 bottom-0 w-3 z-25 cursor-ew-resize hover:bg-indigo-500 transition-colors flex items-center justify-center`}
                                                 onMouseDown={handleDragStart}
                                             >
                                                 <Minus className="rotate-90 font-semibold" strokeWidth={4} />

--- a/packages/ui/src/features/store/objects/components/ContentOverview.tsx
+++ b/packages/ui/src/features/store/objects/components/ContentOverview.tsx
@@ -195,22 +195,21 @@ export function ContentOverview({ object, loadText, refetch, canEditProperties =
 
     return (
         <ResizablePanelGroup direction="horizontal" className="h-full">
-            <ResizablePanel className="min-w-[100px]">
-                <PropertiesPanel
-                    object={object}
-                    refetch={refetch ?? (() => Promise.resolve())}
-                    handleCopyContent={handleCopyContent}
-                    canEditProperties={canEditProperties}
-                />
-            </ResizablePanel>
-            <ResizableHandle withHandle />
-
-            <ResizablePanel className="min-w-[100px]">
+            <ResizablePanel defaultSize={67} className="min-w-[100px]">
                 <DataPanel
                     object={object}
                     loadText={loadText ?? false}
                     handleCopyContent={handleCopyContent}
                     refetch={refetch}
+                />
+            </ResizablePanel>
+            <ResizableHandle withHandle />
+            <ResizablePanel defaultSize={33} className="min-w-[100px]">
+                <PropertiesPanel
+                    object={object}
+                    refetch={refetch ?? (() => Promise.resolve())}
+                    handleCopyContent={handleCopyContent}
+                    canEditProperties={canEditProperties}
                 />
             </ResizablePanel>
         </ResizablePanelGroup>

--- a/packages/ui/src/features/store/objects/layout/renderers.tsx
+++ b/packages/ui/src/features/store/objects/layout/renderers.tsx
@@ -130,12 +130,10 @@ const renderers: Record<
             const objectId = getObjectId(value);
             const displayValue = transforms.reduce((v, t) => t(v), objectId);
             return (
-                <td key={index} className="flex justify-between items-center gap-2">
-                    {hasSlice ? '~' : ''}
-                    {displayValue}
+                <td key={index} className="flex justify-start items-center gap-2">
                     <Button
                         variant="ghost"
-                        alt="Preview Object"
+                        title="Preview Object"
                         onClick={(e) => {
                             e.stopPropagation();
                             onClick?.(objectId);
@@ -143,6 +141,8 @@ const renderers: Record<
                     >
                         <Eye className="size-4" />
                     </Button>
+                    {hasSlice ? '~' : ''}
+                    {displayValue}
                 </td>
             );
         };


### PR DESCRIPTION
## Description 
- Move the preview (eye) to the left of the ID in the object table layouts.
- Move the preview (eye) to the left of the ID in the runs table layouts.
