### PR TITLE
feat(common): add app:manage permission

### DIFF
--- a/packages/common/src/access-control.ts
+++ b/packages/common/src/access-control.ts
@@ -17,6 +17,7 @@ export enum Permission {
 
     env_admin = 'environment:admin',
 
+    app_manage = 'app:manage',
     project_admin = 'project:admin',
     project_integration_read = 'project:integration_read',
     project_settings_write = 'project:settings_write',


### PR DESCRIPTION
## Summary
- Adds the `app:manage` permission (`app_manage = 'app:manage'`) to the `Permission` enum in `packages/common/src/access-control.ts`, placed immediately before `project_admin`.

## Behavior
- The Owner and Admin roles are granted `Object.values(Permission)` in `packages/common/src/roles.ts`, so `app:manage` is automatically included in those roles. No change to `roles.ts` is required.
- The OAuth scope helpers in `packages/common/src/oauth-scopes.ts` derive the set of supported OAuth permission scopes from `Object.values(Permission)` minus a fixed blocklist (`NON_OAUTH_PERMISSION_SCOPES`). `app:manage` is not in that blocklist, so it automatically becomes a supported OAuth permission scope (`getOAuthPermissionScopes` / `isOAuthSupportedScope`). No change to `oauth-scopes.ts` is required.

## Test Plan
- [x] `pnpm turbo build --filter @vertesia/common` succeeds (tsc + rollup).
- [x] Biome lint passes on the changed file (pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>