### PR TITLE
feat(ui): preprod visual indicator

### DIFF
--- a/packages/ui/src/css/color.css
+++ b/packages/ui/src/css/color.css
@@ -60,8 +60,8 @@
   --topnav-border: oklch(0.922 0 0);
   --topnav-ring: oklch(0.708 0 0);
 
+  --preprod: oklch(63.89% 0.103 201.59);
   --preview: oklch(46.95% 0.233 303.17);
-  --staging: oklch(63.89% 0.103 201.59);
   --development: oklch(44.30% 0.193 261.11);
 
 }
@@ -129,8 +129,8 @@
   --topnav-border: oklch(0.269 0 0);
   --topnav-ring: oklch(0.439 0 0);
 
+  --preprod: oklch(63.89% 0.103 201.59);
   --preview: oklch(46.95% 0.233 303.17);
-  --staging: oklch(63.89% 0.103 201.59);
   --development: oklch(44.30% 0.193 261.11);
 
 }

--- a/packages/ui/src/css/theme.css
+++ b/packages/ui/src/css/theme.css
@@ -73,8 +73,8 @@
   --color-topnav-border: var(--topnav-border);
   --color-topnav-ring: var(--topnav-ring);
 
+  --color-preprod: var(--preprod);
   --color-preview: var(--preview);
-  --color-staging: var(--staging);
   --color-development: var(--development);
 
   --font-sans:


### PR DESCRIPTION
The old "staging" environment no longer exists, so the new "preprod" now takes over the same teal color token used for the env indicator badge. Token renamed and reordered to reflect environment progression.