### PR TITLE
feat(ui): resolve documents/ artifact paths as direct project files

### DIFF
--- a/packages/ui/src/features/agent/chat/VegaLiteChart.tsx
+++ b/packages/ui/src/features/agent/chat/VegaLiteChart.tsx
@@ -10,7 +10,7 @@ import type { View } from 'vega';
 import type { TopLevelSpec as VisualizationSpec } from 'vega-lite';
 import { cn } from '../../../core/components/libs/utils';
 import type { VegaLiteChartSpec } from './AgentChart';
-import { getArtifactCacheKey, getFileCacheKey, useArtifactUrlCache } from './useArtifactUrlCache';
+import { getArtifactCacheKey, getFileCacheKey, isProjectFilePath, useArtifactUrlCache } from './useArtifactUrlCache';
 
 type VegaLiteChartProps = {
     spec: VegaLiteChartSpec;
@@ -658,7 +658,7 @@ export const VegaLiteChart = memo(
                         let url: string;
 
                         // Determine if this is a shorthand path or full path
-                        if (artifactRunId && !ref.artifactPath.startsWith('agents/')) {
+                        if (artifactRunId && !isProjectFilePath(ref.artifactPath)) {
                             // Shorthand path - use artifact API
                             const cacheKey = getArtifactCacheKey(artifactRunId, ref.artifactPath, 'inline');
                             if (currentUrlCache) {

--- a/packages/ui/src/features/agent/chat/useArtifactUrlCache.tsx
+++ b/packages/ui/src/features/agent/chat/useArtifactUrlCache.tsx
@@ -67,6 +67,15 @@ export function useArtifactUrlCache(): ArtifactUrlCacheContextValue | null {
 }
 
 /**
+ * Whether an artifact: path points directly into the project bucket
+ * (agents/ run prefixes, documents/ repository copies made by create_document)
+ * rather than being a run-local shorthand like out/chart.png.
+ */
+export function isProjectFilePath(path: string): boolean {
+    return path.startsWith('agents/') || path.startsWith('documents/');
+}
+
+/**
  * Generate a cache key for an artifact URL.
  */
 export function getArtifactCacheKey(runId: string, path: string, disposition: string = 'inline'): string {

--- a/packages/ui/src/widgets/markdown/useResolvedUrl.ts
+++ b/packages/ui/src/widgets/markdown/useResolvedUrl.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import {
     getArtifactCacheKey,
     getFileCacheKey,
+    isProjectFilePath,
     useArtifactUrlCache,
 } from '../../features/agent/chat/useArtifactUrlCache';
 
@@ -107,7 +108,7 @@ export function useResolvedUrl({
         // For artifact/image schemes, check cache first
         if (urlCache && (scheme === 'artifact' || scheme === 'image')) {
             let cacheKey: string;
-            if (scheme === 'artifact' && artifactRunId && !path.startsWith('agents/')) {
+            if (scheme === 'artifact' && artifactRunId && !isProjectFilePath(path)) {
                 cacheKey = getArtifactCacheKey(artifactRunId, path, disposition);
             } else {
                 cacheKey = getFileCacheKey(path);
@@ -143,7 +144,7 @@ export function useResolvedUrl({
             let url: string;
 
             if (scheme === 'artifact') {
-                if (artifactRunId && !path.startsWith('agents/')) {
+                if (artifactRunId && !isProjectFilePath(path)) {
                     const cacheKey = getArtifactCacheKey(artifactRunId, path, disposition);
                     if (currentUrlCache) {
                         url = await currentUrlCache.getOrFetch(cacheKey, async () => {


### PR DESCRIPTION
## Summary
- Document-persistence tooling now copies run-local artifacts referenced by `artifact:` links into durable storage under a `documents/{batchId}/` prefix, instead of leaving them in the run-scoped `agents/{runId}/` prefix.
- Teach artifact URL resolution to treat the `documents/` prefix like `agents/`: a direct project-bucket file download rather than a run-scoped artifact lookup.
- Extract a shared `isProjectFilePath()` helper in `useArtifactUrlCache` and use it in `useResolvedUrl` (markdown links/images) and `VegaLiteChart` (chart data references), replacing the duplicated `startsWith('agents/')` checks.

## Test Plan
- [x] CI: Build and test, Lint — green on this branch
- [x] Links rewritten to `artifact:documents/…` resolve in both agent-chat context (with `artifactRunId`) and store document views (without)
- [x] Run-local shorthand paths (`out/…`, `files/…`) still resolve via the run-scoped artifact API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>