### PR TITLE
fix(ui): restore accessible name on table preview button

### DIFF
--- a/packages/ui/src/features/store/objects/layout/renderers.tsx
+++ b/packages/ui/src/features/store/objects/layout/renderers.tsx
@@ -133,6 +133,7 @@ const renderers: Record<
                 <td key={index} className="flex justify-start items-center gap-2">
                     <Button
                         variant="ghost"
+                        aria-label="Preview Object"
                         title="Preview Object"
                         onClick={(e) => {
                             e.stopPropagation();


### PR DESCRIPTION
## Summary
- #1463 swapped the deprecated `alt` prop for `title` on the object-table preview (eye) button. `Button` only back-fills `aria-label` from `alt`; `title` just feeds the `VTooltip`. The icon-only button therefore lost its accessible name — screen readers announce nothing and `getByRole('button', { name: 'Preview Object' })` no longer matches (WCAG 4.1.2 name-role-value regression, and it violates the package's own "icon-only buttons require aria-label" convention).
- Add `aria-label="Preview Object"`, keeping `title` for the visual tooltip.

## Test Plan
- [x] Accessibility tree shows `button "Preview Object"` in object table rows
- [x] CI build + lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>