### PR TITLE
chore: lint GitHub Actions in hooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,6 +2,7 @@
 # Pre-commit hook:
 # - Runs biome check --write on staged files only.
 # - Re-stages Biome fixes so the commit contains the checked content.
+# - Runs actionlint on staged GitHub Actions workflow files.
 # - Standalone clone or local `pnpm install`: biome is reachable via pnpm exec.
 # - Submodule mode (no local node_modules): falls back to the parent workspace's
 #   biome binary while still using this repo as the working directory.
@@ -12,26 +13,13 @@ hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$hook_dir/.." && pwd)"
 cd "$repo_root"
 
-BIOME_CMD=()
-
-if [ -d node_modules ]; then
-    BIOME_CMD=(pnpm exec biome)
-else
-    PARENT_BIOME="../node_modules/.bin/biome"
-    if [ -x "$PARENT_BIOME" ]; then
-        echo "[pre-commit] biome not installed locally - falling back to parent workspace's: $PARENT_BIOME"
-        BIOME_CMD=("$PARENT_BIOME")
-    else
-        echo "Error: biome not found in this workspace or its parent."
-        echo "Run 'pnpm install' from inside composableai to install local devDeps,"
-        echo "or commit with --no-verify to skip this check."
-        exit 1
-    fi
-fi
-
 staged_files=()
+workflow_files=()
 while IFS= read -r -d '' file; do
     case "$file" in
+        .github/workflows/*.yml | .github/workflows/*.yaml)
+            workflow_files+=("$file")
+            ;;
         package.json | */package.json | \
         *.js | *.cjs | *.mjs | *.jsx | *.ts | *.tsx | *.css | *.html)
             staged_files+=("$file")
@@ -39,29 +27,62 @@ while IFS= read -r -d '' file; do
     esac
 done < <(git diff --cached --name-only --diff-filter=ACMR -z)
 
-if (( ${#staged_files[@]} == 0 )); then
+if (( ${#staged_files[@]} == 0 && ${#workflow_files[@]} == 0 )); then
     exit 0
 fi
 
-if ! git diff --quiet -- "${staged_files[@]}"; then
+status=0
+
+if (( ${#staged_files[@]} > 0 )) && ! git diff --quiet -- "${staged_files[@]}"; then
     echo "Error: cannot run biome --write with partially staged files."
     echo "Stage or stash unstaged changes in the files being committed, then try again."
     exit 1
 fi
 
-# Run Biome, but don't let a nonzero exit (unfixable error-level diagnostics)
-# abort the script before we re-stage. Biome applies its safe --write fixes to
-# the working tree even when it also reports an unfixable error, so we must
-# always re-stage those fixes; otherwise they'd be lost and the next commit
-# attempt would trip the partial-staging guard above.
-set +e
-"${BIOME_CMD[@]}" check --write --staged --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error
-biome_status=$?
-set -e
+if (( ${#workflow_files[@]} > 0 )) && ! git diff --quiet -- "${workflow_files[@]}"; then
+    echo "Error: cannot run actionlint with partially staged workflow files."
+    echo "Stage or stash unstaged changes in the files being committed, then try again."
+    exit 1
+fi
 
-# Re-stage whatever Biome fixed, regardless of its exit status.
-git add -- "${staged_files[@]}"
+if (( ${#staged_files[@]} > 0 )); then
+    BIOME_CMD=()
+    if [ -d node_modules ]; then
+        BIOME_CMD=(pnpm exec biome)
+    else
+        PARENT_BIOME="../node_modules/.bin/biome"
+        if [ -x "$PARENT_BIOME" ]; then
+            echo "[pre-commit] biome not installed locally - falling back to parent workspace's: $PARENT_BIOME"
+            BIOME_CMD=("$PARENT_BIOME")
+        else
+            echo "Error: biome not found in this workspace or its parent."
+            echo "Run 'pnpm install' from inside composableai to install local devDeps,"
+            echo "or commit with --no-verify to skip this check."
+            exit 1
+        fi
+    fi
 
-# Surface remaining unfixable errors by failing the commit (fixes are now staged,
-# so the user can address the error and re-commit without losing formatting work).
-exit "$biome_status"
+    # Run Biome, but don't let a nonzero exit (unfixable error-level diagnostics)
+    # abort the script before we re-stage. Biome applies its safe --write fixes to
+    # the working tree even when it also reports an unfixable error, so we must
+    # always re-stage those fixes; otherwise they'd be lost and the next commit
+    # attempt would trip the partial-staging guard above.
+    set +e
+    "${BIOME_CMD[@]}" check --write --staged --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error
+    biome_status=$?
+    set -e
+
+    # Re-stage whatever Biome fixed, regardless of its exit status.
+    git add -- "${staged_files[@]}"
+    [ "$biome_status" -ne 0 ] && status="$biome_status"
+fi
+
+if (( ${#workflow_files[@]} > 0 )); then
+    set +e
+    scripts/run-actionlint.sh "${workflow_files[@]}"
+    actionlint_status=$?
+    set -e
+    [ "$actionlint_status" -ne 0 ] && status="$actionlint_status"
+fi
+
+exit "$status"

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,1 @@
+config-variables: null

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "format": "pnpm exec biome format --write .",
         "format:check": "pnpm exec biome format .",
         "lint": "pnpm exec biome lint",
+        "lint:actions": "scripts/run-actionlint.sh",
         "lint:fix": "pnpm exec biome lint --write",
         "prepare": "node --input-type=module -e \"import { existsSync } from 'node:fs'; if (existsSync('scripts/install-git-hooks.mjs')) await import('./scripts/install-git-hooks.mjs');\"",
         "prepublishOnly": "pnpm build",

--- a/scripts/run-actionlint.sh
+++ b/scripts/run-actionlint.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACTIONLINT_VERSION="${ACTIONLINT_VERSION:-v1.7.12}"
+ACTIONLINT_ARGS=("-shellcheck" "" "-pyflakes" "")
+
+if command -v actionlint >/dev/null 2>&1; then
+    exec actionlint "${ACTIONLINT_ARGS[@]}" "$@"
+fi
+
+if command -v go >/dev/null 2>&1; then
+    echo "actionlint not found; running actionlint ${ACTIONLINT_VERSION} via go run." >&2
+    exec go run "github.com/rhysd/actionlint/cmd/actionlint@${ACTIONLINT_VERSION}" "${ACTIONLINT_ARGS[@]}" "$@"
+fi
+
+cat >&2 <<EOF
+Error: actionlint is not installed and Go is unavailable for the fallback runner.
+
+Install actionlint:
+  brew install actionlint
+
+Or install the pinned CLI:
+  go install github.com/rhysd/actionlint/cmd/actionlint@${ACTIONLINT_VERSION}
+EOF
+exit 127


### PR DESCRIPTION
## Summary
- Add a `lint:actions` script backed by a pinned actionlint wrapper with local-binary and Go fallback paths.
- Extend the pre-commit hook to run actionlint for staged GitHub Actions workflow files while preserving the existing Biome staged-file flow.
- Add actionlint configuration and update the llumiverse submodule to include the same hook support.

## Submodule Changes
- llumiverse: https://github.com/vertesia/llumiverse/pull/461

## Test Plan
- [x] `pnpm install` (already up to date)
- [x] `pnpm run lint:actions`
- [x] `pnpm --dir llumiverse run lint:actions`
- [x] `git diff --check`
- [x] `git -C llumiverse diff --check`

Skipped runtime build/typecheck because this only changes shell hooks, workflow lint configuration, package scripts, and a submodule pointer.