### PR TITLE
fix: unify public ref identifiers

### DIFF
--- a/packages/cli/src/objects/commands.ts
+++ b/packages/cli/src/objects/commands.ts
@@ -470,7 +470,7 @@ function readObjectTypeName(object: ContentObjectItem<unknown> | ContentObjectIt
     if (typeof object.type === 'string') {
         return object.type;
     }
-    return object.type.name || object.type.id || object.type.code || '';
+    return object.type.name || object.type.id || '';
 }
 
 function printQueryResult(result: QueryResult) {

--- a/packages/client/src/store/TypeCatalogApi.ts
+++ b/packages/client/src/store/TypeCatalogApi.ts
@@ -46,12 +46,11 @@ export class TypeCatalogApi extends ApiTopic {
 
     /**
      * Resolve a type to its full definition.
-     * Accepts a string (type ID or code) or a ContentObjectTypeRef (extracts code or id automatically).
+     * Accepts a string (type ID or code) or a ContentObjectTypeRef.
      * @param typeOrRef Type identifier string, or a ContentObjectTypeRef from a content object
      */
     resolve(typeOrRef: string | ContentObjectTypeRef): Promise<ContentObjectTypeItem> {
-        // biome-ignore lint/style/noNonNullAssertion: intentional non-null assertion; TS can't prove narrowing here
-        const typeId = typeof typeOrRef === 'string' ? typeOrRef : typeOrRef.code || typeOrRef.id!;
+        const typeId = typeof typeOrRef === 'string' ? typeOrRef : typeOrRef.id;
         return this.get(`/resolve/${typeId}`);
     }
 }

--- a/packages/common/src/cost-analytics.ts
+++ b/packages/common/src/cost-analytics.ts
@@ -47,10 +47,8 @@ export interface CostAnalyticsQuery {
     run_id?: string;
     /** Filter by agent run ID */
     agent_run_id?: string;
-    /** Filter by saved-interaction ObjectId */
+    /** Filter by interaction id: stored ObjectId or namespaced in-code id */
     interaction_id?: string;
-    /** Filter by in-code interaction code (e.g. "@sys:chat") */
-    interaction_code?: string;
     /** Filter by principal (bare user or API key id; matched against the suffix of principal_id) */
     principal_id?: string;
     /** Filter by account ID (set automatically by server) */

--- a/packages/common/src/interaction.ts
+++ b/packages/common/src/interaction.ts
@@ -1003,7 +1003,7 @@ export interface RunSource {
     client_ip: string;
 }
 
-export type ExecutionRunInteraction = Interaction | InteractionRef;
+export type ExecutionRunInteraction = InteractionRef;
 
 export interface BaseExecutionRun<P = unknown> {
     readonly id: string;

--- a/packages/common/src/interaction.ts
+++ b/packages/common/src/interaction.ts
@@ -1003,6 +1003,8 @@ export interface RunSource {
     client_ip: string;
 }
 
+export type ExecutionRunInteraction = Interaction | InteractionRef;
+
 export interface BaseExecutionRun<P = unknown> {
     readonly id: string;
     /**
@@ -1022,12 +1024,12 @@ export interface BaseExecutionRun<P = unknown> {
      */
     parameters: P; //params used to create the interaction, only in varies on?
     tags?: string[];
-    // only set when the target interaction is a stored interaction
-    //TODO check the code where Interaction type is used (should be in run details)
-    // TODO when execution string is passed as the type of interaction
-    interaction?: string | Interaction;
-    // only set when the target interaction is an in-code interaction
-    interaction_code?: string; // Interaction code name in case of in-code interaction (not stored in the DB as an Interaction document)
+    /**
+     * Interaction reference. Stored interactions may be populated as full
+     * Interaction documents; in-code interactions are represented as refs whose
+     * `id` is the namespaced interaction id.
+     */
+    interaction?: string | ExecutionRunInteraction;
     /** Environment reference - populated with full object in API responses */
     environment: ExecutionEnvironmentRef;
     modelId?: string; //Can be undefined for virtual environments. In most cases should be defined.
@@ -1065,11 +1067,11 @@ export interface BaseExecutionRun<P = unknown> {
 }
 
 export interface ExecutionRun<P = unknown> extends BaseExecutionRun<P> {
-    interaction?: Interaction;
+    interaction?: ExecutionRunInteraction;
 }
 
 export interface PopulatedExecutionRun<P = unknown> extends BaseExecutionRun<P> {
-    interaction?: Interaction;
+    interaction?: ExecutionRunInteraction;
 }
 
 export interface ExecutionRunWorkflow {
@@ -1130,7 +1132,6 @@ export interface LegacyInteractionExecutionResult<P = unknown>
 
 export interface ExecutionRunRef extends Omit<ExecutionRun, 'result' | 'parameters' | 'interaction'> {
     interaction?: InteractionRef;
-    interaction_code?: string;
 }
 
 export const ExecutionRunRefSelect = '-result -parameters -result_schema -prompt';

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -1,6 +1,5 @@
 import type { JSONSchemaType } from 'ajv';
 import type { SupportedIntegrations } from './integrations.js';
-import type { ContentObjectTypeRef } from './store/store.js';
 import type { WorkflowRunStatus } from './store/workflow.js';
 import type { AccountRef } from './user.js';
 
@@ -600,6 +599,21 @@ export interface ReindexAgentRunsResponse {
 // ============================================================================
 
 /**
+ * Indexed (`_source`) shape of the content type ref. Unlike the public
+ * ContentObjectTypeRef discriminated union, the index stores BOTH kinds under
+ * `id` — the ObjectId hex for stored types, the namespaced code for in-code
+ * types — so search filters and facets work on a single keyword field
+ * regardless of the kind. `ref_type` is kept to rebuild the public union on
+ * read. `code` only exists on documents written before the field was unified.
+ */
+export interface IndexedContentTypeRef {
+    ref_type: 'stored' | 'incode';
+    id: string;
+    code?: string;
+    name: string;
+}
+
+/**
  * Document data structure for Elasticsearch indexing
  */
 export interface ElasticsearchDocumentData {
@@ -607,7 +621,7 @@ export interface ElasticsearchDocumentData {
     text?: string;
     properties?: Record<string, unknown>;
     status?: string;
-    type?: ContentObjectTypeRef;
+    type?: IndexedContentTypeRef;
     security?: {
         'content:read'?: string[];
         'content:write'?: string[];

--- a/packages/common/src/store/store.ts
+++ b/packages/common/src/store/store.ts
@@ -403,19 +403,32 @@ export interface CreateContentObjectPayload<T = JSONObject>
     generation_run_info?: GenerationRunMetadata;
 }
 
-export function getContentTypeRefId(type: ContentObjectTypeRef) {
-    return (type as StoredTypeRef).id || (type as InCodeTypeRef).code;
+type LegacyContentObjectTypeRef = Partial<ContentObjectTypeRef> & {
+    ref_type?: 'stored' | 'incode';
+    id?: string;
+    code?: string;
+    name?: string;
+};
+
+export function getContentTypeRefId(type: ContentObjectTypeRef): string {
+    return type.id;
 }
 
-export function withContentObjectTypeRefDiscriminator(type: ContentObjectTypeRef): ContentObjectTypeRef {
-    if ((type as StoredTypeRef).id) {
-        return { ...type, ref_type: 'stored' } as StoredTypeRef;
+export function withContentObjectTypeRefDiscriminator(
+    type: ContentObjectTypeRef | LegacyContentObjectTypeRef,
+): ContentObjectTypeRef {
+    const legacyCode = 'code' in type ? type.code : undefined;
+    const id = type.id || legacyCode || '';
+    const name = type.name || '';
+    if (type.ref_type === 'incode' || isInCodeType(id)) {
+        return { ref_type: 'incode', id, name };
     }
-    return { ...type, ref_type: 'incode' } as InCodeTypeRef;
+    return { ref_type: 'stored', id, name };
 }
 
 /**
- * Reference to a content object type. Either `id` (stored type) or `code` (in-code type) must be set.
+ * Reference to a content object type. `id` is the canonical identifier for both
+ * stored and in-code types.
  */
 /**
  * @discriminator ref_type
@@ -428,17 +441,15 @@ interface StoredTypeRef {
      * MongoDB ObjectId string for stored types
      */
     id: string;
-    code?: never;
     name: string;
 }
 
 interface InCodeTypeRef {
     ref_type: 'incode';
-    id?: never;
     /**
      * Namespaced identifier for in-code types (e.g. "sys:Invoice", "app:myapp:Contract")
      */
-    code: string;
+    id: string;
     name: string;
 }
 

--- a/packages/ui/src/__tests__/setup.ts
+++ b/packages/ui/src/__tests__/setup.ts
@@ -8,6 +8,59 @@ afterEach(() => {
     cleanup();
 });
 
+function createMemoryStorage(): Storage {
+    const values = new Map<string, string>();
+    return {
+        get length() {
+            return values.size;
+        },
+        clear() {
+            values.clear();
+        },
+        getItem(key: string) {
+            return values.get(String(key)) ?? null;
+        },
+        key(index: number) {
+            return Array.from(values.keys())[index] ?? null;
+        },
+        removeItem(key: string) {
+            values.delete(String(key));
+        },
+        setItem(key: string, value: string) {
+            values.set(String(key), String(value));
+        },
+    };
+}
+
+function readWindowStorage(name: 'localStorage' | 'sessionStorage'): Storage | undefined {
+    if (typeof window === 'undefined') {
+        return undefined;
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(window, name);
+    return descriptor && 'value' in descriptor && descriptor.value ? descriptor.value : undefined;
+}
+
+function exposeDomStorage(name: 'localStorage' | 'sessionStorage'): void {
+    // Node 26 exposes Web Storage globals through getters that return undefined
+    // unless Node is started with --localstorage-file. In jsdom tests, use the
+    // jsdom window storage objects as the globals instead; if those are also
+    // unavailable, fall back to a minimal in-memory Storage implementation.
+    const storage = readWindowStorage(name) ?? createMemoryStorage();
+    Object.defineProperty(globalThis, name, {
+        configurable: true,
+        value: storage,
+    });
+    if (typeof window !== 'undefined') {
+        Object.defineProperty(window, name, {
+            configurable: true,
+            value: storage,
+        });
+    }
+}
+
+exposeDomStorage('localStorage');
+exposeDomStorage('sessionStorage');
+
 // jsdom lacks ResizeObserver, which several Radix-backed components use
 // (Popover trigger width measurement, etc.). Provide a no-op polyfill.
 if (typeof globalThis.ResizeObserver === 'undefined') {


### PR DESCRIPTION
## Summary
- Make content type refs use id for both stored and in-code public shapes
- Represent execution run interactions through interaction.id instead of a separate interaction_code response field
- Use interaction_id as the single cost analytics selector while retaining internal compatibility for legacy records
- Add an indexed content type ref shape for search index sources that can still read legacy code fields

## Test Plan
- pnpm --prefix composableai/packages/common typecheck:test
- pnpm --prefix composableai/packages/common build
- pnpm --prefix composableai/packages/common test
- ../../../node_modules/.bin/biome lint src