### PR TITLE
fix(client): support dev1 preview API site

### DIFF
--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -73,6 +73,17 @@ describe('Test Vertesia Client', () => {
         expect(client.tokenServerUrl).toBe('https://sts.dev1.vertesia.io');
     });
 
+    test('Initialization with site api-preview.dev1.vertesia.io', () => {
+        const client = new VertesiaClient({
+            site: 'api-preview.dev1.vertesia.io',
+        });
+
+        expect(client).toBeDefined();
+        expect(client.baseUrl).toBe('https://api-preview.dev1.vertesia.io');
+        expect(client.storeUrl).toBe('https://api-preview.dev1.vertesia.io');
+        expect(client.tokenServerUrl).toBe('https://sts.dev1.vertesia.io');
+    });
+
     test('Initialization with regional serverUrl (api.us1)', () => {
         const client = new VertesiaClient({
             serverUrl: 'https://api.us1.vertesia.io',

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -54,7 +54,8 @@ export type VertesiaClientProps = {
         | 'api-preview.eu1.vertesia.io'
         | 'api.jp1.vertesia.io'
         | 'api-preview.jp1.vertesia.io'
-        | 'api.dev1.vertesia.io';
+        | 'api.dev1.vertesia.io'
+        | 'api-preview.dev1.vertesia.io';
     serverUrl?: string;
     storeUrl?: string;
     tokenServerUrl?: string;


### PR DESCRIPTION
## Summary
- Add `api-preview.dev1.vertesia.io` as a typed `VertesiaClient` site.
- Cover the derived base, store, and STS URLs for that dev1 preview site.

## Test Plan
- [x] `pnpm --prefix composableai/packages/client lint`
- [x] `pnpm --prefix composableai/packages/client typecheck:test`
- [x] `pnpm --prefix composableai/packages/client test -- client`
- [x] `pnpm --prefix composableai/packages/client build`