### PR TITLE
feat(bulk-import): support processing_priority for bulk object creation

### DIFF
--- a/packages/client/src/store/ObjectsApi.ts
+++ b/packages/client/src/store/ObjectsApi.ts
@@ -384,6 +384,7 @@ export class ObjectsApi extends ApiTopic {
     bulkCreate(objects: CreateContentObjectPayload[], options?: {
         collection_id?: string;
         skip_workflows?: boolean;
+        processing_priority?: ContentObjectProcessingPriority;
     }): Promise<BulkObjectCreateResult> {
         return this.client.runOperation({
             name: 'create',

--- a/packages/workflow/src/bulk-import.ts
+++ b/packages/workflow/src/bulk-import.ts
@@ -1,4 +1,5 @@
 import type {
+    ContentObjectProcessingPriority,
     CreateCollectionPayload,
     CreateContentObjectPayload,
 } from '@vertesia/common';
@@ -97,6 +98,12 @@ export interface BulkImportParams {
     dryRun?: boolean;
     updateByContentSource?: boolean;
     skipWorkflows?: boolean;
+    /**
+     * Processing priority for the document-processing workflows triggered by created objects.
+     * Defaults to `low` so bulk imports run on the low-priority ("bulk") task queue and don't
+     * compete with interactive traffic.
+     */
+    processingPriority?: ContentObjectProcessingPriority;
 }
 
 export interface PartitionError {


### PR DESCRIPTION
## Summary
- Add optional `processing_priority` to `ObjectsApi.bulkCreate` options (`@vertesia/client`), forwarded as part of the bulk-create operation params.
- Add optional `processingPriority` field to `BulkImportParams` (`@vertesia/workflow`), so bulk imports can route the triggered document-processing workflows to the low-priority ("bulk") task queue instead of competing with interactive traffic.

## Context
Part of a cross-repo fix. The server-side bulk-create operation previously hardcoded `normal` priority, so bulk-imported objects never reached the low-priority queue. The parent studio PR wires this through the server and the bulk-import activity (defaulting to `low`).

## Verification
- `pnpm build --filter="@vertesia/workflow" --filter="@vertesia/client"` ✅

## Test Plan
- [ ] Bulk import creates objects whose doc-processing workflows run on the low-priority queue by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>