### PR TITLE
fix(ui): improve environment info panel URL display

### DIFF
--- a/packages/ui/src/shell/login/UserInfo.tsx
+++ b/packages/ui/src/shell/login/UserInfo.tsx
@@ -41,6 +41,9 @@ export default function InfoList() {
     const { account, project, client, authToken } = session;
     const server = client.baseUrl;
     const store = client.store.baseUrl;
+    // Behind the unified LB, server and store share one host (path-routing splits studio
+    // vs zeno), so the Store row just duplicates Server — only show it when they differ.
+    const showStore = store.replace(/\/+$/, '') !== server.replace(/\/+$/, '');
     const mcpServer = Env.endpoints.mcp ?? t('user.unknown');
     const tenantId = project ? getTenantIdFromProject(project) : '';
 
@@ -72,7 +75,7 @@ export default function InfoList() {
                     <InfoItems title={t('user.tenantId')} value={tenantId} />
                     <InfoItems title={t('user.environment')} value={Env.type} />
                     <InfoItems title={t('user.server')} value={server} />
-                    <InfoItems title={t('user.store')} value={store} />
+                    {showStore && <InfoItems title={t('user.store')} value={store} />}
                     <InfoItems title={t('user.mcpServer')} value={mcpServer} />
                     <InfoItems title={t('user.appVersion')} value={Env.version} />
                     <InfoItems title={t('user.sdkVersion')} value={Env.sdkVersion || t('user.unknown')} />

--- a/packages/ui/src/shell/login/UserInfo.tsx
+++ b/packages/ui/src/shell/login/UserInfo.tsx
@@ -39,9 +39,9 @@ export default function InfoList() {
 
     const session = useUserSession();
     const { account, project, client, authToken } = session;
-    const server = new URL(client.baseUrl).hostname;
-    const store = new URL(client.store.baseUrl).hostname;
-    const mcpServer = Env.endpoints.mcp ? new URL(Env.endpoints.mcp).hostname : t('user.unknown');
+    const server = client.baseUrl;
+    const store = client.store.baseUrl;
+    const mcpServer = Env.endpoints.mcp ?? t('user.unknown');
     const tenantId = project ? getTenantIdFromProject(project) : '';
 
     const tabs = [


### PR DESCRIPTION
## Summary
- Show the **full** server/store/MCP URLs in the environment info panel (scheme + path) instead of just the bare hostname — values become copy-pasteable and the MCP URL keeps its `/mcp` path. Previously `new URL(...).hostname` stripped the scheme (and the `/mcp` path).
- Hide the redundant **Store** row when it resolves to the same host as **Server** (e.g. behind a unified load balancer where path-routing splits studio vs store), so the panel only shows distinct endpoints.

## Test Plan
- [ ] Open the user → Environment info panel; verify Server / Store / MCP show full `https://…` URLs (and `…/mcp` for MCP).
- [ ] Unified-host environment (Server == Store host): the Store row is hidden.
- [ ] Split-host environment (separate hosts): the Store row still shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>
