### PR TITLE
fix(cli): request all supported OAuth scopes instead of a curated subset

### DIFF
--- a/packages/cli/src/profiles/oauth.ts
+++ b/packages/cli/src/profiles/oauth.ts
@@ -12,26 +12,17 @@ import type { ConfigResult } from './server/index.js';
 
 const OAUTH_AUTHORIZATION_SERVER_PATH = '/.well-known/oauth-authorization-server';
 const OAUTH_CLIENT_METADATA_PATH = '/.well-known/oauth-client/vertesia-cli';
-const DEFAULT_CLI_OAUTH_SCOPES = [
-    OAUTH_SCOPE_OPENID,
-    OAUTH_SCOPE_PROFILE,
-    OAUTH_SCOPE_OFFLINE_ACCESS,
-    Permission.account_member,
-    Permission.account_read,
-    Permission.project_integration_read,
-    Permission.int_read,
-    Permission.int_execute,
-    Permission.run_read,
-    Permission.run_write,
-    Permission.content_read,
-    Permission.content_write,
-    Permission.content_delete,
-    Permission.workflow_read,
-    Permission.workflow_run,
-    Permission.agent_run_read,
-    Permission.task_read,
-    Permission.task_manage,
-];
+// Base OIDC scopes that are not platform permissions.
+const BASE_OIDC_SCOPES = [OAUTH_SCOPE_OPENID, OAUTH_SCOPE_PROFILE, OAUTH_SCOPE_OFFLINE_ACCESS];
+
+// The full set of platform permission scopes. The CLI requests ALL of them and
+// never curates a subset: dropping admin scopes here (e.g. content:admin,
+// account:admin) silently denied legitimate operations — reindex, publish ACE
+// grants — even for account owners / project admins. The authorization server
+// is the right place to gate access: it downscopes the issued token to exactly
+// what the signed-in user's roles allow, so requesting everything is safe and a
+// user only ever receives the permissions they are entitled to.
+const ALL_PERMISSION_SCOPES = Object.values(Permission) as string[];
 
 type OAuthProfile = Pick<Profile, 'name' | 'studio_server_url' | 'zeno_server_url'> &
     Partial<Pick<Profile, 'account' | 'config_url' | 'project' | 'oauth_server_url'>>;
@@ -167,12 +158,15 @@ async function discoverAuthorizationServer(
 }
 
 function getDefaultOAuthScope(metadata: Partial<Pick<OAuthAuthorizationServerMetadata, 'scopes_supported'>>): string {
-    if (!Array.isArray(metadata.scopes_supported)) {
-        return DEFAULT_CLI_OAUTH_SCOPES.join(' ');
-    }
-    const supportedScopes = new Set(metadata.scopes_supported);
-    const supportedDefaultScopes = DEFAULT_CLI_OAUTH_SCOPES.filter((scope) => supportedScopes.has(scope));
-    return (supportedDefaultScopes.length > 0 ? supportedDefaultScopes : DEFAULT_CLI_OAUTH_SCOPES).join(' ');
+    // Request every scope the server advertises — no exclusions. When the server
+    // does not advertise a list, fall back to the full known permission set. The
+    // authorization server downscopes the issued token to the user's entitlements,
+    // so this never grants more than the signed-in user's roles allow.
+    const requested =
+        Array.isArray(metadata.scopes_supported) && metadata.scopes_supported.length > 0
+            ? metadata.scopes_supported
+            : ALL_PERMISSION_SCOPES;
+    return Array.from(new Set([...BASE_OIDC_SCOPES, ...requested])).join(' ');
 }
 
 function applyProfileAuthorizationEndpoint(


### PR DESCRIPTION
## Summary

The CLI hardcoded `DEFAULT_CLI_OAUTH_SCOPES` — a curated list that omitted every admin scope (`content:admin`, `account:admin`, `project:admin`, …). As a result, admin-capable users (account owners / project admins) silently could **not** perform admin operations from the CLI even when their roles entitled them — e.g. starting a project Elasticsearch reindex (`content:admin`) or completing an app publish that grants ACEs (`account:admin`). The token was issued with exactly the curated scopes and no more.

This changes `oauth.ts` to request **every scope the authorization server advertises** (`scopes_supported`), falling back to the full `Permission` set when the server doesn't advertise a list.

## Why this is safe

The authorization server is the correct place to gate access, and it already does:

- `normalizeRequestedScopes` caps requested scopes to the OAuth client's `allowed_scopes` (the `vertesia-cli` client defaults to "all supported").
- `getGrantablePermissionScopes` filters requested permission scopes to those the **principal actually holds** (`principal.hasPermission(scope)`); scopes the user isn't entitled to become `unavailablePermissionScopes` and are **silently dropped, not granted**.

So requesting everything can't escalate: each user only ever receives the permissions their roles allow. A member who requests `account:admin` simply doesn't get it; an owner/admin does.

## Effect

After a re-authentication, an entitled user's CLI token carries the admin scopes their roles grant, so admin-gated CLI/API operations work as intended.

## Test plan

- [x] `turbo build --filter="@vertesia/cli"` passes (tsc).
- [x] Verified end-to-end: after re-auth with this change, an owner/admin token includes `content:admin` + `account:admin` and a previously-403'd admin operation returned 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>