### PR TITLE
feat(router): expose error subpath

### DIFF
--- a/libraries/koa-stack/router/package.json
+++ b/libraries/koa-stack/router/package.json
@@ -42,6 +42,10 @@
         ".": {
             "types": "./lib/index.d.ts",
             "default": "./lib/index.js"
+        },
+        "./errors": {
+            "types": "./lib/errors.d.ts",
+            "default": "./lib/errors.js"
         }
     }
 }

--- a/libraries/koa-stack/router/src/errors.ts
+++ b/libraries/koa-stack/router/src/errors.ts
@@ -1,0 +1,2 @@
+export type { ErrorFormatter, ErrorHandlerOpts, ErrorInfo, ErrorObject } from './error.js';
+export { ServerError } from './ServerError.js';


### PR DESCRIPTION
## Summary
- Add an `@koa-stack/router/errors` export for `ServerError` and `ErrorInfo`.
- Keep the root router export unchanged while allowing consumers to import only the error helpers.

## Test Plan
- [x] `pnpm --prefix composableai/libraries/koa-stack/router run build`
- [x] `pnpm --prefix composableai/libraries/koa-stack/router run test`
