### PR TITLE
Add project switch scope to CLI OAuth

### DIFF
--- a/packages/cli/src/profiles/oauth.ts
+++ b/packages/cli/src/profiles/oauth.ts
@@ -3,7 +3,13 @@ import type {
     OAuthDeviceAuthorizationResponse,
     OAuthTokenResponse,
 } from '@vertesia/common';
-import { OAUTH_SCOPE_OFFLINE_ACCESS, OAUTH_SCOPE_OPENID, OAUTH_SCOPE_PROFILE, Permission } from '@vertesia/common';
+import {
+    OAUTH_SCOPE_OFFLINE_ACCESS,
+    OAUTH_SCOPE_OPENID,
+    OAUTH_SCOPE_PROFILE,
+    OAUTH_SCOPE_PROJECT_SWITCH,
+    Permission,
+} from '@vertesia/common';
 import jwt from 'jsonwebtoken';
 import open from 'open';
 import type { Profile } from './index.js';
@@ -12,8 +18,13 @@ import type { ConfigResult } from './server/index.js';
 
 const OAUTH_AUTHORIZATION_SERVER_PATH = '/.well-known/oauth-authorization-server';
 const OAUTH_CLIENT_METADATA_PATH = '/.well-known/oauth-client/vertesia-cli';
-// Base OIDC scopes that are not platform permissions.
-const BASE_OIDC_SCOPES = [OAUTH_SCOPE_OPENID, OAUTH_SCOPE_PROFILE, OAUTH_SCOPE_OFFLINE_ACCESS];
+// Base CLI scopes that are not platform API permissions.
+const BASE_CLI_SCOPES = [
+    OAUTH_SCOPE_OPENID,
+    OAUTH_SCOPE_PROFILE,
+    OAUTH_SCOPE_OFFLINE_ACCESS,
+    OAUTH_SCOPE_PROJECT_SWITCH,
+];
 
 // The full set of platform permission scopes. The CLI requests ALL of them and
 // never curates a subset: dropping admin scopes here (e.g. content:admin,
@@ -166,7 +177,7 @@ function getDefaultOAuthScope(metadata: Partial<Pick<OAuthAuthorizationServerMet
         Array.isArray(metadata.scopes_supported) && metadata.scopes_supported.length > 0
             ? metadata.scopes_supported
             : ALL_PERMISSION_SCOPES;
-    return Array.from(new Set([...BASE_OIDC_SCOPES, ...requested])).join(' ');
+    return Array.from(new Set([...BASE_CLI_SCOPES, ...requested])).join(' ');
 }
 
 function applyProfileAuthorizationEndpoint(

--- a/packages/cli/src/projects/index.ts
+++ b/packages/cli/src/projects/index.ts
@@ -35,6 +35,14 @@ export async function useProject(program: Command, projectId?: string) {
         console.error('No profile is selected. Run `vertesia profiles use <name>` to select a profile');
         process.exit(1);
     }
+    const envCredential = readEnvCredentialName();
+    if (envCredential) {
+        console.error(
+            `Cannot switch the current profile project while ${envCredential} is set. ` +
+                'Unset it or use profile-backed authentication.',
+        );
+        process.exit(1);
+    }
 
     const client = await getClient(program);
     const projects = await client.projects.list();
@@ -78,4 +86,17 @@ async function selectProject(projects: ProjectChoice[]): Promise<string> {
         process.exit(1);
     }
     return response.project;
+}
+
+function readEnvCredentialName(): string | undefined {
+    if (process.env.VERTESIA_TOKEN) {
+        return 'VERTESIA_TOKEN';
+    }
+    if (process.env.VERTESIA_APIKEY) {
+        return 'VERTESIA_APIKEY';
+    }
+    if (process.env.COMPOSABLE_PROMPTS_APIKEY) {
+        return 'COMPOSABLE_PROMPTS_APIKEY';
+    }
+    return undefined;
 }

--- a/packages/common/src/oauth-scopes.ts
+++ b/packages/common/src/oauth-scopes.ts
@@ -3,10 +3,13 @@ import { Permission } from './access-control.js';
 export const OAUTH_SCOPE_OPENID = 'openid';
 export const OAUTH_SCOPE_PROFILE = 'profile';
 export const OAUTH_SCOPE_OFFLINE_ACCESS = 'offline_access';
+export const OAUTH_SCOPE_PROJECT_SWITCH = 'project_switch';
 
 export const OAUTH_STANDARD_SCOPES = [OAUTH_SCOPE_OPENID, OAUTH_SCOPE_PROFILE, OAUTH_SCOPE_OFFLINE_ACCESS] as const;
+export const OAUTH_PLATFORM_SCOPES = [OAUTH_SCOPE_PROJECT_SWITCH] as const;
 
 export type OAuthStandardScope = (typeof OAUTH_STANDARD_SCOPES)[number];
+export type OAuthPlatformScope = (typeof OAUTH_PLATFORM_SCOPES)[number];
 
 const NON_OAUTH_PERMISSION_SCOPES = new Set<Permission>([
     Permission.api_key_secret_read,
@@ -17,6 +20,7 @@ const NON_OAUTH_PERMISSION_SCOPES = new Set<Permission>([
 ]);
 const OAUTH_PERMISSION_SCOPES = Object.values(Permission).filter((scope) => !NON_OAUTH_PERMISSION_SCOPES.has(scope));
 const OAUTH_STANDARD_SCOPE_SET = new Set<string>(OAUTH_STANDARD_SCOPES);
+const OAUTH_PLATFORM_SCOPE_SET = new Set<string>(OAUTH_PLATFORM_SCOPES);
 const OAUTH_PERMISSION_SCOPE_SET = new Set<string>(OAUTH_PERMISSION_SCOPES);
 const OBJECT_ID_PATTERN = /^[0-9a-f]{24}$/i;
 const OAUTH_PROJECT_BINDING_SCOPE_PREFIX = 'project:';
@@ -29,12 +33,16 @@ export function isOAuthStandardScope(scope: string): scope is OAuthStandardScope
     return OAUTH_STANDARD_SCOPE_SET.has(scope);
 }
 
+export function isOAuthPlatformScope(scope: string): scope is OAuthPlatformScope {
+    return OAUTH_PLATFORM_SCOPE_SET.has(scope);
+}
+
 export function isOAuthPermissionScope(scope: string): scope is Permission {
     return OAUTH_PERMISSION_SCOPE_SET.has(scope);
 }
 
 export function isOAuthSupportedScope(scope: string): boolean {
-    return isOAuthStandardScope(scope) || isOAuthPermissionScope(scope);
+    return isOAuthStandardScope(scope) || isOAuthPlatformScope(scope) || isOAuthPermissionScope(scope);
 }
 
 export function isOAuthProjectBindingScope(scope: string): boolean {
@@ -58,6 +66,10 @@ export function hasOAuthProfileScope(scopes: readonly string[]): boolean {
 
 export function hasOAuthOfflineAccessScope(scopes: readonly string[]): boolean {
     return scopes.includes(OAUTH_SCOPE_OFFLINE_ACCESS);
+}
+
+export function hasOAuthProjectSwitchScope(scopes: readonly string[]): boolean {
+    return scopes.includes(OAUTH_SCOPE_PROJECT_SWITCH);
 }
 
 export function getOAuthScopesWithProfileDependency(scopes: readonly string[]): string[] {


### PR DESCRIPTION
## Summary

- add `project_switch` as a supported non-permission OAuth scope
- have the CLI request `project_switch` during OAuth login so refresh can move between accessible projects
- prevent `projects use` from claiming success when environment credentials override the active profile
- derive the CLI OAuth `client_id` from discovered canonical STS metadata so regional discovery aliases such as `sts.us1.vertesia.io` work correctly
- surface OAuth error `message` fields when the server does not send `error_description`

## Release Backport

- `release/1.4`: https://github.com/vertesia/composableai/pull/1639

## Test Plan

- `pnpm --prefix packages/common build`
- `pnpm --prefix packages/cli build`
- `../node_modules/.bin/biome lint packages/common/src packages/cli/src`
- `PATH=../node_modules/.bin:$PATH pnpm --filter @vertesia/cli lint`
- `PATH=../node_modules/.bin:$PATH pnpm --filter @vertesia/cli... build`
- Live smoke: device authorization against `https://sts.us1.vertesia.io` returned 200 with canonical client ID `https://sts.vertesia.io/.well-known/oauth-client/vertesia-cli`.

Package-local lint scripts were also checked, but `pnpm --prefix packages/common lint` and `pnpm --prefix packages/cli lint` cannot run in this checkout unless `biome` is provided on PATH.
