### PR TITLE
ci: make submodule sync release-branch-aware

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -29,6 +29,8 @@ committed JSON, as for `main`) so the release automation can operate on `release
   fallback opens PRs instead and needs no push bypass — use it until the bypass is
   configured.
 
-Because `release.json` mirrors `main`'s CodeQL `code_scanning` rule, the CodeQL
-workflow must also run on `release/**` for PRs into a release line to be mergeable —
-verify its trigger covers those branches before enabling enforcement.
+`release.json` keeps `main`'s CodeQL `code_scanning` rule because `release/X.Y` is
+the production line and must be CodeQL-gated. This repo uses CodeQL **default
+setup**, which scans pull requests targeting the default branch *or any protected
+branch* — so protecting `release/**` (this ruleset) makes those scans run
+automatically, with no advanced-setup workflow required.

--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -1,0 +1,34 @@
+# RuleSets
+
+These JSON files mirror rulesets defined in this repository's settings. Import them
+at <https://github.com/vertesia/composableai/settings/rules>. Note that editing
+these files does **not** apply to GitHub automatically — it requires a manual
+import by someone with an administrator role on the repo (or `gh api
+repos/vertesia/composableai/rulesets --input <file>`, dropping the export-only
+`source`/`source_type` fields). Reach out to the `#dev` Slack channel if needed.
+
+## `release.json`
+
+Protects the `release/X.Y` release lines coordinated by the studio release process
+(see `docs/release-process.md` in `vertesia/studio`). It mirrors this repo's `main`
+ruleset (PR + 1 approval, no deletion / non-fast-forward, CodeQL code scanning) but
+targets `refs/heads/release/**` instead of the default branch.
+
+Note: this is distinct from the existing `maintenance` ruleset, which targets bare
+`X.Y` branches (the older scheme); the coordinated release lines use the
+`release/X.Y` prefix.
+
+When importing, an admin must configure the **bypass actors** (left empty in the
+committed JSON, as for `main`) so the release automation can operate on `release/*`:
+
+- the submodule-sync automerge app (so `(sync) Update Git submodule` PRs auto-merge
+  into `release/X.Y`), and
+- the actor used by studio's `release-cut.yaml` for `bump_via=push` to push the
+  version-bump commits past protection (the GitHub App that mints the cross-repo
+  token, or the same deploy-key/automation actor used on `main`). The `bump_via=pr`
+  fallback opens PRs instead and needs no push bypass — use it until the bypass is
+  configured.
+
+Because `release.json` mirrors `main`'s CodeQL `code_scanning` rule, the CodeQL
+workflow must also run on `release/**` for PRs into a release line to be mergeable —
+verify its trigger covers those branches before enabling enforcement.

--- a/.github/rulesets/release.json
+++ b/.github/rulesets/release.json
@@ -1,0 +1,51 @@
+{
+  "name": "release",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "vertesia/composableai",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/heads/release/**"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": false,
+        "required_reviewers": [],
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": [
+          "squash",
+          "merge"
+        ]
+      }
+    },
+    {
+      "type": "code_scanning",
+      "parameters": {
+        "code_scanning_tools": [
+          {
+            "tool": "CodeQL",
+            "security_alerts_threshold": "high_or_higher",
+            "alerts_threshold": "errors"
+          }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/.github/workflows/automerge-llumiverse.yaml
+++ b/.github/workflows/automerge-llumiverse.yaml
@@ -104,8 +104,8 @@ jobs:
             echo "Skipping PR #$pr_number: head repository owner is $head_owner, not $repo_owner."
             exit 0
           fi
-          if [[ "$base_ref" != "main" && "$base_ref" != "preview" && ! "$base_ref" =~ ^maintenance/[0-9]+\.[0-9]+$ ]]; then
-            echo "Skipping PR #$pr_number: base branch is $base_ref, not main, preview, or maintenance/X.Y."
+          if [[ "$base_ref" != "main" && "$base_ref" != "preview" && ! "$base_ref" =~ ^release/[0-9]+\.[0-9]+$ ]]; then
+            echo "Skipping PR #$pr_number: base branch is $base_ref, not main, preview, or release/X.Y."
             exit 0
           fi
           if [[ "$is_draft" != "false" ]]; then

--- a/.github/workflows/automerge-llumiverse.yaml
+++ b/.github/workflows/automerge-llumiverse.yaml
@@ -104,8 +104,8 @@ jobs:
             echo "Skipping PR #$pr_number: head repository owner is $head_owner, not $repo_owner."
             exit 0
           fi
-          if [[ "$base_ref" != "main" && "$base_ref" != "preview" ]]; then
-            echo "Skipping PR #$pr_number: base branch is $base_ref, not main or preview."
+          if [[ "$base_ref" != "main" && "$base_ref" != "preview" && ! "$base_ref" =~ ^maintenance/[0-9]+\.[0-9]+$ ]]; then
+            echo "Skipping PR #$pr_number: base branch is $base_ref, not main, preview, or maintenance/X.Y."
             exit 0
           fi
           if [[ "$is_draft" != "false" ]]; then

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -79,7 +79,7 @@ jobs:
     name: Notify vertesia/studio of new commit
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.ref == 'refs/heads/preview' || startsWith(github.ref, 'refs/heads/repo-dispatch')
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/preview' || startsWith(github.ref, 'refs/heads/maintenance/') || startsWith(github.ref, 'refs/heads/repo-dispatch'))
     needs:
       - unit-tests
       - template-smoke-test

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -79,7 +79,7 @@ jobs:
     name: Notify vertesia/studio of new commit
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/preview' || startsWith(github.ref, 'refs/heads/maintenance/') || startsWith(github.ref, 'refs/heads/repo-dispatch'))
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/preview' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/repo-dispatch'))
     needs:
       - unit-tests
       - template-smoke-test

--- a/.github/workflows/update-git-submodule.yaml
+++ b/.github/workflows/update-git-submodule.yaml
@@ -48,8 +48,8 @@ jobs:
         run: |
           if [[ "${TARGET_COMPOSABLEAI_BRANCH}" != "main" \
                 && "${TARGET_COMPOSABLEAI_BRANCH}" != "preview" \
-                && ! "${TARGET_COMPOSABLEAI_BRANCH}" =~ ^maintenance/[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Invalid branch '${TARGET_COMPOSABLEAI_BRANCH}'. Only 'main', 'preview', and 'maintenance/X.Y' branches are supported."
+                && ! "${TARGET_COMPOSABLEAI_BRANCH}" =~ ^release/[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid branch '${TARGET_COMPOSABLEAI_BRANCH}'. Only 'main', 'preview', and 'release/X.Y' branches are supported."
             exit 1
           fi
           echo "Branch '${TARGET_COMPOSABLEAI_BRANCH}' is valid."
@@ -137,7 +137,7 @@ jobs:
           export MAYBE_LLUMIVERSE_PR="$(echo $TARGET_LLUMIVERSE_MSG | grep -oP '(?<=#)\d+')"
           # Include the (sanitized) target branch so the same child SHA can have
           # distinct temp branches when synced into multiple base branches
-          # (e.g. main and maintenance/1.4).
+          # (e.g. main and release/1.4).
           export TARGET_BRANCH_SLUG="${TARGET_COMPOSABLEAI_BRANCH//\//-}"
           export TEMP_BRANCH="sync-llumiverse-${TARGET_BRANCH_SLUG}-${TARGET_LLUMIVERSE_SHA::7}"
 
@@ -207,7 +207,7 @@ jobs:
           fi
 
           # Ensure the dynamic `branch:<target>` label exists; for a new
-          # maintenance/X.Y line it won't, and `gh pr create --label` errors on
+          # release/X.Y line it won't, and `gh pr create --label` errors on
           # a missing label. `--force` is a no-op if it already exists.
           gh label create "branch:${TARGET_COMPOSABLEAI_BRANCH}" --color ededed --force
 

--- a/.github/workflows/update-git-submodule.yaml
+++ b/.github/workflows/update-git-submodule.yaml
@@ -42,11 +42,14 @@ jobs:
     permissions:
       contents: write       # required for pushing the temp branch and deleting old branches
       pull-requests: write  # required for creating new PRs and closing superseded ones
+      issues: write         # required for `gh label create` (labels are an Issues API resource)
     steps:
       - name: Validate branch
         run: |
-          if [[ "${TARGET_COMPOSABLEAI_BRANCH}" != "main" && "${TARGET_COMPOSABLEAI_BRANCH}" != "preview" ]]; then
-            echo "::error::Invalid branch '${TARGET_COMPOSABLEAI_BRANCH}'. Only 'main' and 'preview' branches are supported."
+          if [[ "${TARGET_COMPOSABLEAI_BRANCH}" != "main" \
+                && "${TARGET_COMPOSABLEAI_BRANCH}" != "preview" \
+                && ! "${TARGET_COMPOSABLEAI_BRANCH}" =~ ^maintenance/[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid branch '${TARGET_COMPOSABLEAI_BRANCH}'. Only 'main', 'preview', and 'maintenance/X.Y' branches are supported."
             exit 1
           fi
           echo "Branch '${TARGET_COMPOSABLEAI_BRANCH}' is valid."
@@ -132,7 +135,11 @@ jobs:
           #   - "Fix important bug in workflow (#123)" => "123"
           #   - "Update dependencies" => ""
           export MAYBE_LLUMIVERSE_PR="$(echo $TARGET_LLUMIVERSE_MSG | grep -oP '(?<=#)\d+')"
-          export TEMP_BRANCH="sync-llumiverse-${TARGET_LLUMIVERSE_SHA::7}"
+          # Include the (sanitized) target branch so the same child SHA can have
+          # distinct temp branches when synced into multiple base branches
+          # (e.g. main and maintenance/1.4).
+          export TARGET_BRANCH_SLUG="${TARGET_COMPOSABLEAI_BRANCH//\//-}"
+          export TEMP_BRANCH="sync-llumiverse-${TARGET_BRANCH_SLUG}-${TARGET_LLUMIVERSE_SHA::7}"
 
           cat << EOF >> $GITHUB_STEP_SUMMARY
           Type   | Item              | Value
@@ -198,6 +205,11 @@ jobs:
 
             This update does not correspond to any specific PR in llumiverse."
           fi
+
+          # Ensure the dynamic `branch:<target>` label exists; for a new
+          # maintenance/X.Y line it won't, and `gh pr create --label` errors on
+          # a missing label. `--force` is a no-op if it already exists.
+          gh label create "branch:${TARGET_COMPOSABLEAI_BRANCH}" --color ededed --force
 
           new_pr_url=$(gh pr create \
               --title "chore: update llumiverse to ${TARGET_LLUMIVERSE_SHA::7}" \


### PR DESCRIPTION
## Summary
Make the cross-repo submodule-sync automation work on `release/X.Y` release branches, so fixes on a release line propagate the same way they do on `main`:

- **`main.yaml`**: the downstream submodule-update dispatch now fires for `release/X.Y` pushes, and the `&&`/`||` precedence is fixed so the `push`-event guard applies to every branch in the set (not just `main`).
- **`update-git-submodule.yaml`** (llumiverse to composableai receiver): accept `release/X.Y` as a target branch; include the target branch in the temporary sync-branch name so the same llumiverse SHA can be synced into multiple base branches without collision; create the dynamic `branch:<target>` label before opening the PR (it won't exist for a brand-new release line); add `issues: write` for label creation.
- **`automerge-llumiverse.yaml`**: allow `release/X.Y` as an eligible base ref for auto-merging llumiverse sync PRs.

## Verification
- `actionlint` on the three workflows -- no new findings vs base (the remaining `SC2086:info` / `SC2155:warning` are pre-existing in the unchanged script bodies).

## Test Plan
- [ ] Push to a `release/X.Y` branch in llumiverse; confirm a sync PR is opened into `release/X.Y` here and auto-merges after checks pass.

Includes:
- llumiverse: https://github.com/vertesia/llumiverse/pull/476

🤖 Generated with [Claude Code](https://claude.com/claude-code)
