### PR TITLE
fix(client): derive per-env STS host so preview uses its own STS

### DIFF
--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -59,7 +59,8 @@ describe('Test Vertesia Client', () => {
         expect(client).toBeDefined();
         expect(client.baseUrl).toBe('https://api-preview.vertesia.io');
         expect(client.storeUrl).toBe('https://api-preview.vertesia.io');
-        expect(client.tokenServerUrl).toBe('https://sts.vertesia.io');
+        // preview keeps its env segment: api-preview → sts-preview (its own STS)
+        expect(client.tokenServerUrl).toBe('https://sts-preview.vertesia.io');
     });
 
     test('Initialization with site api.dev1.vertesia.io', () => {
@@ -81,7 +82,8 @@ describe('Test Vertesia Client', () => {
         expect(client).toBeDefined();
         expect(client.baseUrl).toBe('https://api-preview.dev1.vertesia.io');
         expect(client.storeUrl).toBe('https://api-preview.dev1.vertesia.io');
-        expect(client.tokenServerUrl).toBe('https://sts.dev1.vertesia.io');
+        // preview keeps its env segment: api-preview → sts-preview (its own STS)
+        expect(client.tokenServerUrl).toBe('https://sts-preview.dev1.vertesia.io');
     });
 
     test('Initialization with regional serverUrl (api.us1)', () => {
@@ -116,8 +118,8 @@ describe('Test Vertesia Client', () => {
 
         expect(client).toBeDefined();
         expect(client.baseUrl).toBe('https://api-preview.us1.vertesia.io');
-        // preview strips -preview., then api → sts: sts.us1.vertesia.io
-        expect(client.tokenServerUrl).toBe('https://sts.us1.vertesia.io');
+        // preview keeps its env segment: api-preview → sts-preview (its own versioned STS)
+        expect(client.tokenServerUrl).toBe('https://sts-preview.us1.vertesia.io');
     });
 
     test('Initialization with site localhost', () => {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -158,14 +158,17 @@ export class VertesiaClient extends AbstractFetchClient<VertesiaClient> {
         if (opts.tokenServerUrl) {
             this.tokenServerUrl = opts.tokenServerUrl;
         } else if (opts.site) {
-            // Strip -preview (preview uses the same STS as production for the same region),
-            // then replace api prefix with sts.
+            // Replace the leading api prefix with sts, preserving the env segment so each
+            // environment hits its own STS. preview/preprod run a separately versioned STS
+            // (sts-preview / sts-preprod); collapsing them onto the production sts.<region>
+            // can route to an older STS that rejects scopes the env-matched STS supports
+            // (e.g. `offline_access`).
             // Examples:
-            //   api.vertesia.io          -> sts.vertesia.io
-            //   api-preview.vertesia.io  -> sts.vertesia.io
-            //   api.us1.vertesia.io      -> sts.us1.vertesia.io
-            //   api-preview.eu1.vertesia.io -> sts.eu1.vertesia.io
-            const stsHost = opts.site.replace('api-preview.', 'api.').replace(/^api/, 'sts');
+            //   api.vertesia.io             -> sts.vertesia.io
+            //   api-preview.vertesia.io     -> sts-preview.vertesia.io
+            //   api.us1.vertesia.io         -> sts.us1.vertesia.io
+            //   api-preview.eu1.vertesia.io -> sts-preview.eu1.vertesia.io
+            const stsHost = opts.site.replace(/^api/, 'sts');
             this.tokenServerUrl = `https://${stsHost}`;
         } else if (opts.serverUrl || opts.storeUrl) {
             // Determine STS URL based on environment in serverUrl or storeUrl
@@ -173,11 +176,12 @@ export class VertesiaClient extends AbstractFetchClient<VertesiaClient> {
             try {
                 const url = new URL(urlToCheck);
                 if (url.hostname.startsWith('api')) {
-                    // Strip -preview and replace api with sts.
+                    // Replace the leading api prefix with sts, preserving the env segment so
+                    // preview/preprod hit their own STS rather than production's.
                     // api.us1.vertesia.io         -> sts.us1.vertesia.io
-                    // api-preview.us1.vertesia.io -> sts.us1.vertesia.io
+                    // api-preview.us1.vertesia.io -> sts-preview.us1.vertesia.io
                     // api.vertesia.io             -> sts.vertesia.io
-                    const stsHost = url.hostname.replace('api-preview.', 'api.').replace(/^api/, 'sts');
+                    const stsHost = url.hostname.replace(/^api/, 'sts');
                     this.tokenServerUrl = `https://${stsHost}`;
                 } else {
                     this.tokenServerUrl = 'https://sts.dev1.vertesia.io';


### PR DESCRIPTION
## Summary
- `VertesiaClient` derived `tokenServerUrl` by rewriting `api-preview.` → `api.` before mapping `api*` → `sts*`, which collapsed preview (and preprod) onto the **production** STS for a given region.
- That assumption ("preview uses the same STS as production") no longer holds: preview/preprod run their own separately-versioned STS (`sts-preview.<region>` / `sts-preprod.<region>`). Routing preview's OAuth/token calls to the production STS can hit an older deployment that rejects scopes the env-matched STS supports (e.g. `offline_access` during the authorization flow).
- Fix: drop the `api-preview.` → `api.` collapse so the leading `api` → `sts` rewrite preserves the env segment.

| `site` / `serverUrl` host | before | after |
|---|---|---|
| `api.us1.vertesia.io` | `sts.us1.vertesia.io` | `sts.us1.vertesia.io` (unchanged) |
| `api-preview.us1.vertesia.io` | `sts.us1.vertesia.io` | `sts-preview.us1.vertesia.io` |
| `api-preview.vertesia.io` | `sts.vertesia.io` | `sts-preview.vertesia.io` |

Applies to both the `opts.site` and `opts.serverUrl`/`opts.storeUrl` derivation paths. Explicitly passing `tokenServerUrl` is unaffected.

## Test Plan
- [x] `turbo build --filter=@vertesia/client`
- [x] `vitest run` in `packages/client` — 67/67 pass (updated the 3 `tokenServerUrl` derivation assertions for preview hosts)
- [x] `biome check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>