### PR TITLE
ci: backport plugin smoke-test fix (#1568) to release/1.4

### DIFF
--- a/.github/bin/lib-template-test.sh
+++ b/.github/bin/lib-template-test.sh
@@ -9,6 +9,7 @@
 # Variables set by this library:
 #   NPM_TAG        - "dev" (snapshot) or "latest" (release)
 #   TEMPLATE_REF   - "main" (snapshot) or "" (release — CLI resolves tag automatically)
+#   CREATE_ARGS    - Extra create-plugin args derived from release type
 #   TEST_PROJECT_DIR - Path to bootstrapped project (set by bootstrap_template)
 
 # =============================================================================
@@ -33,9 +34,13 @@ derive_tag_and_branch() {
     NPM_TAG="dev"
     # Use caller-supplied TEMPLATE_BRANCH so packages and template come from the same branch.
     TEMPLATE_REF="${TEMPLATE_BRANCH:-main}"
+    # Snapshot packages are published under the dev tag. Tell create-plugin to resolve
+    # internal workspace dependencies to that tag instead of its release templateVersions map.
+    CREATE_ARGS="--dev"
   else
     NPM_TAG="latest"
     TEMPLATE_REF=""
+    CREATE_ARGS=""
   fi
 }
 
@@ -56,6 +61,7 @@ bootstrap_template() {
   echo "  Template: ${TEMPLATE_NAME}"
   echo "  Ref: ${TEMPLATE_REF:-<auto>}"
   echo "  Tag: ${NPM_TAG}"
+  [ -n "$CREATE_ARGS" ] && echo "  Create args: ${CREATE_ARGS}"
   [ -n "$pkg_manager" ] && echo "  Package manager: ${pkg_manager}"
 
   # Create project in /tmp to avoid interference from composableai's pnpm-workspace.yaml
@@ -84,7 +90,7 @@ bootstrap_template() {
     npm_config_registry="${npm_config_registry:-}" \
     npm_config_package_lock="false" \
     npm_config_cache="${npm_cache_dir}" \
-    npm exec --yes -- "@vertesia/create-plugin@${NPM_TAG}" "$project_name" -t "${TEMPLATE_NAME}" --yes ${branch_args} ${pm_args} ${EXTRA_CREATE_ARGS:-})
+    npm exec --yes -- "@vertesia/create-plugin@${NPM_TAG}" "$project_name" -t "${TEMPLATE_NAME}" --yes ${CREATE_ARGS} ${branch_args} ${pm_args} ${EXTRA_CREATE_ARGS:-})
   rm -rf "${npm_cache_dir}"
 }
 

--- a/.github/bin/test-template-integration.sh
+++ b/.github/bin/test-template-integration.sh
@@ -130,10 +130,10 @@ publish_to_verdaccio() {
 
   local count=0
   while IFS= read -r pkg_dir; do
-    pkg_name=$(basename "$pkg_dir")
     cd "$pkg_dir"
+    pkg_name=$(npm pkg get name | tr -d '"')
     pkg_version=$(npm pkg get version | tr -d '"')
-    echo "  Publishing @vertesia/${pkg_name}@${pkg_version}..."
+    echo "  Publishing ${pkg_name}@${pkg_version}..."
     pnpm publish --access public --tag "${NPM_TAG}" --no-git-checks --registry "${VERDACCIO_URL}" > /dev/null 2>&1
     count=$((count + 1))
     cd "${SCRIPT_DIR}/../.."
@@ -147,9 +147,10 @@ workspace_package_dirs() {
   repo_root="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
   # Use pnpm workspace filtering so pnpm-workspace.yaml exclusions are authoritative.
-  pnpm -r --filter "./packages/**" exec pwd | while IFS= read -r pkg_dir; do
+  # Publish llumiverse/common first because several @vertesia packages depend on it.
+  pnpm -r --filter "./llumiverse/common" --filter "./packages/**" exec pwd | while IFS= read -r pkg_dir; do
     case "$pkg_dir" in
-      "${repo_root}"/packages/*)
+      "${repo_root}"/llumiverse/common|"${repo_root}"/packages/*)
         [ -f "${pkg_dir}/package.json" ] && printf '%s\n' "$pkg_dir"
         ;;
     esac

--- a/packages/create-plugin/package.json
+++ b/packages/create-plugin/package.json
@@ -28,8 +28,8 @@
     "author": "Vertesia",
     "license": "Apache-2.0",
     "templateVersions": {
-        "@vertesia": "1.3.0",
-        "@llumiverse": "1.3.0"
+        "@vertesia": "1.4.0-dev",
+        "@llumiverse": "1.4.0-dev"
     },
     "repository": {
         "type": "git",

--- a/packages/create-plugin/package.json
+++ b/packages/create-plugin/package.json
@@ -28,8 +28,8 @@
     "author": "Vertesia",
     "license": "Apache-2.0",
     "templateVersions": {
-        "@vertesia": "1.4.0-dev",
-        "@llumiverse": "1.4.0-dev"
+        "@vertesia": "1.3.0",
+        "@llumiverse": "1.3.0"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Summary

Backports the plugin template smoke-test fix from vertesia/composableai#1568 (merged to `main`) onto `release/1.4`.

The net change is limited to two CI scripts. An earlier `create-plugin` version bump on this branch was reverted, so `templateVersions` stays at `1.3.0` (no net change to `packages/create-plugin/package.json`).

## Changes

- **`.github/bin/lib-template-test.sh`** — in snapshot mode, pass `--dev` (new `CREATE_ARGS`) to `create-plugin` so internal workspace dependencies resolve to the `dev` npm tag instead of the release `templateVersions` map.
- **`.github/bin/test-template-integration.sh`** — publish `llumiverse/common` to verdaccio first (several `@vertesia` packages depend on it), and derive the published package name from `npm pkg get name` instead of the directory basename.

## Commits

- `ci: fix plugin smoke test (backport #1568)` — cherry-pick of `a98eb5c0`
- `Revert "update" (74440a8)` — restores `create-plugin` `templateVersions` to `1.3.0` (the prior bump to `1.4.0-dev` on this branch is undone)

## Net effect

`git diff release/1.4...fix-r14v` touches only the two CI scripts above; `packages/create-plugin/package.json` is unchanged relative to the base.
