### PR TITLE
feat(common,ui): OAuth owner-account fields + filter & agent-consent fixes

### DIFF
--- a/packages/common/src/oauth-server.ts
+++ b/packages/common/src/oauth-server.ts
@@ -40,6 +40,13 @@ export interface OAuthClientData {
     status: OAuthClientStatus;
     project_binding_mode: OAuthProjectBindingMode;
     fixed_project_id?: string;
+    /**
+     * When true (the default for new clients), the client may only be authorized for projects in its
+     * owning account/organization. Set to false to allow authorization for any project the approving
+     * user can access, regardless of account — required for OAuth/MCP clients used across
+     * organizations. The owning account itself is internal and not exposed here.
+     */
+    restrict_to_owner_account?: boolean;
     metadata?: Record<string, unknown>;
     created_by?: string;
     client_secret_configured?: boolean;
@@ -119,6 +126,7 @@ export interface CreateOAuthClientPayload {
     default_scopes?: string[];
     project_binding_mode?: OAuthProjectBindingMode;
     fixed_project_id?: string;
+    restrict_to_owner_account?: boolean;
     client_secret?: string;
     metadata?: Record<string, unknown>;
 }
@@ -134,6 +142,7 @@ export interface UpdateOAuthClientPayload {
     status?: OAuthClientStatus;
     project_binding_mode?: OAuthProjectBindingMode;
     fixed_project_id?: string;
+    restrict_to_owner_account?: boolean;
     client_secret?: string;
     metadata?: Record<string, unknown>;
 }
@@ -203,6 +212,14 @@ export interface OAuthAuthorizationRequest {
     requested_project_id?: string;
     project_binding_mode: OAuthProjectBindingMode;
     fixed_project_id?: string;
+    /**
+     * When true, the consent UI must constrain project selection to {@link owner_account_id}: the
+     * client may only be authorized for projects in its owning account. False (default) lets the user
+     * authorize any project they can access. Mirrors the server-side authorization enforcement.
+     */
+    restrict_to_owner_account?: boolean;
+    /** The owning account the client is restricted to, when {@link restrict_to_owner_account} is true. */
+    owner_account_id?: string;
     status: OAuthAuthorizationRequestStatus;
     created_at: string;
     expires_at: string;

--- a/packages/ui/src/core/components/shadcn/filters/filterBar.tsx
+++ b/packages/ui/src/core/components/shadcn/filters/filterBar.tsx
@@ -99,7 +99,11 @@ const FilterProvider = ({ filters, setFilters, filterGroups, children, inModal }
             const newFilters: Filter[] = [];
 
             for (const pair of filterPairs) {
-                const [encodedName, valuesString] = pair.split(':');
+                const separatorIndex = pair.indexOf(':');
+                if (separatorIndex === -1) continue;
+
+                const encodedName = pair.slice(0, separatorIndex);
+                const valuesString = pair.slice(separatorIndex + 1);
                 const name = decodeURIComponent(encodedName);
 
                 if (processedUrlFilters.current.has(name)) continue;
@@ -161,7 +165,10 @@ const FilterProvider = ({ filters, setFilters, filterGroups, children, inModal }
             }
 
             if (newFilters.length > 0) {
-                setFilters((prev) => [...prev, ...newFilters]);
+                setFilters((prev) => {
+                    const restoredNames = new Set(newFilters.map((filter) => filter.name));
+                    return [...prev.filter((filter) => !restoredNames.has(filter.name)), ...newFilters];
+                });
             }
 
             hasRestoredFromUrl.current = true;

--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
@@ -695,7 +695,10 @@ export interface ModernAgentConversationProps {
     pendingStartMessage?: string;
     /** Timestamp for the internal optimistic first-message waiting state. */
     pendingStartTimestamp?: number;
-    /** Initial approval mode to show while active run metadata loads. */
+    /**
+     * Initial approval mode: seeds the start screen for a new interactive run, and is shown
+     * while an existing run's metadata loads. Defaults to `full_control`.
+     */
     initialToolApprovalMode?: AgentToolApprovalMode;
     /** Force display playback controls on or off. When omitted, local playback can be toggled from the header. */
     enablePlayback?: boolean;
@@ -758,6 +761,7 @@ function StartWorkflowView({
     inputClassName,
     className,
     allowWorkflowControl,
+    initialToolApprovalMode,
 }: ModernAgentConversationProps) {
     const { t } = useUITranslation();
     const canStageFiles = !hideFileUpload;
@@ -771,7 +775,7 @@ function StartWorkflowView({
     const [pendingStartMessage, setPendingStartMessage] = useState<string | null>(null);
     const [pendingStartTimestamp, setPendingStartTimestamp] = useState<number | null>(null);
     const [toolApprovalMode, setToolApprovalMode] = useState<AgentToolApprovalMode>(() =>
-        normalizeAgentToolApprovalMode(undefined, interactive),
+        normalizeAgentToolApprovalMode(initialToolApprovalMode, interactive),
     );
     const toast = useToast();
     const inputRef = useRef<HTMLTextAreaElement>(null);


### PR DESCRIPTION
## Summary
- **common (OAuth server types):** add an optional `restrict_to_owner_account` flag to the OAuth client data and create/update payloads, and `restrict_to_owner_account` + `owner_account_id` to the OAuth authorization-request type. Lets consumers model OAuth clients that may only be authorized for projects in their owning account, and surface that constraint to the consent UI.
- **ui (FilterBar):** fix URL filter parsing — split each `name:value` pair on the first `:` only (values containing a colon were being truncated), and when restoring filters from the URL, replace existing same-named filters instead of appending duplicates.
- **ui (ModernAgentConversation):** the start screen now seeds its tool-approval mode from the `initialToolApprovalMode` prop (it previously always started from the default), so callers can choose the initial approval mode for a new interactive run.

## Test Plan
- [x] `@vertesia/common` and `@vertesia/ui` build clean (`turbo build`).
- [x] Type/UI additions are consumed and exercised by downstream consumer test suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)