### PR TITLE
Fix: ui improvement for agent right panel

### DIFF
--- a/packages/ui/src/features/agent/chat/AgentRightPanel.tsx
+++ b/packages/ui/src/features/agent/chat/AgentRightPanel.tsx
@@ -5,10 +5,7 @@ import {
     Button,
     Center,
     cn,
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
+    SelectBox,
     type Tab as TabDefinition,
     Tabs,
     TabsPanel,
@@ -18,8 +15,6 @@ import { useUITranslation } from '@vertesia/ui/i18n';
 import { useUserSession } from '@vertesia/ui/session';
 import {
     CheckCircleIcon,
-    CheckIcon,
-    ChevronsUpDownIcon,
     ClipboardCopyIcon,
     DownloadCloudIcon,
     FileTextIcon,
@@ -355,61 +350,6 @@ function WorkstreamsTab({ workstreams, messages, runId }: WorkstreamsTabProps) {
 
 type RightPanelTab = 'plan' | 'workstreams' | 'documents' | 'uploads' | 'artifacts' | 'payload' | 'conversation';
 
-function RightPanelTabSelect({
-    tabs,
-    activeTab,
-    onChange,
-    ariaLabel,
-}: {
-    tabs: TabDefinition[];
-    activeTab: RightPanelTab;
-    onChange: (tab: RightPanelTab) => void;
-    ariaLabel: string;
-}) {
-    const [open, setOpen] = useState(false);
-    const currentTab = tabs.find((tab) => tab.name === activeTab) ?? tabs[0];
-
-    return (
-        <DropdownMenu open={open} onOpenChange={setOpen}>
-            <DropdownMenuTrigger asChild>
-                <button
-                    type="button"
-                    aria-label={ariaLabel}
-                    aria-haspopup="menu"
-                    aria-expanded={open}
-                    className={cn(
-                        'inline-flex min-w-40 max-w-56 flex-row items-center justify-between gap-2 rounded-md border border-border bg-transparent px-2.5 py-2 text-start text-inherit',
-                        'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
-                        'hover:bg-muted',
-                    )}
-                >
-                    <span className="min-w-0 flex-1 overflow-hidden text-sm">{currentTab?.label}</span>
-                    <ChevronsUpDownIcon className="size-4 shrink-0 opacity-50" aria-hidden="true" />
-                </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" className="z-[1000000] min-w-56 max-w-[min(24rem,calc(100vw-1rem))]">
-                {tabs.map((tab) => {
-                    const isSelected = tab.name === activeTab;
-
-                    return (
-                        <DropdownMenuItem
-                            key={tab.name}
-                            className="min-h-9 justify-between gap-3 px-2 py-1.5 text-sm"
-                            onSelect={() => {
-                                onChange(tab.name as RightPanelTab);
-                                setOpen(false);
-                            }}
-                        >
-                            <span className="min-w-0 flex-1 overflow-hidden">{tab.label}</span>
-                            {isSelected && <CheckIcon className="size-4 shrink-0" aria-hidden="true" />}
-                        </DropdownMenuItem>
-                    );
-                })}
-            </DropdownMenuContent>
-        </DropdownMenu>
-    );
-}
-
 export interface AgentRightPanelProps {
     /** Optional payload content to show as a "Payload" tab */
     payloadContent?: React.ReactNode;
@@ -640,12 +580,13 @@ function AgentRightPanelComponent({
     return (
         <Tabs tabs={tabs} current={activeTab} onTabChange={handleTabChange} fullHeight className="px-0">
             <div className="flex items-center justify-between shrink-0 px-1 py-1 gap-1">
-                <div className="min-w-0">
-                    <RightPanelTabSelect
-                        ariaLabel={t('agent.selectRightPanelSection')}
-                        tabs={visibleTabs}
-                        activeTab={activeTab}
+                <div className="w-full">
+                    <SelectBox
+                        label={t('agent.selectRightPanelSection')}
+                        className="w-full"
+                        value={activeTab}
                         onChange={handleTabChange}
+                        options={visibleTabs.map((tab) => tab.name)}
                     />
                 </div>
                 {!conversationContent && (

--- a/packages/ui/src/i18n/locales/ar.json
+++ b/packages/ui/src/i18n/locales/ar.json
@@ -158,6 +158,7 @@
   "agent.searchDocuments": "البحث في المستندات",
   "agent.selectInteraction": "اختر تفاعلاً وانقر ابدأ لتشغيل الوكيل",
   "agent.selectRightPanelSection": "حدد قسم اللوحة اليمنى",
+  "agent.selectOption": "حدد خيارًا",
   "agent.send": "إرسال",
   "agent.sendTooltip": "انقر أو Enter للإرسال",
   "agent.showAllMessages": "عرض جميع الرسائل",

--- a/packages/ui/src/i18n/locales/de.json
+++ b/packages/ui/src/i18n/locales/de.json
@@ -154,6 +154,7 @@
   "agent.searchDocuments": "Dokumente suchen",
   "agent.selectInteraction": "Wählen Sie eine Interaktion aus und klicken Sie auf Starten, um einen Agenten zu starten",
   "agent.selectRightPanelSection": "Rechten Panelbereich auswählen",
+  "agent.selectOption": "Option auswählen",
   "agent.send": "Senden",
   "agent.sendTooltip": "Klicken oder Enter zum Senden",
   "agent.showAllMessages": "Alle Nachrichten anzeigen",

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -154,6 +154,7 @@
   "agent.searchDocuments": "Attach Documents",
   "agent.selectInteraction": "Select an interaction and click Start to start an agent",
   "agent.selectRightPanelSection": "Select right panel section",
+  "agent.selectOption": "Select Option",
   "agent.send": "Send",
   "agent.sendTooltip": "Click or Enter to send",
   "agent.showAllMessages": "Show all messages",

--- a/packages/ui/src/i18n/locales/es.json
+++ b/packages/ui/src/i18n/locales/es.json
@@ -155,6 +155,7 @@
   "agent.searchDocuments": "Buscar documentos",
   "agent.selectInteraction": "Selecciona una interacción y haz clic en Iniciar para iniciar un agente",
   "agent.selectRightPanelSection": "Seleccionar sección del panel derecho",
+  "agent.selectOption": "Seleccionar opción",
   "agent.send": "Enviar",
   "agent.sendTooltip": "Hacer clic o Enter para enviar",
   "agent.showAllMessages": "Mostrar todos los mensajes",

--- a/packages/ui/src/i18n/locales/fr.json
+++ b/packages/ui/src/i18n/locales/fr.json
@@ -155,6 +155,7 @@
   "agent.searchDocuments": "Rechercher des documents",
   "agent.selectInteraction": "Sélectionnez une interaction et cliquez sur Démarrer pour lancer un agent",
   "agent.selectRightPanelSection": "Sélectionner la section du panneau droit",
+  "agent.selectOption": "Sélectionner une option",
   "agent.send": "Envoyer",
   "agent.sendTooltip": "Cliquer ou Entrée pour envoyer",
   "agent.showAllMessages": "Afficher tous les messages",

--- a/packages/ui/src/i18n/locales/it.json
+++ b/packages/ui/src/i18n/locales/it.json
@@ -155,6 +155,7 @@
   "agent.searchDocuments": "Cerca documenti",
   "agent.selectInteraction": "Seleziona un'interazione e clicca Avvia per avviare un agente",
   "agent.selectRightPanelSection": "Seleziona sezione del pannello destro",
+  "agent.selectOption": "Seleziona opzione",
   "agent.send": "Invia",
   "agent.sendTooltip": "Clicca o Invio per inviare",
   "agent.showAllMessages": "Mostra tutti i messaggi",

--- a/packages/ui/src/i18n/locales/ja.json
+++ b/packages/ui/src/i18n/locales/ja.json
@@ -154,6 +154,7 @@
   "agent.searchDocuments": "ドキュメントを検索",
   "agent.selectInteraction": "インタラクションを選択して開始をクリックしてエージェントを起動",
   "agent.selectRightPanelSection": "右パネルのセクションを選択",
+  "agent.selectOption": "オプションを選択",
   "agent.send": "送信",
   "agent.sendTooltip": "クリックまたはEnterで送信",
   "agent.showAllMessages": "すべてのメッセージを表示",

--- a/packages/ui/src/i18n/locales/ko.json
+++ b/packages/ui/src/i18n/locales/ko.json
@@ -154,6 +154,7 @@
   "agent.searchDocuments": "문서 검색",
   "agent.selectInteraction": "인터랙션을 선택하고 시작을 클릭하여 에이전트를 시작하세요",
   "agent.selectRightPanelSection": "오른쪽 패널 섹션 선택",
+  "agent.selectOption": "옵션 선택",
   "agent.send": "보내기",
   "agent.sendTooltip": "클릭하거나 Enter로 전송",
   "agent.showAllMessages": "모든 메시지 표시",

--- a/packages/ui/src/i18n/locales/pt.json
+++ b/packages/ui/src/i18n/locales/pt.json
@@ -155,6 +155,7 @@
   "agent.searchDocuments": "Pesquisar documentos",
   "agent.selectInteraction": "Selecione uma interação e clique em Iniciar para iniciar um agente",
   "agent.selectRightPanelSection": "Selecionar seção do painel direito",
+  "agent.selectOption": "Selecionar opção",
   "agent.send": "Enviar",
   "agent.sendTooltip": "Clique ou Enter para enviar",
   "agent.showAllMessages": "Mostrar todas as mensagens",

--- a/packages/ui/src/i18n/locales/ru.json
+++ b/packages/ui/src/i18n/locales/ru.json
@@ -156,6 +156,7 @@
   "agent.searchDocuments": "Поиск документов",
   "agent.selectInteraction": "Выберите взаимодействие и нажмите Запустить, чтобы запустить агента",
   "agent.selectRightPanelSection": "Выбрать раздел правой панели",
+  "agent.selectOption": "Выбрать вариант",
   "agent.send": "Отправить",
   "agent.sendTooltip": "Нажмите или Enter для отправки",
   "agent.showAllMessages": "Показать все сообщения",

--- a/packages/ui/src/i18n/locales/tr.json
+++ b/packages/ui/src/i18n/locales/tr.json
@@ -154,6 +154,7 @@
   "agent.searchDocuments": "Belgeleri ara",
   "agent.selectInteraction": "Bir etkileşim seçin ve ajanı başlatmak için Başlat'a tıklayın",
   "agent.selectRightPanelSection": "Sağ panel bölümünü seç",
+  "agent.selectOption": "Seçenek seç",
   "agent.send": "Gönder",
   "agent.sendTooltip": "Göndermek için tıkla veya Enter",
   "agent.showAllMessages": "Tüm mesajları göster",

--- a/packages/ui/src/i18n/locales/zh-TW.json
+++ b/packages/ui/src/i18n/locales/zh-TW.json
@@ -154,6 +154,7 @@
   "agent.searchDocuments": "搜尋文件",
   "agent.selectInteraction": "選擇一個互動並點擊開始以啟動代理",
   "agent.selectRightPanelSection": "選擇右側面板區段",
+  "agent.selectOption": "選擇選項",
   "agent.send": "傳送",
   "agent.sendTooltip": "點擊或Enter傳送",
   "agent.showAllMessages": "顯示所有訊息",

--- a/packages/ui/src/i18n/locales/zh.json
+++ b/packages/ui/src/i18n/locales/zh.json
@@ -154,6 +154,7 @@
   "agent.searchDocuments": "搜索文档",
   "agent.selectInteraction": "选择一个交互并点击开始以启动代理",
   "agent.selectRightPanelSection": "选择右侧面板部分",
+  "agent.selectOption": "选择选项",
   "agent.send": "发送",
   "agent.sendTooltip": "点击或Enter发送",
   "agent.showAllMessages": "显示所有消息",


### PR DESCRIPTION
## Description

- Agent payload form: https://preview.cloud.vertesia.io/store/agents/6a28093fc261ddeb4bec096c?p=69d4762f24d3048c99149d0b&a=68b1779130afe5403a1589ba#conversation
  - Resolve IDs to labels
  - Config Details section shows JSON instead of table
  -  Add "Select Option" title back into the tab drop down 
  <img width="373" height="586" alt="Screenshot 2026-06-24 at 14 34 52" src="https://github.com/user-attachments/assets/da56658d-a1a8-421b-9247-3df5f855008d" />

