### PR TITLE
fix(build): stop cross-package re-emit by using tsc -p over tsc --build

### DIFF
--- a/libraries/jst/package.json
+++ b/libraries/jst/package.json
@@ -25,8 +25,8 @@
     "scripts": {
         "lint": "biome lint src",
         "test": "vitest run",
-        "build": "tsc --build && pnpm exec rollup -c",
-        "clean": "rm -rf ./lib tsconfig.tsbuildinfo",
+        "build": "tsc -p tsconfig.json && pnpm exec rollup -c",
+        "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo",
         "typecheck": "tsc --noEmit",
         "typecheck:test": "tsc -p tsconfig.test.json --noEmit"
     },

--- a/libraries/koa-stack/body/package.json
+++ b/libraries/koa-stack/body/package.json
@@ -4,8 +4,8 @@
     "description": "Expose the request body as a promise in koa Context.body",
     "type": "module",
     "scripts": {
-        "build": "tsc",
-        "clean": "rm -rf ./lib ./tsconfig.tsbuildinfo",
+        "build": "tsc -p tsconfig.json",
+        "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo",
         "test": "echo \"Error: no test specified\""
     },
     "files": [

--- a/libraries/koa-stack/router/package.json
+++ b/libraries/koa-stack/router/package.json
@@ -4,8 +4,8 @@
     "description": "A powerfull koa router using typescript decorations",
     "type": "module",
     "scripts": {
-        "build": "tsc",
-        "clean": "rm -rf ./lib ./tsconfig.tsbuildinfo",
+        "build": "tsc -p tsconfig.json",
+        "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo",
         "test": "vitest run"
     },
     "files": [

--- a/libraries/koa-stack/server/package.json
+++ b/libraries/koa-stack/server/package.json
@@ -4,8 +4,9 @@
     "description": " A web server based on koa with advanced routing, lazy body and flexbile error handling",
     "type": "module",
     "scripts": {
-        "build": "tsc --build",
-        "clean": "rm -rf ./lib ./tsconfig.tsbuildinfo",
+        "clean:lib": "rimraf ./lib ./tsconfig.tsbuildinfo",
+        "build": "pnpm run clean:lib && tsc -p tsconfig.json",
+        "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo",
         "test": "echo \"Error: no test specified\""
     },
     "files": [

--- a/libraries/koa-stack/tests/package.json
+++ b/libraries/koa-stack/tests/package.json
@@ -5,8 +5,9 @@
     "description": "Tests",
     "type": "module",
     "scripts": {
-        "build": "pnpm run clean && tsc --project ./tsconfig.build.json",
-        "clean": "rm -rf ./lib ./tsconfig.tsbuildinfo",
+        "clean:lib": "rimraf ./lib ./tsconfig.tsbuildinfo",
+        "build": "pnpm run clean:lib && tsc --project ./tsconfig.build.json",
+        "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo",
         "test": "pnpm exec vitest run src"
     },
     "keywords": [],

--- a/packages/api-fetch-client/package.json
+++ b/packages/api-fetch-client/package.json
@@ -19,8 +19,9 @@
         "test": "ESBK_TSCONFIG_PATH=./test/tsconfig.json pnpm exec mocha -r tsx --exit ./test/**/*.ts",
         "lint": "biome lint src",
         "typecheck:test": "tsc -p test/tsconfig.json --noEmit",
-        "build": "rm -rf ./lib ./tsconfig.tsbuildinfo && tsc --build",
-        "clean": "rm -rf ./node_modules ./lib ./tsconfig.tsbuildinfo"
+        "clean:lib": "rimraf ./lib ./tsconfig.tsbuildinfo",
+        "build": "pnpm run clean:lib && tsc -p tsconfig.json",
+        "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
     },
     "repository": {
         "type": "git",

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -17,8 +17,9 @@
         "lint": "biome lint src",
         "test": "vitest run",
         "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
-        "build": "rm -rf ./lib ./tsconfig.tsbuildinfo && tsc --build && chmod +x ./lib/bin/build.js",
-        "clean": "rm -rf ./node_modules ./lib ./tsconfig.tsbuildinfo"
+        "clean:lib": "rimraf ./lib ./tsconfig.tsbuildinfo",
+        "build": "pnpm run clean:lib && tsc -p tsconfig.json && chmod +x ./lib/bin/build.js",
+        "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
     },
     "exports": {
         ".": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,8 +27,9 @@
     ],
     "scripts": {
         "lint": "biome lint src",
-        "build": "tsc --build",
-        "clean": "rm -rf ./lib ./tsconfig.tsbuildinfo && tsc --build"
+        "clean:lib": "rimraf ./lib ./tsconfig.tsbuildinfo",
+        "build": "pnpm run clean:lib && tsc -p tsconfig.json",
+        "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
     },
     "dependencies": {
         "@llumiverse/common": "workspace:*",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -12,8 +12,9 @@
     "license": "Apache-2.0",
     "scripts": {
         "lint": "biome lint src",
-        "build": "rm -rf ./lib ./tsconfig.tsbuildinfo && tsc --build && pnpm exec rollup -c",
-        "clean": "rm -rf ./node_modules ./lib ./tsconfig.tsbuildinfo",
+        "clean:lib": "rimraf ./lib ./tsconfig.tsbuildinfo",
+        "build": "pnpm run clean:lib && tsc -p tsconfig.json && pnpm exec rollup -c",
+        "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo",
         "test": "vitest run",
         "typecheck:test": "tsc -p tsconfig.test.json --noEmit"
     },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -14,8 +14,9 @@
         "lint": "biome lint src",
         "test": "vitest run",
         "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
-        "build": "rm -rf ./lib ./tsconfig.tsbuildinfo && tsc --build && pnpm exec rollup -c",
-        "clean": "rm -rf ./node_modules ./lib ./tsconfig.tsbuildinfo"
+        "clean:lib": "rimraf ./lib ./tsconfig.tsbuildinfo",
+        "build": "pnpm run clean:lib && tsc -p tsconfig.json && pnpm exec rollup -c",
+        "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
     },
     "exports": {
         ".": {

--- a/packages/common/rollup.config.js
+++ b/packages/common/rollup.config.js
@@ -3,7 +3,7 @@ import nodeResolve from '@rollup/plugin-node-resolve';
 import terser from '@rollup/plugin-terser';
 
 // Bundles the already-built ES output (`lib/index.js`, produced by `tsc`) into a single
-// browser-friendly file. Build script: `tsc && rollup -c`.
+// browser-friendly file. Build script: `tsc -p tsconfig.json && rollup -c`.
 const TARGET_FILE = 'lib/vertesia-common.js';
 
 export default {

--- a/packages/converters/package.json
+++ b/packages/converters/package.json
@@ -14,8 +14,9 @@
         "lint": "biome lint src",
         "test": "vitest run",
         "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
-        "build": "rm -rf ./lib ./tsconfig.tsbuildinfo && tsc --build",
-        "clean": "rm -rf ./node_modules ./lib ./tsconfig.tsbuildinfo"
+        "clean:lib": "rimraf ./lib ./tsconfig.tsbuildinfo",
+        "build": "pnpm run clean:lib && tsc -p tsconfig.json",
+        "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
     },
     "exports": {
         ".": {

--- a/packages/create-plugin/package.json
+++ b/packages/create-plugin/package.json
@@ -12,7 +12,8 @@
     ],
     "scripts": {
         "lint": "biome lint src",
-        "build": "tsc",
+        "build": "tsc -p tsconfig.json",
+        "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo",
         "dev": "tsc --watch",
         "test": "node ./scripts/run-smoke-test.mjs",
         "prepublishOnly": "pnpm run build"

--- a/packages/fusion-ux/package.json
+++ b/packages/fusion-ux/package.json
@@ -20,7 +20,9 @@
         "react"
     ],
     "scripts": {
-        "build": "rm -rf ./lib ./tsconfig.tsbuildinfo && tsc --build && pnpm exec rollup -c",
+        "clean:lib": "rimraf ./lib ./tsconfig.tsbuildinfo",
+        "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo",
+        "build": "pnpm run clean:lib && tsc -p tsconfig.json && pnpm exec rollup -c",
         "lint": "biome lint src",
         "lint:fix": "biome lint --write src",
         "test": "vitest run",

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -14,8 +14,9 @@
         "lint": "biome lint src",
         "test": "vitest run",
         "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
-        "build": "rm -rf ./lib ./tsconfig.tsbuildinfo && tsc --build && pnpm exec rollup -c",
-        "clean": "rm -rf ./node_modules ./lib ./tsconfig.tsbuildinfo"
+        "clean:lib": "rimraf ./lib ./tsconfig.tsbuildinfo",
+        "build": "pnpm run clean:lib && tsc -p tsconfig.json && pnpm exec rollup -c",
+        "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
     },
     "exports": {
         ".": {

--- a/packages/json/tsconfig.json
+++ b/packages/json/tsconfig.json
@@ -4,8 +4,5 @@
         "rootDir": "./src",
         "outDir": "./lib",
     },
-    "include": ["src"],
-    "references": [
-        { "path": "../../llumiverse/common" }
-    ]
+    "include": ["src"]
 }

--- a/packages/plugin-builder/package.json
+++ b/packages/plugin-builder/package.json
@@ -23,8 +23,8 @@
     ],
     "scripts": {
         "lint": "biome lint src",
-        "build": "tsc",
-        "clean": "rm -rf ./lib ./tsconfig.tsbuildinfo && tsc"
+        "build": "tsc -p tsconfig.json",
+        "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
     },
     "devDependencies": {
         "@vertesia/tsconfig": "workspace:*",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -21,8 +21,9 @@
     ],
     "scripts": {
         "lint": "biome lint src",
-        "build": "tsc --build",
-        "clean": "rm -rf ./lib ./tsconfig.tsbuildinfo && tsc --build"
+        "clean:lib": "rimraf ./lib ./tsconfig.tsbuildinfo",
+        "build": "pnpm run clean:lib && tsc -p tsconfig.json",
+        "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
     },
     "devDependencies": {
         "@types/react": "^19.2.17",

--- a/packages/studio-utils/package.json
+++ b/packages/studio-utils/package.json
@@ -44,8 +44,9 @@
     "scripts": {
         "lint": "biome lint src",
         "test": "vitest run",
-        "build": "pnpm exec tsc --build && pnpm exec rollup -c",
-        "clean": "rm -rf ./lib ./tsconfig.tsbuildinfo && pnpm exec tsc --build && pnpm exec rollup -c"
+        "clean:lib": "rimraf ./lib ./tsconfig.tsbuildinfo",
+        "build": "pnpm run clean:lib && pnpm exec tsc -p tsconfig.json && pnpm exec rollup -c",
+        "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^29.0.3",

--- a/packages/tools-admin-ui/package.json
+++ b/packages/tools-admin-ui/package.json
@@ -17,7 +17,9 @@
     },
     "scripts": {
         "lint": "biome lint src",
-        "build": "rm -rf lib tsconfig.tsbuildinfo && tsc --build && vite build --mode lib",
+        "clean:lib": "rimraf ./lib ./tsconfig.tsbuildinfo",
+        "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo",
+        "build": "pnpm run clean:lib && tsc -p tsconfig.json && vite build --mode lib",
         "dev": "vite dev"
     },
     "peerDependencies": {

--- a/packages/tools-sdk/package.json
+++ b/packages/tools-sdk/package.json
@@ -14,8 +14,9 @@
         "lint": "biome lint src",
         "test": "vitest run",
         "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
-        "build": "rm -rf ./lib ./tsconfig.tsbuildinfo && tsc",
-        "clean": "rm -rf ./node_modules ./lib ./tsconfig.tsbuildinfo"
+        "clean:lib": "rimraf ./lib ./tsconfig.tsbuildinfo",
+        "build": "pnpm run clean:lib && tsc -p tsconfig.json",
+        "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
     },
     "exports": {
         ".": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -21,7 +21,9 @@
         "hooks"
     ],
     "scripts": {
-        "build": "pnpm run check:locales && rm -rf ./lib ./tsconfig.tsbuildinfo && tsc --build && pnpm exec rollup -c",
+        "clean:lib": "rimraf ./lib ./tsconfig.tsbuildinfo",
+        "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo",
+        "build": "pnpm run check:locales && pnpm run clean:lib && tsc -p tsconfig.json && pnpm exec rollup -c",
         "lint": "biome lint src && pnpm run check:rtl-classes",
         "lint:fix": "biome lint --write src",
         "check:locales": "node scripts/check-locales.mjs",

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -16,8 +16,9 @@
         "lint": "biome lint src",
         "test": "vitest run",
         "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
-        "build": "rm -rf ./lib ./tsconfig.tsbuildinfo && tsc --build && node ./bin/bundle-workflows.mjs lib/workflows.js lib/workflows-bundle.js",
-        "clean": "rm -rf ./lib tsconfig.tsbuildinfo"
+        "clean:lib": "rimraf ./lib ./tsconfig.tsbuildinfo",
+        "build": "pnpm run clean:lib && tsc -p tsconfig.json && node ./bin/bundle-workflows.mjs lib/workflows.js lib/workflows-bundle.js",
+        "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo"
     },
     "license": "Apache-2.0",
     "devDependencies": {


### PR DESCRIPTION
## Summary
- Packages with cross-package TypeScript project references built with `tsc --build`, which **re-emits every referenced project's output**. Under turbo's parallel builds, many packages concurrently rewrote the same shared `lib/` directories (`llumiverse/common` alone is re-emitted by **11** packages) while another package's `rollup` read them — producing flaky `Could not resolve "./options/context-windows.js"` errors.
- Switch in-graph single-project packages to **`tsc -p tsconfig.json`** so each builds only itself and relies on turbo's `^build` for dependency ordering. This also future-proofs: a later-added cross-package reference can't silently re-introduce the race. `tsc --build` is kept only for out-of-workspace packages that build their own deps standalone.
- Remove a **dead `llumiverse/common` project reference** from `@vertesia/json` (it imports nothing from it; the reference only triggered re-emit).
- Standardize build/clean scripts: `rimraf` for portability, `clean:lib` for build-time output cleaning, canonical deep `clean`.

This reverts the mechanism of #1527 (which introduced `tsc --build` for these packages) while preserving its intended benefit — correct cross-project type resolution with no `TS7016`/`TS2307` — now provided by turbo ordering instead of in-task re-emit.

## Test Plan
- [x] `pnpm build --force` — full monorepo build green (56/56 tasks)
- [x] Forced parallel rebuilds (`turbo build --force --concurrency=10`) of the previously-racing chain — green across repeated runs
- [x] `biome check` on all changed files — clean
- [x] Verified each converted package's tsconfig is single-project (`include`-based), so `tsc -p` emits correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>