### PR TITLE
feat(common): add skill_instructions_delivered to ConversationState

### DIFF
--- a/packages/common/src/store/conversation-state.ts
+++ b/packages/common/src/store/conversation-state.ts
@@ -158,6 +158,18 @@ export interface ConversationState {
     skill_tool_map?: Record<string, string[]>;
 
     /**
+     * Names of skills whose full instructions are already present in the live conversation
+     * history (i.e. were delivered by a prior `learn_<skill>` call). Used to make skill
+     * re-activation idempotent: a repeat call returns a short "already active" acknowledgement
+     * instead of re-dumping the instructions.
+     *
+     * Unlike `unlocked_tools`/`skill_tool_map` (which must survive a checkpoint so tools stay
+     * unlocked), this list is reset when a checkpoint compacts the conversation, because the
+     * summary no longer carries the skill instructions and the next call must re-deliver them.
+     */
+    skill_instructions_delivered?: string[];
+
+    /**
      * Denylist of MCP tool-collection ids deactivated for this conversation.
      * `undefined`/empty means all installed/connected MCP collections are active.
      * Updated mid-conversation via the MCP config signal; consumed when tools are re-discovered.


### PR DESCRIPTION
## Summary
- Add an optional `skill_instructions_delivered?: string[]` field to `ConversationState`.
- It records which skills have already delivered their full instructions into the live conversation, so an agent runtime can make skill (`learn_<skill>`) re-activation idempotent — returning a short "already active" acknowledgement on a repeat call instead of re-dumping the full instruction text.
- Intentionally has a different lifecycle from `unlocked_tools` / `skill_tool_map`: those must survive a conversation checkpoint (so tools stay unlocked), whereas this list is reset when a checkpoint compacts the conversation, because the summary no longer carries the original instructions and the next activation must re-deliver them in full.

This is a purely additive, optional field on a shared type; existing consumers are unaffected.

## Test Plan
- [x] `@vertesia/common` builds (`pnpm build`)
- [x] Consumed by the agent conversation workflow (separate change), whose unit tests exercise the set/reset contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>