### PR TITLE
fix(ci): unblock release/1.4 npm publishing and template integration test

### DIFF
--- a/.github/bin/test-template-integration.sh
+++ b/.github/bin/test-template-integration.sh
@@ -82,10 +82,14 @@ packages:
   '@vertesia/*':
     access: $all
     publish: $all
+  # Local-only (no npmjs proxy): we publish the vendored @llumiverse/common from
+  # the submodule, and it is the only @llumiverse package the templates need.
+  # Without a proxy, verdaccio never consults npm for this scope, so re-publishing
+  # a version that already exists upstream (a pinned submodule snapshot) succeeds
+  # instead of failing with a 409 conflict.
   '@llumiverse/*':
     access: $all
     publish: $all
-    proxy: npmjs
   '@dglabs/*':
     access: $all
     publish: $all
@@ -134,7 +138,17 @@ publish_to_verdaccio() {
     pkg_name=$(npm pkg get name | tr -d '"')
     pkg_version=$(npm pkg get version | tr -d '"')
     echo "  Publishing ${pkg_name}@${pkg_version}..."
-    pnpm publish --access public --tag "${NPM_TAG}" --no-git-checks --registry "${VERDACCIO_URL}" > /dev/null 2>&1
+    # @vertesia/* and @llumiverse/* are local-only scopes in the verdaccio config
+    # (no npmjs proxy), so publishing always targets local storage and never
+    # conflicts with an already-published upstream version. Surface the real
+    # error on failure instead of discarding it.
+    local output
+    if ! output=$(pnpm publish --access public --tag "${NPM_TAG}" --no-git-checks --registry "${VERDACCIO_URL}" 2>&1); then
+      echo "ERROR: failed to publish ${pkg_name}@${pkg_version} to verdaccio:" >&2
+      printf '%s\n' "$output" >&2
+      cd "${SCRIPT_DIR}/../.."
+      return 1
+    fi
     count=$((count + 1))
     cd "${SCRIPT_DIR}/../.."
   done < <(workspace_package_dirs)

--- a/.github/workflows/publish-koa.yaml
+++ b/.github/workflows/publish-koa.yaml
@@ -48,11 +48,16 @@ jobs:
       contents: write # required to push version-bump commits for preview
     steps:
       - name: Checkout repository
+        # persist-credentials must stay true so the DEPLOY_KEY SSH config survives
+        # into the publish step, where the script runs `git push origin "$REF"` to
+        # push the version-bump commit past branch protection. With it false, the
+        # push fails with "git@github.com: Permission denied (publickey)".
+        # zizmor: ignore[artipacked] deploy key is scoped to the `build` environment.
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: recursive
           ssh-key: ${{ secrets.DEPLOY_KEY }} # Use deploy key to bypass branch protection rules
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -48,11 +48,16 @@ jobs:
       contents: write # required to push version-bump commits for preview
     steps:
       - name: Checkout repository
+        # persist-credentials must stay true so the DEPLOY_KEY SSH config survives
+        # into the publish step, where the script runs `git push origin "$REF"` to
+        # push the version-bump commit past branch protection. With it false, the
+        # push fails with "git@github.com: Permission denied (publickey)".
+        # zizmor: ignore[artipacked] deploy key is scoped to the `build` environment.
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: recursive
           ssh-key: ${{ secrets.DEPLOY_KEY }} # Use deploy key to bypass branch protection rules
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9


### PR DESCRIPTION
## Summary

Two CI fixes that unblock the `release/1.4` npm publishing pipeline, plus a llumiverse submodule bump.

### 1. Persist the deploy key so the npm publish push succeeds

Both publish workflows — `(publish) NPM packages` (`publish-npm.yaml`) and `(publish) NPM koa-stack packages` (`publish-koa.yaml`) — check out with `ssh-key: ${{ secrets.DEPLOY_KEY }}` but also set `persist-credentials: false`. That unsets the SSH config (`core.sshCommand`) right after checkout, so when the shared `publish-all-packages.sh` later runs `git push origin "$REF"` (plus a tag push) for the version-bump commit, there is no key to authenticate with:

```
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
```

The push only runs when `dry_run=false` (the default is `true`), so it stayed hidden until the first real publish. Fix: set `persist-credentials: true` on the publish-job checkout in both workflows; the key is scoped to the dedicated `build` environment, so a `zizmor: ignore[artipacked]` annotation keeps the audit green. The integration-test-job checkout is left as `false` (no `ssh-key`, never pushes).

Verified live in llumiverse: after #497 merged, the publish workflow successfully pushed snapshot `6a0a649 chore: snapshot 1.4.0-dev.20260629.090753Z` to `release/1.4`.

### 2. Make `@llumiverse/*` a local-only verdaccio scope

The template integration test (`test-template-integration.sh`) publishes the vendored workspace packages to a local verdaccio. verdaccio proxied `@llumiverse/*` to npmjs, so once the llumiverse submodule is pinned to a real, already-published snapshot (`@llumiverse/common@1.4.0-dev.20260629.090753Z`), re-publishing that exact version was rejected with a 409 conflict. The publish output was sent to `/dev/null` under `set -e`, so the job failed silently with exit 1.

`@llumiverse/common` is the only `@llumiverse` package the templates need (7 `@vertesia` packages depend on it; nothing needs `core`/`drivers`/`examples`), and it is published locally. So the npmjs proxy on that scope is unnecessary. Fix: drop it so `@llumiverse/*` is local-only (like `@vertesia/*`) — verdaccio never consults npm for our own packages, and re-publishing an already-upstream version simply succeeds. Third-party deps still come from npm via the `**` uplink. Also surfaces the real publish error on failure instead of discarding it.

## Submodule change

- Bumps the `llumiverse` submodule to `6a0a649` (includes llumiverse #497 and the latest 1.4 snapshot).

## Test Plan

- [x] `actionlint` passes (pre-commit hook) for both workflow files
- [x] `bash -n` clean on `test-template-integration.sh`
- [x] Dependency check: only `@llumiverse/common` is needed from the `@llumiverse` scope, and it is published locally — so the npmjs proxy was safe to drop
- [x] CI green on this branch — Template integration test publishes 17 packages locally and passes; Unit tests pass
- [ ] Trigger each publish workflow with `dry_run=false` and confirm the version-bump commit pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>