### PR TITLE
ci: publish @koa-stack packages via the shared publish script

### DIFF
--- a/.github/bin/publish-all-packages.md
+++ b/.github/bin/publish-all-packages.md
@@ -6,8 +6,11 @@ The file `publish-all-packages.sh` contains logic for publishing vertesia packag
 
 The `publish-all-packages.sh` script handles publishing packages with appropriate versioning based on the git branch:
 
-- **`@vertesia/*` packages**: Publish on both `main` and `preview` branches
+- **`@vertesia/*` packages** (`--scope vertesia`, the default): Publish on both `main` and `preview` branches. Versioned off the repository-root `package.json`. Driven by `publish-npm.yaml`.
+- **`@koa-stack/*` packages** (`--scope koa-stack`): the koa-stack libraries in `libraries/koa-stack/*`. They are published on an independent version line (versioned off `libraries/koa-stack/router/package.json`, not the root) by the separate `publish-koa.yaml` workflow. The private `@koa-stack/tests` package is never published.
 - **`@llumiverse/*` packages**: out of scope. They are handled by another GitHub Actions workflow, defined in their GitHub repository "vertesia/llumiverse".
+
+Both scopes share this single script: the `--scope` flag selects which package set, version source, npm scope label, git-tag prefix, and template-update behavior to use. `@vertesia`-only steps (root `package.json` bump, `create-plugin` template version sync) are skipped for `koa-stack`.
 
 ## Usage
 
@@ -30,6 +33,7 @@ The `publish-all-packages.sh` script handles publishing packages with appropriat
   - `patch` increases the patch version in the package version
   - `keep` keeps using the current base version.
 - `--dry-run` (optional): Flag to enable dry run mode. The value can be `true`, `false` or no value (which means `true`). If not specified, it means that it is not a dry-run.
+- `--scope` (optional): The publish scope, `vertesia` (default) or `koa-stack`. Selects the package set and version line (see the Overview). Omit it for `@vertesia` publishing.
 
 ### Examples
 
@@ -213,16 +217,23 @@ The `publish-all-packages.sh` script handles publishing packages with appropriat
 
 ## GitHub Actions Workflow
 
-The script is designed to be run from the `publish-npm.yaml` GitHub Actions workflow:
+The script is run from two GitHub Actions workflows that share the same inputs and concurrency group, differing only by `--scope`:
+
+- `publish-npm.yaml` → `--scope vertesia` (the `@vertesia/*` packages)
+- `publish-koa.yaml` → `--scope koa-stack` (the `@koa-stack/*` packages)
 
 ```yaml
+# publish-npm.yaml
 - name: Publish all packages
   run: |
     ./.github/bin/publish-all-packages.sh \
+        --scope vertesia \
         --ref "${{ inputs.ref }}" \
         --release-type "${{ inputs.release_type }}" \
         --bump-type "${{ inputs.bump_type }}" \
         --dry-run "${{ inputs.dry_run }}"
+
+# publish-koa.yaml — identical, with --scope koa-stack
 ```
 
 ### Workflow Inputs

--- a/.github/bin/publish-all-packages.sh
+++ b/.github/bin/publish-all-packages.sh
@@ -2,11 +2,15 @@
 set -e
 
 # Script to publish all composableai packages to NPM
-# Usage: publish-all-packages.sh --ref <ref> --release-type <type> --bump-type <type> [--dry-run [true|false]]
+# Usage: publish-all-packages.sh --ref <ref> --release-type <type> --bump-type <type> [--dry-run [true|false]] [--scope <vertesia|koa-stack>]
 #   --ref: Git reference (main for dev builds, preview for releases)
 #   --release-type: Release type (release, snapshot). Release creates stable versions, snapshot creates dev versions.
 #   --bump-type: Bump type (minor, patch, keep). How to change the version.
 #   --dry-run: Optional flag for dry run mode (value can be true, false, or omitted which means true)
+#   --scope: Optional publish scope (default: vertesia).
+#     - vertesia:  @vertesia/* packages (packages/** + libraries/jst), versioned off the root package.json.
+#     - koa-stack: @koa-stack/* packages (libraries/koa-stack/*), versioned independently off libraries/koa-stack/router.
+#     Both scopes share this script but have a different release cadence and version line.
 
 # =============================================================================
 # Functions
@@ -17,14 +21,36 @@ workspace_package_dirs() {
   repo_root="$(git rev-parse --show-toplevel)"
 
   # Use pnpm workspace filtering so pnpm-workspace.yaml exclusions are authoritative.
-  # Published scope: all packages/* + libraries/jst. Libraries/koa-stack/* are
-  # published by a separate workflow (different release cadence).
-  pnpm -r --filter "./packages/**" --filter "./libraries/jst" exec pwd | while IFS= read -r pkg_dir; do
-    case "$pkg_dir" in
-      "${repo_root}"/packages/*|"${repo_root}"/libraries/jst)
-        [ -f "${pkg_dir}/package.json" ] && printf '%s\n' "$pkg_dir"
+  # The filter and the allowed-path guard are scope-specific (see configure_scope):
+  #   - vertesia:  packages/* + libraries/jst
+  #   - koa-stack: libraries/koa-stack/* (independent release cadence)
+  pnpm -r "${PKG_FILTERS[@]}" exec pwd | while IFS= read -r pkg_dir; do
+    [ -f "${pkg_dir}/package.json" ] || continue
+
+    # Belt-and-suspenders: only keep dirs under the scope's expected subtree, so a
+    # stray workspace match can never be published under the wrong release line.
+    case "$SCOPE" in
+      vertesia)
+        case "$pkg_dir" in
+          "${repo_root}"/packages/*|"${repo_root}"/libraries/jst) ;;
+          *) continue ;;
+        esac
+        ;;
+      koa-stack)
+        case "$pkg_dir" in
+          "${repo_root}"/libraries/koa-stack/*) ;;
+          *) continue ;;
+        esac
         ;;
     esac
+
+    # Never publish private packages (e.g. @koa-stack/tests). `npm pkg get private`
+    # prints `{}` when the field is absent, so only an explicit `true` is skipped.
+    if [ "$(cd "$pkg_dir" && npm pkg get private | tr -d '"')" = "true" ]; then
+      continue
+    fi
+
+    printf '%s\n' "$pkg_dir"
   done
 }
 
@@ -38,8 +64,9 @@ update_package_versions() {
     npm_tag="latest"
   fi
 
-  # Get current version and strip any existing -dev* suffix to get base version
-  current_version=$(npm pkg get version | tr -d '"')
+  # Get current version (from the scope's version source) and strip any existing
+  # -dev* suffix to get the base version.
+  current_version=$( (cd "$VERSION_SOURCE_DIR" && npm pkg get version) | tr -d '"')
   base_version=$(echo "$current_version" | sed 's/-dev.*//')
 
   # Apply bump if needed (for both snapshot and release)
@@ -67,11 +94,14 @@ update_package_versions() {
     echo "Updating to release version ${new_version}"
   fi
 
-  # Update root package.json
-  npm version "${new_version}" --no-git-tag-version --workspaces=false
+  # Update root package.json (only for the vertesia scope — the root version is
+  # @vertesia's source of truth; koa-stack versions live in their own packages).
+  if [ "$UPDATE_ROOT_VERSION" = "true" ]; then
+    npm version "${new_version}" --no-git-tag-version --workspaces=false
+  fi
 
-  # Update all workspace packages (excluding llumiverse and libraries/koa-stack/*)
-  pnpm -r --filter "./packages/**" --filter "./libraries/jst" exec npm version "${new_version}" --no-git-tag-version
+  # Update every package in the scope's publish set.
+  pnpm -r "${PKG_FILTERS[@]}" exec npm version "${new_version}" --no-git-tag-version
 }
 
 publish_packages() {
@@ -89,7 +119,7 @@ publish_packages() {
       exit 1
     fi
 
-    echo "Publishing @vertesia/${pkg_name}@${pkg_version} with tag ${npm_tag}"
+    echo "Publishing ${NPM_SCOPE}/${pkg_name}@${pkg_version} with tag ${npm_tag}"
 
     # Publish
     if [ -n "$DRY_RUN_FLAG" ]; then
@@ -108,10 +138,10 @@ write_package_summary_rows() {
   while IFS= read -r pkg_dir; do
     pkg_name=$(basename "$pkg_dir")
     if [ "$DRY_RUN" = "true" ]; then
-      echo "| \`@vertesia/${pkg_name}\` | ${version} |" >> "$GITHUB_STEP_SUMMARY"
+      echo "| \`${NPM_SCOPE}/${pkg_name}\` | ${version} |" >> "$GITHUB_STEP_SUMMARY"
     else
-      pkg_url="https://www.npmjs.com/package/@vertesia/${pkg_name}?activeTab=versions"
-      echo "| \`@vertesia/${pkg_name}\` | [${version}](${pkg_url}) |" >> "$GITHUB_STEP_SUMMARY"
+      pkg_url="https://www.npmjs.com/package/${NPM_SCOPE}/${pkg_name}?activeTab=versions"
+      echo "| \`${NPM_SCOPE}/${pkg_name}\` | [${version}](${pkg_url}) |" >> "$GITHUB_STEP_SUMMARY"
     fi
   done < <(workspace_package_dirs)
 }
@@ -155,27 +185,36 @@ update_template_versions() {
 commit_and_push() {
   echo "=== Committing version changes ==="
 
-  # Get the version from root package.json
-  version=$(npm pkg get version | tr -d '"')
+  # Get the version from the scope's version source.
+  version=$( (cd "$VERSION_SOURCE_DIR" && npm pkg get version) | tr -d '"')
 
   git config user.email "github-actions[bot]@users.noreply.github.com"
   git config user.name "github-actions[bot]"
   git add .
 
+  # Tag the scope in non-default commit messages so koa-stack and @vertesia
+  # version bumps stay distinguishable in the shared branch history.
+  local scope_label=""
+  [ "$SCOPE" != "vertesia" ] && scope_label="${NPM_SCOPE} "
+
   if [ "$RELEASE_TYPE" = "release" ]; then
-    git commit -m "chore: release ${version}"
+    git commit -m "chore: release ${scope_label}${version}"
   else
-    git commit -m "chore: snapshot ${version}"
+    git commit -m "chore: snapshot ${scope_label}${version}"
   fi
 
   git push origin "$REF"
 
-  # Create git tag for template stability on releases
+  # Create git tag(s) for release stability. vertesia publishes both the legacy
+  # `v${version}` (for backward compatibility) and the namespaced
+  # `vertesia/v${version}`; koa-stack uses its own `koa-stack/v${version}` line.
   if [ "$RELEASE_TYPE" = "release" ]; then
-    tag_name="v${version}"
-    git tag "$tag_name"
-    git push origin "$tag_name"
-    echo "Created and pushed tag: ${tag_name}"
+    for tag_prefix in "${TAG_PREFIXES[@]}"; do
+      tag_name="${tag_prefix}${version}"
+      git tag "$tag_name"
+      git push origin "$tag_name"
+      echo "Created and pushed tag: ${tag_name}"
+    done
   fi
 
   echo "Version changes pushed to ${REF}"
@@ -190,8 +229,8 @@ write_github_summary() {
 
   echo "=== Writing GitHub Summary ==="
 
-  # Get the version from root package.json
-  version=$(npm pkg get version | tr -d '"')
+  # Get the version from the scope's version source.
+  version=$( (cd "$VERSION_SOURCE_DIR" && npm pkg get version) | tr -d '"')
 
   # Determine title based on dry run mode
   if [ "$DRY_RUN" = "true" ]; then
@@ -228,6 +267,7 @@ REF=""
 DRY_RUN=false
 RELEASE_TYPE=""
 BUMP_TYPE=""
+SCOPE="vertesia"
 
 # Parse named arguments
 while [[ $# -gt 0 ]]; do
@@ -262,9 +302,13 @@ while [[ $# -gt 0 ]]; do
       BUMP_TYPE="$2"
       shift 2
       ;;
+    --scope)
+      SCOPE="$2"
+      shift 2
+      ;;
     *)
       echo "Error: Unknown argument '$1'"
-      echo "Usage: $0 --ref <ref> --release-type <type> --bump-type <type> [--dry-run [true|false]]"
+      echo "Usage: $0 --ref <ref> --release-type <type> --bump-type <type> [--dry-run [true|false]] [--scope <vertesia|koa-stack>]"
       exit 1
       ;;
   esac
@@ -301,6 +345,46 @@ if [[ ! "$BUMP_TYPE" =~ ^(minor|patch|keep)$ ]]; then
   exit 1
 fi
 
+# Validate scope
+if [[ ! "$SCOPE" =~ ^(vertesia|koa-stack)$ ]]; then
+  echo "Error: Invalid scope '$SCOPE'. Must be 'vertesia' or 'koa-stack'."
+  exit 1
+fi
+
+# =============================================================================
+# Scope profile
+# =============================================================================
+# Each scope publishes a disjoint set of packages on its own version line. These
+# variables drive every scope-specific decision in the functions above.
+#   PKG_FILTERS         pnpm -r filters selecting the publish set
+#   NPM_SCOPE           npm scope used in logs / GitHub summary links
+#   VERSION_SOURCE_DIR  dir whose package.json holds the canonical base version
+#   UPDATE_ROOT_VERSION whether to bump the repo-root package.json
+#   UPDATE_TEMPLATES    whether to refresh create-plugin templateVersions
+#   TAG_PREFIXES        git tag prefix(es) created on releases (one tag per prefix)
+case "$SCOPE" in
+  vertesia)
+    PKG_FILTERS=(--filter "./packages/**" --filter "./libraries/jst")
+    NPM_SCOPE="@vertesia"
+    VERSION_SOURCE_DIR="."
+    UPDATE_ROOT_VERSION=true
+    UPDATE_TEMPLATES=true
+    # Keep the legacy `v${version}` tag (create-plugin's template resolver and
+    # other scripts rely on it) and add the namespaced `vertesia/v${version}`.
+    TAG_PREFIXES=("v" "vertesia/v")
+    ;;
+  koa-stack)
+    PKG_FILTERS=(--filter "./libraries/koa-stack/*")
+    NPM_SCOPE="@koa-stack"
+    VERSION_SOURCE_DIR="libraries/koa-stack/router"
+    UPDATE_ROOT_VERSION=false
+    UPDATE_TEMPLATES=false
+    TAG_PREFIXES=("koa-stack/v")
+    ;;
+esac
+
+echo "=== Publishing scope: ${SCOPE} (${NPM_SCOPE}/*) ==="
+
 # Validate that releases can only be published from 'preview' or maintenance branches (skip in dry-run)
 if [ "$RELEASE_TYPE" = "release" ] && [ "$DRY_RUN" != "true" ] && [ "$REF" != "preview" ] && [[ ! "$REF" =~ ^[0-9]+\.[0-9]+$ ]]; then
   echo "Error: Release versions can only be published from 'preview' or maintenance branches."
@@ -322,7 +406,10 @@ fi
 
 update_package_versions
 
-update_template_versions
+# create-plugin templates embed @vertesia versions only; koa-stack has no templates.
+if [ "$UPDATE_TEMPLATES" = "true" ]; then
+  update_template_versions
+fi
 
 echo "=== Building all packages ==="
 pnpm build

--- a/.github/workflows/publish-koa.yaml
+++ b/.github/workflows/publish-koa.yaml
@@ -26,10 +26,12 @@ on:
         type: boolean
         default: true
 
-# Serialize publish runs so two concurrent dispatches don't race on the
-# shared npm registry or push competing version bumps.
+# Serialize publish runs so two concurrent dispatches don't race on the shared
+# npm registry or push competing version bumps. The group is shared with
+# publish-npm.yaml (same string) because both workflows commit and push version
+# bumps to the same ref — serializing them keeps git pushes fast-forward.
 concurrency:
-  group: publish-npm-${{ github.ref }}
+  group: publish-packages-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:
@@ -37,7 +39,7 @@ permissions:
 
 jobs:
   publish:
-    name: Publish all packages
+    name: Publish all koa-stack packages
     runs-on: ubuntu-latest
     timeout-minutes: 30
     # Scopes DEPLOY_KEY (used to push version bumps past branch protection)
@@ -73,6 +75,8 @@ jobs:
         timeout-minutes: 5
         run: pnpm install
 
+      # Publishes @koa-stack/* (libraries/koa-stack/*) on their own version line.
+      # Reuses the shared publish-all-packages.sh via --scope koa-stack.
       - name: Publish all packages
         timeout-minutes: 15
         env:
@@ -81,55 +85,8 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           ./.github/bin/publish-all-packages.sh \
+              --scope koa-stack \
               --ref "${GITHUB_REF_NAME}" \
               --release-type "${RELEASE_TYPE}" \
               --bump-type "${BUMP_TYPE}" \
               --dry-run "${DRY_RUN}"
-
-      # Template integration tests using local verdaccio registry (dry-run only)
-      - name: Template integration test - Plugin
-        if: inputs.dry_run == true
-        timeout-minutes: 10
-        env:
-          RELEASE_TYPE: ${{ inputs.release_type }}
-        run: ./.github/bin/test-template-integration.sh --release-type "${RELEASE_TYPE}" --template "Vertesia Plugin"
-      - name: Template integration test - Tool Server (deprecated)
-        if: inputs.dry_run == true
-        timeout-minutes: 10
-        env:
-          RELEASE_TYPE: ${{ inputs.release_type }}
-        run: ./.github/bin/test-template-integration.sh --release-type "${RELEASE_TYPE}" --template "Vertesia Tool Server (deprecated)"
-
-  # ============================================================
-  # Integration test after real publish (non-dry-run only)
-  # Verifies published packages work by bootstrapping a template.
-  # ============================================================
-
-  integration-test:
-    name: Integration test (published packages)
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    needs: publish
-    if: inputs.dry_run == false
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-      - name: Install pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - name: Install Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 24
-
-      - name: Smoke test - Plugin
-        timeout-minutes: 10
-        env:
-          RELEASE_TYPE: ${{ inputs.release_type }}
-        run: ./.github/bin/test-template-smoke.sh --release-type "${RELEASE_TYPE}" --template "Vertesia Plugin" --branch "${GITHUB_REF_NAME}" --wait
-      - name: Smoke test - Tool Server (deprecated)
-        timeout-minutes: 10
-        env:
-          RELEASE_TYPE: ${{ inputs.release_type }}
-        run: ./.github/bin/test-template-smoke.sh --release-type "${RELEASE_TYPE}" --template "Vertesia Tool Server (deprecated)" --branch "${GITHUB_REF_NAME}" --wait

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -26,10 +26,12 @@ on:
         type: boolean
         default: true
 
-# Serialize publish runs so two concurrent dispatches don't race on the
-# shared npm registry or push competing version bumps.
+# Serialize publish runs so two concurrent dispatches don't race on the shared
+# npm registry or push competing version bumps. The group is shared with
+# publish-koa.yaml (same string) because both workflows commit and push version
+# bumps to the same ref — serializing them keeps git pushes fast-forward.
 concurrency:
-  group: publish-npm-${{ github.ref }}
+  group: publish-packages-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:
@@ -81,6 +83,7 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           ./.github/bin/publish-all-packages.sh \
+              --scope vertesia \
               --ref "${GITHUB_REF_NAME}" \
               --release-type "${RELEASE_TYPE}" \
               --bump-type "${BUMP_TYPE}" \


### PR DESCRIPTION
## Summary

`publish-koa.yaml` was a placeholder — a verbatim copy of `publish-npm.yaml` that
republished `@vertesia` packages and ran `@vertesia`-only template tests. This wires up
real release logic for the `@koa-stack/*` libraries while keeping a **single** publish
script across both workflows.

- **`bin/publish-all-packages.sh`** — add a `--scope vertesia|koa-stack` flag (default
  `vertesia`, so `@vertesia` publishing is unchanged). A small scope profile drives every
  difference:

  | | `vertesia` | `koa-stack` |
  |---|---|---|
  | publish set | `packages/**` + `libraries/jst` | `libraries/koa-stack/*` |
  | version source | root `package.json` | `libraries/koa-stack/router` (independent line) |
  | bump root `package.json` | yes | no |
  | `create-plugin` template sync | yes | skipped |
  | npm label / summary links | `@vertesia` | `@koa-stack` |
  | release git tag(s) | `v${version}` **+** `vertesia/v${version}` | `koa-stack/v${version}` |

- Added a **private-package skip** in the publish loop so `@koa-stack/tests` is never
  published (also future-proofs the `@vertesia` set).
- **Release tags are namespaced per scope.** `@vertesia` keeps the legacy `v${version}`
  tag — `create-plugin`'s template resolver (`template-selector.ts`) and other scripts
  rely on it — and *additionally* gets `vertesia/v${version}`. `@koa-stack` uses its own
  `koa-stack/v${version}` line. Tags with a `/` don't collide with each other or with the
  bare `v*` tags.
- **`workflows/publish-koa.yaml`** — calls the script with `--scope koa-stack`; removed
  the `create-plugin` template integration tests and the post-publish smoke-test job
  (neither applies to these low-level libraries).
- **`workflows/publish-npm.yaml`** — pass explicit `--scope vertesia`; rename the
  concurrency group to the neutral `publish-packages-${{ github.ref }}`, **shared** with
  the koa workflow so version-bump pushes to the same ref stay fast-forward.
- **`bin/publish-all-packages.md`** — document `--scope` and the koa-stack scope.

## Verification

Standard `build` / `lint` / `test` don't cover `.github/` shell + YAML CI files, so the
following targeted checks were run instead:

- `bash -n bin/publish-all-packages.sh` — passes (syntax valid).
- Scope spot-check: `--scope koa-stack` selects `@koa-stack/{body,router,server}`, **skips**
  the private `@koa-stack/tests`, and resolves the version source to `0.24.0`.
- Regression spot-check: `--scope vertesia` skips no packages (no private packages in that
  set) — selection is unchanged.
- Tag generation simulated: `vertesia` 1.4.0 → `v1.4.0` + `vertesia/v1.4.0`; `koa-stack`
  0.24.1 → `koa-stack/v0.24.1`.

### Dry-run CI test ✅

Dispatched `publish-koa.yaml` on this branch in dry-run mode
([run 28366777699](https://github.com/vertesia/composableai/actions/runs/28366777699/job/84034513519)
— ✅ success in 2m21s). Confirmed from the logs:

- `=== Publishing scope: koa-stack (@koa-stack/*) ===` followed by `=== DRY RUN MODE ENABLED ===`.
- Snapshot version came off the **independent koa line**: `0.24.0-dev.20260629.105250Z`
  (base `0.24.0` from `libraries/koa-stack/router`, not the root `@vertesia` version).
- Exactly **3 packages** packed and resolved against the registry, all tagged `dev`:
  `@koa-stack/body`, `@koa-stack/router`, `@koa-stack/server` — each followed by
  `[WARN] Skip publishing … (dry run)`.
- **`@koa-stack/tests` is built but never published** — the private-package skip works as intended.
- npm **OIDC** token exchange (`audience=npm:registry.npmjs.org`) returned `200`, so the GitHub
  side of trusted publishing is wired up.
- No git commit/push (dry-run), no errors, and `External dependencies are consistent with
  package.json dependencies.`

## Notes for reviewers

- The real (non-dry-run) publish uses **npm OIDC trusted publishing** (`id-token: write`, no
  `NODE_AUTH_TOKEN`), same as `@vertesia`. Each `@koa-stack/*` package needs a trusted
  publisher on npm pointing at `publish-koa.yaml` before the first real publish; dry-run does
  not require it.
- Release-branch gating is inherited unchanged from the shared script (releases only from
  `preview` / maintenance branches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
