### PR TITLE
fix(koa-stack): add repository field for npm provenance

### DIFF
--- a/libraries/koa-stack/body/package.json
+++ b/libraries/koa-stack/body/package.json
@@ -20,6 +20,11 @@
     ],
     "author": "stefanescu.bogdan@gmail.com",
     "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/vertesia/composableai.git",
+        "directory": "libraries/koa-stack/body"
+    },
     "dependencies": {
         "formidable": "^3.5.4",
         "inflation": "^2.1.0",

--- a/libraries/koa-stack/router/package.json
+++ b/libraries/koa-stack/router/package.json
@@ -20,6 +20,11 @@
     ],
     "author": "stefanescu.bogdan@gmail.com",
     "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/vertesia/composableai.git",
+        "directory": "libraries/koa-stack/router"
+    },
     "dependencies": {
         "koa": "^3.2.1",
         "koa-compose": "^4.1.0",

--- a/libraries/koa-stack/server/package.json
+++ b/libraries/koa-stack/server/package.json
@@ -20,6 +20,11 @@
     ],
     "author": "stefanescu.bogdan@gmail.com",
     "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/vertesia/composableai.git",
+        "directory": "libraries/koa-stack/server"
+    },
     "dependencies": {
         "@koa-stack/body": "workspace:*",
         "@koa-stack/router": "workspace:*",


### PR DESCRIPTION
## Summary

The first real (non-dry-run) `@koa-stack` publish failed because npm's OIDC trusted
publishing auto-enables **sigstore provenance**, which verifies that `package.json`
`repository.url` matches the attested source repo. The `@koa-stack/*` packages had **no
`repository` field**, so the publish was rejected:

```
422 Unprocessable Entity - PUT https://registry.npmjs.org/@koa-stack%2fbody
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "", expected to match "https://github.com/vertesia/composableai"
```

This adds the `repository` block — identical in form to the working `@vertesia` packages
— to the three published packages:

- `@koa-stack/body` → `directory: libraries/koa-stack/body`
- `@koa-stack/router` → `directory: libraries/koa-stack/router`
- `@koa-stack/server` → `directory: libraries/koa-stack/server`

```json
"repository": {
    "type": "git",
    "url": "https://github.com/vertesia/composableai.git",
    "directory": "libraries/koa-stack/<pkg>"
}
```

The private `@koa-stack/tests` is intentionally left untouched — it is never published, and
private `@vertesia` packages (e.g. `@vertesia/tsconfig`) carry no `repository` field either.

## Verification

- JSON validated for all three files; each `repository.url` now resolves to
  `https://github.com/vertesia/composableai`, matching the provenance expectation.
- Format matches the `@vertesia` convention (same `url`, per-package `directory`).
- The definitive test is a real publish — provenance is only verified on the actual registry
  `PUT`, not in dry-run — so this should be confirmed by re-dispatching `publish-koa.yaml`
  (non-dry-run) after merge.

## Context

Follow-up to #1607, which wired up `@koa-stack` publishing via the shared
`publish-all-packages.sh`. The provenance requirement only surfaced on the first real publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)