### PR TITLE
chore(koa-stack): roll back version to 0.25.0-dev

### DIFF
--- a/libraries/koa-stack/body/package.json
+++ b/libraries/koa-stack/body/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@koa-stack/body",
-    "version": "0.26.0-dev.20260629.120624Z",
+    "version": "0.25.0-dev.20260629.114133Z",
     "description": "Expose the request body as a promise in koa Context.body",
     "type": "module",
     "scripts": {

--- a/libraries/koa-stack/router/package.json
+++ b/libraries/koa-stack/router/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@koa-stack/router",
-    "version": "0.26.0-dev.20260629.120624Z",
+    "version": "0.25.0-dev.20260629.114133Z",
     "description": "A powerfull koa router using typescript decorations",
     "type": "module",
     "scripts": {

--- a/libraries/koa-stack/server/package.json
+++ b/libraries/koa-stack/server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@koa-stack/server",
-    "version": "0.26.0-dev.20260629.120624Z",
+    "version": "0.25.0-dev.20260629.114133Z",
     "description": " A web server based on koa with advanced routing, lazy body and flexbile error handling",
     "type": "module",
     "scripts": {

--- a/libraries/koa-stack/tests/package.json
+++ b/libraries/koa-stack/tests/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@koa-stack/tests",
-    "version": "0.26.0-dev.20260629.120624Z",
+    "version": "0.25.0-dev.20260629.114133Z",
     "private": true,
     "description": "Tests",
     "type": "module",


### PR DESCRIPTION
## Summary

Roll the `@koa-stack/*` package version back from `0.26.0-dev.20260629.120624Z` to
`0.25.0-dev.20260629.114133Z` on `release/1.4`.

**What happened:** the version got `minor`-bumped twice. The first release dispatch bumped
`0.24.0 → 0.25.0-dev…` but failed to publish (the sigstore provenance issue fixed in #1608).
After #1608 merged, a second dispatch re-applied `minor` from base `0.25.0`, producing
`0.26.0-dev.20260629.120624Z`, which published successfully. The intended target was the
**0.25.x** line.

This sets all four lockstep packages (`@koa-stack/body`, `router`, `server`, and the private
`tests`) back to the `0.25.0-dev` snapshot that preceded the erroneous bump, so the next
release continues on `0.25.x` instead of `0.26.x`.

## Notes

- **npm versions are immutable** — `@koa-stack/*@0.26.0-dev.20260629.120624Z` stays published
  under the `dev` tag. This PR only corrects the repo's working version; the next
  snapshot/release publish will move the `dev`/`latest` tags back onto the `0.25.x` line.
  (`0.25.0-dev.20260629.114133Z` itself was never published, so reusing it is safe.)
- **Not backported to `main`.** `main`'s koa packages are independently at `0.24.0` — the
  version bumps only ever touched `release/1.4`. Forward-porting a `0.25.0-dev` version would
  wrongly bump `main`, so no `backport/main` label here.
- Diff is the `version` field only (4 lines); `repository` blocks and formatting unchanged.

Follow-up to #1607 / #1608.

🤖 Generated with [Claude Code](https://claude.com/claude-code)