### PR TITLE
fix(ci): drop publish steps for removed Tool Server template

### DIFF
--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -101,12 +101,6 @@ jobs:
         env:
           RELEASE_TYPE: ${{ inputs.release_type }}
         run: ./.github/bin/test-template-integration.sh --release-type "${RELEASE_TYPE}" --template "Vertesia Plugin"
-      - name: Template integration test - Tool Server (deprecated)
-        if: inputs.dry_run == true
-        timeout-minutes: 10
-        env:
-          RELEASE_TYPE: ${{ inputs.release_type }}
-        run: ./.github/bin/test-template-integration.sh --release-type "${RELEASE_TYPE}" --template "Vertesia Tool Server (deprecated)"
 
   # ============================================================
   # Integration test after real publish (non-dry-run only)
@@ -136,8 +130,3 @@ jobs:
         env:
           RELEASE_TYPE: ${{ inputs.release_type }}
         run: ./.github/bin/test-template-smoke.sh --release-type "${RELEASE_TYPE}" --template "Vertesia Plugin" --branch "${GITHUB_REF_NAME}" --wait
-      - name: Smoke test - Tool Server (deprecated)
-        timeout-minutes: 10
-        env:
-          RELEASE_TYPE: ${{ inputs.release_type }}
-        run: ./.github/bin/test-template-smoke.sh --release-type "${RELEASE_TYPE}" --template "Vertesia Tool Server (deprecated)" --branch "${GITHUB_REF_NAME}" --wait


### PR DESCRIPTION
## Summary

The `create-plugin` templates were consolidated into a single **"Vertesia Plugin"** template (`templates/plugin-template`). The standalone `tool-server-template`, `ui-plugin-template`, and `worker-template` — including their `packages/create-plugin/src/configuration.ts` entries and the template directories themselves — were removed in **#1296** ("feat: app-template improvements and new media-viewer components", merged 2026-05-13). They had earlier been renamed to "… (deprecated)" in **#832** ("Unified plugin template", 2026-01-27).

The `publish-npm` workflow was never updated to match — it still runs template integration and smoke tests against the deleted **"Vertesia Tool Server (deprecated)"** template. As a result, every dry-run publish fails at the integration step:

```
❌ Installation failed: Template "Vertesia Tool Server (deprecated)" not found. Available templates:
  - Vertesia Plugin
```

This PR removes the two obsolete steps:
- `Template integration test - Tool Server (deprecated)` (the failing dry-run step)
- `Smoke test - Tool Server (deprecated)` (post-publish `integration-test` job — would fail identically on a real publish)

The remaining "Plugin" steps exercise the only surviving template.

## Test Plan

- [x] Confirmed only "Vertesia Plugin" exists in `create-plugin` config and `templates/`; no other references pass the removed template name to the CLI.
- [x] Validated the edited workflow parses as YAML (`js-yaml`).
- [x] Re-ran the **(publish) NPM packages** workflow in dry-run mode on this branch — [run 28373461833](https://github.com/vertesia/composableai/actions/runs/28373461833) succeeded. The "Publish all packages" and "Template integration test - Plugin" steps both passed; the post-publish `integration-test` job correctly skipped (gated on `dry_run == false`).

> Note: change is limited to a single CI workflow YAML; no package code changed, so no build/lint/test commands apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>
