### PR TITLE
Add environment model toggle client and CLI support

### DIFF
--- a/packages/cli/src/envs/index.ts
+++ b/packages/cli/src/envs/index.ts
@@ -1,7 +1,54 @@
+import type { AIModel, ModelSearchPayload } from '@llumiverse/common';
 import type { ExecutionEnvironment } from '@vertesia/common';
 import colors from 'ansi-colors';
 import type { Command } from 'commander';
 import { getClient } from '../client.js';
+import { getBooleanOption, getStringOption } from '../utils/options.js';
+
+interface ModelCommandOptions {
+    text?: string;
+    type?: string;
+    json?: boolean;
+}
+
+interface JsonCommandOptions {
+    json?: boolean;
+}
+
+export function registerEnvsCommand(program: Command) {
+    const envs = program
+        .command('envs [envId]')
+        .description('List the environments you have access to')
+        .action((envId: string | undefined, options: Record<string, unknown>) =>
+            listEnvironments(program, envId, options),
+        );
+
+    envs.command('models <envId>')
+        .description('List provider-available models for an environment')
+        .option('--text <text>', 'Filter models by text')
+        .option('--type <type>', 'Filter models by type')
+        .option('--json', 'Print raw JSON')
+        .action((envId: string, options: ModelCommandOptions) => listEnvironmentModels(program, envId, options));
+
+    envs.command('enabled-models <envId>')
+        .description('List enabled models for an environment')
+        .option('--json', 'Print raw JSON')
+        .action((envId: string, options: JsonCommandOptions) => listEnabledModels(program, envId, options));
+
+    envs.command('enable-model <envId> <modelId>')
+        .description('Enable one model in an environment')
+        .option('--json', 'Print raw JSON')
+        .action((envId: string, modelId: string, options: JsonCommandOptions) =>
+            enableEnvironmentModel(program, envId, modelId, options),
+        );
+
+    envs.command('disable-model <envId> <modelId>')
+        .description('Disable one model in an environment')
+        .option('--json', 'Print raw JSON')
+        .action((envId: string, modelId: string, options: JsonCommandOptions) =>
+            disableEnvironmentModel(program, envId, modelId, options),
+        );
+}
 
 export async function listEnvironments(program: Command, envId: string | undefined, options: Record<string, unknown>) {
     const client = await getClient(program);
@@ -27,4 +74,74 @@ function printEnv(env: ExecutionEnvironment, _options: Record<string, unknown>) 
             ? env.enabled_models.map((model) => model.name).join(', ')
             : 'n/a',
     );
+}
+
+async function listEnvironmentModels(program: Command, envId: string, options: ModelCommandOptions) {
+    const client = await getClient(program);
+    const payload = getModelSearchPayload(options);
+    const models = await client.environments.listModels(envId, payload);
+    printModels(models, options);
+}
+
+async function listEnabledModels(program: Command, envId: string, options: JsonCommandOptions) {
+    const client = await getClient(program);
+    const env = await client.environments.retrieve(envId);
+    printModels(env.enabled_models ?? [], options);
+}
+
+async function enableEnvironmentModel(program: Command, envId: string, modelId: string, options: JsonCommandOptions) {
+    const client = await getClient(program);
+    const env = await client.environments.enableModel(envId, { model_id: modelId });
+    if (getBooleanOption(options.json)) {
+        console.log(JSON.stringify(env, null, 2));
+        return;
+    }
+
+    const model = env.enabled_models?.find((candidate) => candidate.id === modelId);
+    console.log(`Enabled model: ${formatModel(model ?? { id: modelId, name: modelId, provider: env.provider })}`);
+}
+
+async function disableEnvironmentModel(program: Command, envId: string, modelId: string, options: JsonCommandOptions) {
+    const client = await getClient(program);
+    const env = await client.environments.disableModel(envId, modelId);
+    if (getBooleanOption(options.json)) {
+        console.log(JSON.stringify(env, null, 2));
+        return;
+    }
+
+    console.log(`Disabled model: ${modelId}`);
+    console.log(`Enabled models: ${env.enabled_models?.length ?? 0}`);
+}
+
+function getModelSearchPayload(options: ModelCommandOptions): ModelSearchPayload | undefined {
+    const text = getStringOption(options.text);
+    const type = getStringOption(options.type) as ModelSearchPayload['type'] | undefined;
+    if (!text && !type) {
+        return undefined;
+    }
+    return {
+        text: text ?? '',
+        ...(type ? { type } : {}),
+    };
+}
+
+function printModels(models: AIModel[], options: JsonCommandOptions) {
+    if (getBooleanOption(options.json)) {
+        console.log(JSON.stringify(models, null, 2));
+        return;
+    }
+
+    if (models.length === 0) {
+        console.log('No models found.');
+        return;
+    }
+
+    for (const model of models) {
+        console.log(formatModel(model));
+    }
+}
+
+function formatModel(model: AIModel): string {
+    const details = [model.type, model.status].filter(Boolean).join(', ');
+    return details ? `${model.name} [${model.id}] (${details})` : `${model.name} [${model.id}]`;
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,7 +3,7 @@ import { registerAgentsCommand } from './agents/index.js';
 import { registerAppsCommand } from './apps/index.js';
 import { registerArtifactsCommand } from './artifacts/index.js';
 import { registerDataCommand } from './data/index.js';
-import { listEnvironments } from './envs/index.js';
+import { registerEnvsCommand } from './envs/index.js';
 import { registerEventsCommand } from './events/index.js';
 import { registerExportCommand } from './export/index.js';
 import { registerIamCommand } from './iam/index.js';
@@ -106,10 +106,7 @@ authRoot
     .option('-p, --project <project>', 'Refresh the current profile token for the given project ID')
     .action((options: { project?: string }) => updateCurrentProfile(undefined, undefined, options));
 
-program
-    .command('envs [envId]')
-    .description('List the environments you have access to')
-    .action((envId: string | undefined, options: Record<string, unknown>) => listEnvironments(program, envId, options));
+registerEnvsCommand(program);
 program
     .command('interactions [interaction]')
     .description('List the interactions available in the current project')

--- a/packages/client/src/EnvironmentsApi.test.ts
+++ b/packages/client/src/EnvironmentsApi.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+import { VertesiaClient } from './client.js';
+
+describe('EnvironmentsApi', () => {
+    it('encodes model IDs in disableModel paths', async () => {
+        const requests: Request[] = [];
+        const fetchMock = vi.fn(async () => {
+            return new Response(
+                JSON.stringify({
+                    id: 'env-id',
+                    name: 'Test Environment',
+                    provider: 'test',
+                    account: 'account-id',
+                    created_by: 'user:test',
+                    updated_by: 'user:test',
+                    created_at: new Date(0).toISOString(),
+                    updated_at: new Date(0).toISOString(),
+                }),
+                {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' },
+                },
+            );
+        });
+
+        const client = new VertesiaClient({
+            serverUrl: 'https://api.example.com',
+            storeUrl: 'https://api.example.com',
+            fetch: fetchMock,
+            onRequest: (request) => requests.push(request),
+        });
+
+        await client.environments.disableModel('env-id', 'provider/model#v?1');
+
+        expect(requests[0]?.url).toBe(
+            'https://api.example.com/api/v1/environments/env-id/models/enabled/provider%2Fmodel%23v%3F1',
+        );
+    });
+});

--- a/packages/client/src/EnvironmentsApi.ts
+++ b/packages/client/src/EnvironmentsApi.ts
@@ -3,6 +3,7 @@ import { ApiTopic, type ClientBase } from '@vertesia/api-fetch-client';
 import type {
     EmbeddingsApiRequest,
     EmbeddingsApiResult,
+    EnableEnvironmentModelPayload,
     ExecutionEnvironment,
     ExecutionEnvironmentCreatePayload,
     ExecutionEnvironmentRef,
@@ -69,6 +70,16 @@ export default class EnvironmentsApi extends ApiTopic {
         return this.get(`/${id}/models`, {
             query: payload ? { ...payload } : undefined,
         });
+    }
+
+    enableModel(id: string, payload: EnableEnvironmentModelPayload): Promise<ExecutionEnvironment> {
+        return this.post(`/${id}/models/enabled`, {
+            payload,
+        });
+    }
+
+    disableModel(id: string, modelId: string): Promise<ExecutionEnvironment> {
+        return this.del(`/${id}/models/enabled/${encodeURIComponent(modelId)}`);
     }
 
     listTrainableModels(id: string): Promise<AIModel[]> {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,6 +1,6 @@
 import type { AsyncExecutionResult } from '@vertesia/common';
 
-export type { OrphanedAppInstallation } from '@vertesia/common';
+export type { EnableEnvironmentModelPayload, OrphanedAppInstallation } from '@vertesia/common';
 export { getOAuthPermissionScopes, Permission } from '@vertesia/common';
 export * from './client.js';
 export type { GroupsQueryOptions } from './GroupsApi.js';

--- a/packages/common/src/environment.ts
+++ b/packages/common/src/environment.ts
@@ -166,6 +166,13 @@ export interface ExecutionEnvironmentConfigUpdatePayload {
     config?: MediatorEnvConfig | LoadBalancingEnvConfig;
 }
 
+export interface EnableEnvironmentModelPayload {
+    /**
+     * Provider model ID to resolve from the environment's available model listing.
+     */
+    model_id: string;
+}
+
 export interface MigrateInteractionsPayload {
     /**
      * The new environment ID to set in the Interactions


### PR DESCRIPTION
## Summary
- Add a shared payload type for enabling one environment model by provider model ID.
- Add environment client helpers for enabling and disabling models, including encoded model IDs in disable paths.
- Expand the envs CLI command group with provider model listing, enabled model listing, and single-model enable/disable commands.

## Verification
- common/client/cli: lint and builds passed.
- client: tests and test typecheck passed.
- Smoke: CLI listed provider/enabled models and enabled/disabled one model against a local API server.