### PR TITLE
fix: allow npm release from release/* branches

### DIFF
--- a/.github/bin/publish-all-packages.md
+++ b/.github/bin/publish-all-packages.md
@@ -6,7 +6,7 @@ The file `publish-all-packages.sh` contains logic for publishing vertesia packag
 
 The `publish-all-packages.sh` script handles publishing packages with appropriate versioning based on the git branch:
 
-- **`@vertesia/*` packages** (`--scope vertesia`, the default): Publish on both `main` and `preview` branches. Versioned off the repository-root `package.json`. Driven by `publish-npm.yaml`.
+- **`@vertesia/*` packages** (`--scope vertesia`, the default): Publish dev snapshots from `main` and releases from `release/X.Y` branches (e.g. `release/1.4`). Versioned off the repository-root `package.json`. Driven by `publish-npm.yaml`.
 - **`@koa-stack/*` packages** (`--scope koa-stack`): the koa-stack libraries in `libraries/koa-stack/*`. They are published on an independent version line (versioned off `libraries/koa-stack/router/package.json`, not the root) by the separate `publish-koa.yaml` workflow. The private `@koa-stack/tests` package is never published.
 - **`@llumiverse/*` packages**: out of scope. They are handled by another GitHub Actions workflow, defined in their GitHub repository "vertesia/llumiverse".
 
@@ -24,9 +24,9 @@ Both scopes share this single script: the `--scope` flag selects which package s
 
 ### Parameters
 
-- `--ref` (required): Git reference - `main` for dev builds, `preview` for releases. Publishing releases outside of `preview` branch is forbidden.
+- `--ref` (required): Git reference - `main` for dev builds, a `release/X.Y` branch (e.g. `release/1.4`) for releases. Publishing releases outside of a `release/*` branch is forbidden.
 - `--release-type` (required): The type of the version, either "release" or "snapshot". A "release" means this is a stable version. A "snapshot" means this is a development version.
-  - "release" creates a stable version respecting semantic versioning, such as `1.0.0`. Release can only be performed from the `preview` branch.
+  - "release" creates a stable version respecting semantic versioning, such as `1.0.0`. Release can only be performed from a `release/*` branch (e.g. `release/1.4`).
   - "snapshot" creates a new development version in format `{base}-dev.{date}.{time}`, such as `1.0.0-dev.20260128.144200Z`. Note that the time part contains 'Z', which means that the time is in UTC; it also allows NPM to use leading zeros, as it turns the segment into alphanumeric.
 - `--bump-type` (required): The strategy for changing the version (`minor`, `patch`, `keep`)
   - `minor` increases the minor version in the package version
@@ -52,19 +52,19 @@ Both scopes share this single script: the `--scope` flag selects which package s
     --release-type snapshot \
     --bump-type keep
 
-# Publish release with 'patch' bump from preview
+# Publish release with 'patch' bump from a release branch
 # (ex: 0.24.0-dev.20260203.164053Z -> 0.24.1)
 # (ex: 0.24.0 -> 0.24.1)
 ./publish-all-packages.sh \
-    --ref preview \
+    --ref release/1.4 \
     --release-type release \
     --bump-type patch
 
-# Publish release with minor bump from preview
+# Publish release with minor bump from a release branch
 # (ex: 0.24.0-dev.20260203.164053Z -> 0.25.0)
 # (ex: 0.24.0 -> 0.25.0)
 ./publish-all-packages.sh \
-    --ref preview \
+    --ref release/1.4 \
     --release-type release \
     --bump-type minor
 ```
@@ -135,14 +135,14 @@ Both scopes share this single script: the `--scope` flag selects which package s
 
 ### Scenario 2: Publishing official releases
 
-**Purpose**: Publish official releases from `preview`
+**Purpose**: Publish official releases from a `release/*` branch (e.g. `release/1.4`)
 
 **Steps**:
 1. Bumps root `package.json` version and all composableai package versions using semantic versioning
    - Bump type: specified by `bump-type` parameter (patch/minor/keep)
    - Verify that the release type is "release" and is not "snapshot".
    - Version format: standard semver (e.g., `1.2.0` → `1.2.1` for patch)
-2. **Commits and pushes** version changes back to the `preview` branch (only if dry-run is false)
+2. **Commits and pushes** version changes back to the release branch (only if dry-run is false)
 3. Publishes all composableai packages
    - NPM tag: `latest`
 
@@ -157,7 +157,7 @@ Both scopes share this single script: the `--scope` flag selects which package s
 # ==========
 # Example 1: we had a snapshot version
 # -----
-# params: ref=preview, release_type=release, bump_type=keep
+# params: ref=release/1.4, release_type=release, bump_type=keep
 # ==========
 
 # Before (package.json):
@@ -173,7 +173,7 @@ Both scopes share this single script: the `--scope` flag selects which package s
 # ==========
 # Example 2: we had a release version
 # -----
-# params: ref=preview, release_type=release, bump_type=patch
+# params: ref=release/1.4, release_type=release, bump_type=patch
 # ==========
 
 # Before (package.json):
@@ -203,10 +203,10 @@ Both scopes share this single script: the `--scope` flag selects which package s
 # Test publishing logic on main
 ./publish-all-packages.sh --ref main --dry-run --release-type snapshot --bump-type keep
 
-# Test publishing logic on preview
-./publish-all-packages.sh --ref preview --dry-run --release-type release --bump-type minor
-./publish-all-packages.sh --ref preview --dry-run --release-type release --bump-type patch
-./publish-all-packages.sh --ref preview --dry-run --release-type snapshot --bump-type keep
+# Test publishing logic on a release branch
+./publish-all-packages.sh --ref release/1.4 --dry-run --release-type release --bump-type minor
+./publish-all-packages.sh --ref release/1.4 --dry-run --release-type release --bump-type patch
+./publish-all-packages.sh --ref release/1.4 --dry-run --release-type snapshot --bump-type keep
 ```
 
 **Result**:
@@ -265,7 +265,7 @@ In dry run mode, the script:
 - Dry run enabled by default in GitHub Actions
 - All version updates happen before any publishing
 - Changes push to GitHub before publishing to prevent Git conflicts
-- Restrict publishing from the `preview` branch
+- Restrict publishing to `release/*` branches
 - Portable shell syntax (works on macOS and Linux)
 
 ### Requirements

--- a/.github/bin/publish-all-packages.sh
+++ b/.github/bin/publish-all-packages.sh
@@ -3,7 +3,7 @@ set -e
 
 # Script to publish all composableai packages to NPM
 # Usage: publish-all-packages.sh --ref <ref> --release-type <type> --bump-type <type> [--dry-run [true|false]] [--scope <vertesia|koa-stack>]
-#   --ref: Git reference (main for dev builds, preview for releases)
+#   --ref: Git reference (main for dev builds, release/X.Y for releases, e.g. release/1.4)
 #   --release-type: Release type (release, snapshot). Release creates stable versions, snapshot creates dev versions.
 #   --bump-type: Bump type (minor, patch, keep). How to change the version.
 #   --dry-run: Optional flag for dry run mode (value can be true, false, or omitted which means true)
@@ -385,9 +385,10 @@ esac
 
 echo "=== Publishing scope: ${SCOPE} (${NPM_SCOPE}/*) ==="
 
-# Validate that releases can only be published from 'preview' or maintenance branches (skip in dry-run)
-if [ "$RELEASE_TYPE" = "release" ] && [ "$DRY_RUN" != "true" ] && [ "$REF" != "preview" ] && [[ ! "$REF" =~ ^[0-9]+\.[0-9]+$ ]]; then
-  echo "Error: Release versions can only be published from 'preview' or maintenance branches."
+# Validate that releases can only be published from a release branch (release/X.Y, e.g. release/1.4)
+# or a legacy bare-numeric maintenance branch (skip in dry-run)
+if [ "$RELEASE_TYPE" = "release" ] && [ "$DRY_RUN" != "true" ] && [[ ! "$REF" =~ ^release/[0-9]+\.[0-9]+$ ]] && [[ ! "$REF" =~ ^[0-9]+\.[0-9]+$ ]]; then
+  echo "Error: Release versions can only be published from a 'release/X.Y' branch (e.g. release/1.4) or a maintenance branch."
   echo "Current branch: $REF"
   exit 1
 fi


### PR DESCRIPTION
## Summary
- Real (non-dry-run) releases were gated on the now-deleted `preview` branch plus a legacy bare-numeric maintenance pattern (`^[0-9]+\.[0-9]+$`), so `publish-all-packages.sh` rejected `--release-type release` from the `release/X.Y` branches that are now the convention (`release/1.4`, `release/1.3`).
- The guard now allows releases from `release/X.Y` branches (e.g. `release/1.4`), matching the convention already used by this repo's other workflows (`automerge-llumiverse.yaml`, `main.yaml`).
- Legacy bare-numeric maintenance branches (e.g. `0.82`, still present on the remote) remain allowed for backward compatibility.
- The dead `preview` reference is removed. Dry-run behavior is unchanged (the guard is still skipped for dry-runs).
- Updated `publish-all-packages.md` to document the new release-branch convention.

## Note (out of scope)
`.github/bin/README.md` is broadly stale — it documents an obsolete positional-argument CLI (`./publish-all-packages.sh <ref> [dry-run] [version-type]`), llumiverse-published-from-this-script, and `-dev-{hash}` versioning — and is superseded by `publish-all-packages.md`. It was deliberately left untouched: a `preview` find-replace would have produced invalid example commands. Recommend deleting or rewriting it in a separate change.

## Verification
- `bash -n .github/bin/publish-all-packages.sh` — syntax OK
- Guard logic check (`RELEASE_TYPE=release`, `DRY_RUN=false`): allows `release/1.4`, `release/1.3`, legacy `1.4`/`0.82`; rejects `preview`/`main`. `DRY_RUN=true` allows all (unchanged).
- No build/typecheck/test applies — change limited to a CI shell script and its markdown doc.

## Test Plan
- [ ] Dispatch the `(publish) NPM packages` workflow (`publish-npm.yaml`, `--scope vertesia`) from `release/1.4` with `release_type=release`, `dry_run=false`; confirm it passes the branch guard.
- [ ] Same for `publish-koa.yaml` (`--scope koa-stack`) from `release/1.4`.
- [ ] Confirm a `release_type=release`, `dry_run=false` run from `main` is rejected with the new error message.

## Related
- Companion fix in llumiverse: https://github.com/vertesia/llumiverse/pull/499

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
