### PR TITLE
feat(common): composite app header menu configuration types

### DIFF
--- a/packages/common/src/apps.ts
+++ b/packages/common/src/apps.ts
@@ -1056,6 +1056,10 @@ export interface CompositeAppSwitchersOverrides {
 
 /**
  * Header button visibility overrides for the CompositeApp header.
+ *
+ * @deprecated Superseded by `CompositeAppConfig.headerMenu` (free-form header items).
+ * Retained for backward compatibility and to seed the default header menu when no
+ * `headerMenu` has been configured yet.
  */
 export interface CompositeAppHeaderOverrides {
     /** Whether to hide the App Portal button (defaults to false) */
@@ -1068,6 +1072,10 @@ export interface CompositeAppHeaderOverrides {
 
 /**
  * User menu overrides for the CompositeApp.
+ *
+ * @deprecated Superseded by the `user_menu` item in `CompositeAppConfig.headerMenu`.
+ * Retained for backward compatibility and to seed the default header menu when no
+ * `headerMenu` has been configured yet.
  */
 export interface CompositeAppUserMenuOverrides {
     /** Whether to hide the User Menu (defaults to false) */
@@ -1189,6 +1197,51 @@ export interface CompositeAppHomePlugin {
     appRoute?: string;
 }
 
+// ============================================================================
+// Header Menu Types
+// ============================================================================
+
+/**
+ * Discriminator for a header item.
+ * The four built-ins (`app_portal`, `docs`, `help`, `user_menu`) seed the default
+ * header and cannot be deleted (only hidden/customized); `custom` items are fully
+ * user-defined buttons.
+ */
+export type CompositeAppHeaderItemKind = 'app_portal' | 'docs' | 'help' | 'user_menu' | 'custom';
+
+/** Where a header link opens. */
+export type CompositeAppHeaderItemTarget = '_self' | '_blank';
+
+/** Stable identifiers for the built-in header items. */
+export const COMPOSITE_APP_HEADER_BUILTIN_IDS = ['app_portal', 'docs', 'help', 'user_menu'] as const;
+
+/**
+ * A single button in the CompositeApp header bar.
+ *
+ * Unlike sidebar nav-items, header items are free-form and not tied to an installed
+ * app: each is a labelled, icon-bearing button linking to a route or external URL.
+ * The `user_menu` item is special — it renders the account dropdown, so its `icon`,
+ * `href`, and `target` are ignored.
+ */
+export interface CompositeAppHeaderItem {
+    /** Stable unique identifier. Built-ins use their kind as id (e.g. "app_portal"). */
+    id: string;
+    /** Item kind. `custom` for user-added buttons; otherwise one of the four built-ins. */
+    kind: CompositeAppHeaderItemKind;
+    /** Display label, used as the button tooltip / accessible name. */
+    label: string;
+    /** Lucide icon name or SVG content string. Ignored for `user_menu`. */
+    icon?: string;
+    /** Destination route ("/...") or external URL. Ignored for `user_menu`. */
+    href?: string;
+    /** Where to open the link (defaults to "_self"). Ignored for `user_menu`. */
+    target?: CompositeAppHeaderItemTarget;
+    /** When true, this item is hidden from the header. */
+    hidden?: boolean;
+    /** Optional access control settings for this header item. */
+    permissions?: CompositeAppNavItemPermissions;
+}
+
 /**
  * CompositeApp shell configuration.
  * This is the main configuration interface for storing CompositeApp settings.
@@ -1212,10 +1265,23 @@ export interface CompositeAppConfig {
     switchers?: CompositeAppSwitchersOverrides;
     /** Optional sidebar display overrides */
     sidebar?: CompositeAppSidebarOverrides;
-    /** Optional header button visibility overrides */
+    /**
+     * @deprecated Use `headerMenu` instead. Optional header button visibility overrides.
+     * Still read to seed `headerMenu` defaults for configs saved before the header menu existed.
+     */
     header?: CompositeAppHeaderOverrides;
-    /** Optional user menu overrides */
+    /**
+     * @deprecated Use the `user_menu` item in `headerMenu` instead. Optional user menu overrides.
+     * Still read to seed `headerMenu` defaults for configs saved before the header menu existed.
+     */
     userMenu?: CompositeAppUserMenuOverrides;
+    /**
+     * Optional free-form header menu. When present, the header renders from this ordered
+     * list instead of the legacy `header`/`userMenu` flags. Built-in items (App Portal,
+     * Docs, Help, User Menu) can be hidden/relabeled/re-icon'd/redirected; custom items
+     * are arbitrary buttons.
+     */
+    headerMenu?: CompositeAppHeaderItem[];
     /** Optional theme overrides (e.g. disable dark mode) */
     theme?: CompositeAppThemeOverrides;
     /** Optional home page override. When set, redirects "/" to the specified app route instead of the dashboard. Send null to unset. */


### PR DESCRIPTION
## Summary
- Adds shared types for configuring a composite app's top header bar as an ordered list of buttons — the built-in buttons (App Portal, Docs, Help, User Menu) plus admin-defined custom ones.
- Each header button carries a label, icon, link/target, visibility, and optional per-item access rules.
- Introduces a `headerMenu` field on the composite app configuration; the prior header on/off flags are retained for backward compatibility.

## Test Plan
- [x] `tsc` typecheck + package build (green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>