### PR TITLE
Fix ask-user prompt overflow

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -23,7 +23,7 @@
     "scripts": {
         "clean:lib": "rimraf ./lib ./tsconfig.tsbuildinfo",
         "clean": "rimraf ./node_modules ./lib ./tsconfig.tsbuildinfo",
-        "build": "pnpm run check:locales && pnpm run clean:lib && tsc -p tsconfig.json && pnpm exec rollup -c",
+        "build": "pnpm run check:locales && pnpm run check:rtl-classes && pnpm run clean:lib && tsc -p tsconfig.json && pnpm exec rollup -c",
         "lint": "biome lint src && pnpm run check:rtl-classes",
         "lint:fix": "biome lint --write src",
         "check:locales": "node scripts/check-locales.mjs",

--- a/packages/ui/src/features/agent/chat/AgentRightPanel.tsx
+++ b/packages/ui/src/features/agent/chat/AgentRightPanel.tsx
@@ -537,7 +537,7 @@ function OverflowTabsBar({ tabs, current, onTabChange, className }: OverflowTabs
         <div ref={containerRef} className={cn('relative', className)}>
             {/* Hidden measurement row: all tabs + More at natural width, kept separate
                 from the visible row so measuring can't feed back into the layout. */}
-            <div aria-hidden className="pointer-events-none invisible absolute left-0 top-0 flex w-max gap-1">
+            <div aria-hidden className="pointer-events-none invisible absolute start-0 top-0 flex w-max gap-1">
                 {tabs.map((tab, i) => (
                     <button
                         type="button"

--- a/packages/ui/src/features/agent/chat/AskUserWidget.test.tsx
+++ b/packages/ui/src/features/agent/chat/AskUserWidget.test.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../__tests__/test-utils.js';
+import { AskUserWidget } from './AskUserWidget';
+
+vi.mock('../../../widgets/markdown/MarkdownRenderer', () => ({
+    MarkdownRenderer: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+function getScrollablePrompt(container: HTMLElement): HTMLElement {
+    const question = container.querySelector('.agent-ask-question');
+    const scrollable = question?.parentElement;
+    if (!scrollable) {
+        throw new Error('Expected ask user question to be wrapped in a scrollable prompt container');
+    }
+    return scrollable;
+}
+
+describe('AskUserWidget', () => {
+    it('keeps compact prompt text in a bounded scrollable area', () => {
+        const { container } = renderWithProviders(
+            <AskUserWidget
+                compact
+                hideBorder
+                question={'Long prompt\n\n'.repeat(80)}
+                allowFreeResponse
+                submitLabel="Send"
+            />,
+        );
+
+        const scrollable = getScrollablePrompt(container);
+
+        expect(scrollable.className).toContain('max-h-80');
+        expect(scrollable.className).toContain('overflow-y-auto');
+        expect(scrollable.className).toContain('overscroll-contain');
+    });
+
+    it('keeps default prompt text in a bounded scrollable area', () => {
+        const { container } = renderWithProviders(
+            <AskUserWidget question={'Long prompt\n\n'.repeat(80)} allowFreeResponse submitLabel="Send" />,
+        );
+
+        const scrollable = getScrollablePrompt(container);
+
+        expect(scrollable.className).toContain('max-h-80');
+        expect(scrollable.className).toContain('overflow-y-auto');
+        expect(scrollable.className).toContain('overscroll-contain');
+    });
+});

--- a/packages/ui/src/features/agent/chat/AskUserWidget.tsx
+++ b/packages/ui/src/features/agent/chat/AskUserWidget.tsx
@@ -104,6 +104,8 @@ const VARIANT_ICONS = {
     success: CheckCircle,
 };
 
+const SCROLLABLE_PROMPT_CLASS = 'max-h-80 overflow-y-auto overscroll-contain pe-2';
+
 /**
  * AskUserWidget - A styled component for displaying agent prompts/questions to users
  *
@@ -197,10 +199,14 @@ export function AskUserWidget({
         if (answered) {
             return (
                 <div className={cn('my-1.5 font-sans', className)}>
-                    {compactQuestion}
-                    {description && (
-                        <p className={cn('mt-1 text-xs leading-5 text-muted', descriptionClassName)}>{description}</p>
-                    )}
+                    <div className={SCROLLABLE_PROMPT_CLASS}>
+                        {compactQuestion}
+                        {description && (
+                            <p className={cn('mt-1 text-xs leading-5 text-muted', descriptionClassName)}>
+                                {description}
+                            </p>
+                        )}
+                    </div>
                 </div>
             );
         }
@@ -214,12 +220,14 @@ export function AskUserWidget({
                                 <div className={cn('mt-1 flex-shrink-0 text-attention', iconClassName)}>{iconNode}</div>
                             )}
                             <div className="min-w-0 flex-1">
-                                {compactQuestion}
-                                {description && (
-                                    <p className={cn('mt-1 text-xs leading-5 text-muted', descriptionClassName)}>
-                                        {description}
-                                    </p>
-                                )}
+                                <div className={SCROLLABLE_PROMPT_CLASS}>
+                                    {compactQuestion}
+                                    {description && (
+                                        <p className={cn('mt-1 text-xs leading-5 text-muted', descriptionClassName)}>
+                                            {description}
+                                        </p>
+                                    )}
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -355,19 +363,21 @@ export function AskUserWidget({
                                 {icon || <DefaultIcon className="size-5" />}
                             </div>
                         )}
-                        <div className="flex-1 min-w-0">
-                            <div
-                                className={`prose prose-sm dark:prose-invert max-w-none text-gray-900 dark:text-gray-100 ${questionClassName || ''}`}
-                            >
-                                <MarkdownRenderer>{question}</MarkdownRenderer>
-                            </div>
-                            {description && (
-                                <p
-                                    className={`mt-1 text-sm text-gray-600 dark:text-gray-400 ${descriptionClassName || ''}`}
+                        <div className="min-w-0 flex-1">
+                            <div className={SCROLLABLE_PROMPT_CLASS}>
+                                <div
+                                    className={`agent-ask-question prose prose-sm dark:prose-invert max-w-none text-gray-900 dark:text-gray-100 ${questionClassName || ''}`}
                                 >
-                                    {description}
-                                </p>
-                            )}
+                                    <MarkdownRenderer>{question}</MarkdownRenderer>
+                                </div>
+                                {description && (
+                                    <p
+                                        className={`mt-1 text-sm text-gray-600 dark:text-gray-400 ${descriptionClassName || ''}`}
+                                    >
+                                        {description}
+                                    </p>
+                                )}
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- Keep ask-user prompts and descriptions inside a bounded scrollable area in compact and default layouts.
- Add regression coverage for long ask-user prompt rendering.
- Run the strict RTL class checker during `@vertesia/ui` builds and use logical positioning for the hidden tab measurement row.

## Test Plan
- [x] `pnpm --prefix composableai/packages/ui run lint`
- [x] `pnpm --prefix composableai/packages/ui exec vitest run src/features/agent/chat/AskUserWidget.test.tsx`
- [x] `pnpm --prefix composableai/packages/ui run typecheck:test`
- [x] `pnpm --prefix composableai/packages/ui run build`