### PR TITLE
Fix approval mode selector race

### DIFF
--- a/packages/ui/src/features/agent/chat/AgentRightPanel.tsx
+++ b/packages/ui/src/features/agent/chat/AgentRightPanel.tsx
@@ -537,7 +537,7 @@ function OverflowTabsBar({ tabs, current, onTabChange, className }: OverflowTabs
         <div ref={containerRef} className={cn('relative', className)}>
             {/* Hidden measurement row: all tabs + More at natural width, kept separate
                 from the visible row so measuring can't feed back into the layout. */}
-            <div aria-hidden className="pointer-events-none invisible absolute left-0 top-0 flex w-max gap-1">
+            <div aria-hidden className="pointer-events-none invisible absolute start-0 top-0 flex w-max gap-1">
                 {tabs.map((tab, i) => (
                     <button
                         type="button"

--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.test.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.test.tsx
@@ -425,6 +425,65 @@ describe('ModernAgentConversation send handling', () => {
         expect(screen.queryByText('Switch to full control?')).toBeNull();
     });
 
+    it('orders a follow-up user message after an in-flight approval mode change', async () => {
+        let resolveModeSignal: (() => void) | undefined;
+        mocks.retrieve.mockResolvedValue({
+            tool_approval_mode: 'ask',
+            interactive: true,
+            disabled_mcp_collections: undefined,
+        });
+        mocks.sendSignal.mockImplementation((_runId: string, signalName: string) => {
+            if (signalName === 'ToolApprovalModeChanged') {
+                return new Promise<void>((resolve) => {
+                    resolveModeSignal = resolve;
+                });
+            }
+            return Promise.resolve({});
+        });
+        mockStreamState({
+            messages: [createMessage(AgentMessageType.REQUEST_INPUT, 'What should I do next?')],
+            isCompleted: false,
+            agentRunStatus: 'RUNNING',
+        });
+
+        renderConversation({ hideMessageInput: false, interactive: true, allowWorkflowControl: true });
+
+        const selector = await screen.findByRole('button', { name: 'Agent approval mode' });
+        fireEvent.pointerDown(selector, {
+            button: 0,
+            ctrlKey: false,
+        });
+        fireEvent.click(await screen.findByRole('menuitemradio', { name: /Full control/ }));
+
+        await waitFor(() => {
+            expect(mocks.sendSignal).toHaveBeenCalledWith('agent-run-1', 'ToolApprovalModeChanged', {
+                mode: 'full_control',
+            });
+            expect(resolveModeSignal).toBeDefined();
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'composer send' }));
+
+        expect(mocks.sendSignal.mock.calls.some((call) => call[1] === 'UserInput')).toBe(false);
+
+        await act(async () => {
+            resolveModeSignal?.();
+        });
+
+        await waitFor(() => {
+            expect(mocks.sendSignal).toHaveBeenCalledWith(
+                'agent-run-1',
+                'UserInput',
+                expect.objectContaining({ message: 'follow up' }),
+            );
+        });
+
+        const modeCallIndex = mocks.sendSignal.mock.calls.findIndex((call) => call[1] === 'ToolApprovalModeChanged');
+        const userInputCallIndex = mocks.sendSignal.mock.calls.findIndex((call) => call[1] === 'UserInput');
+        expect(modeCallIndex).toBeGreaterThanOrEqual(0);
+        expect(userInputCallIndex).toBeGreaterThan(modeCallIndex);
+    });
+
     it('keeps a local approval mode change when stale run metadata loads later', async () => {
         let resolveRetrieve: (run: {
             tool_approval_mode: 'ask';

--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.test.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.test.tsx
@@ -425,6 +425,81 @@ describe('ModernAgentConversation send handling', () => {
         expect(screen.queryByText('Switch to full control?')).toBeNull();
     });
 
+    it('keeps a local approval mode change when stale run metadata loads later', async () => {
+        let resolveRetrieve: (run: {
+            tool_approval_mode: 'ask';
+            interactive: true;
+            disabled_mcp_collections: undefined;
+        }) => void = () => {};
+        mocks.retrieve.mockReturnValue(
+            new Promise((resolve) => {
+                resolveRetrieve = resolve;
+            }),
+        );
+        mockStreamState({
+            messages: [createMessage(AgentMessageType.ANSWER, 'still running')],
+            isCompleted: false,
+            agentRunStatus: 'RUNNING',
+        });
+
+        renderConversation({
+            hideMessageInput: false,
+            interactive: true,
+            allowWorkflowControl: true,
+            initialToolApprovalMode: 'ask',
+        });
+
+        expect(await screen.findByText('Ask for approval')).not.toBeNull();
+        fireEvent.pointerDown(screen.getByRole('button', { name: 'Agent approval mode' }), {
+            button: 0,
+            ctrlKey: false,
+        });
+        fireEvent.click(await screen.findByRole('menuitemradio', { name: /Full control/ }));
+
+        await waitFor(() => {
+            expect(mocks.sendSignal).toHaveBeenCalledWith('agent-run-1', 'ToolApprovalModeChanged', {
+                mode: 'full_control',
+            });
+        });
+
+        resolveRetrieve({
+            tool_approval_mode: 'ask',
+            interactive: true,
+            disabled_mcp_collections: undefined,
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText('Full control')).not.toBeNull();
+        });
+    });
+
+    it('reverts the local approval mode when the change signal fails', async () => {
+        mocks.retrieve.mockResolvedValue({
+            tool_approval_mode: 'ask',
+            interactive: true,
+            disabled_mcp_collections: undefined,
+        });
+        mocks.sendSignal.mockRejectedValueOnce(new Error('Signal failed'));
+        mockStreamState({
+            messages: [createMessage(AgentMessageType.ANSWER, 'still running')],
+            isCompleted: false,
+            agentRunStatus: 'RUNNING',
+        });
+
+        renderConversation({ hideMessageInput: false, interactive: true, allowWorkflowControl: true });
+
+        expect(await screen.findByText('Ask for approval')).not.toBeNull();
+        fireEvent.pointerDown(screen.getByRole('button', { name: 'Agent approval mode' }), {
+            button: 0,
+            ctrlKey: false,
+        });
+        fireEvent.click(await screen.findByRole('menuitemradio', { name: /Full control/ }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Ask for approval')).not.toBeNull();
+        });
+    });
+
     it('does not show a full-control fallback before active run mode metadata loads', () => {
         mocks.retrieve.mockReturnValue(new Promise(() => {}));
         mockStreamState({

--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.test.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.test.tsx
@@ -474,12 +474,17 @@ describe('ModernAgentConversation send handling', () => {
     });
 
     it('reverts the local approval mode when the change signal fails', async () => {
+        let rejectSignal: (error: Error) => void = () => {};
         mocks.retrieve.mockResolvedValue({
             tool_approval_mode: 'ask',
             interactive: true,
             disabled_mcp_collections: undefined,
         });
-        mocks.sendSignal.mockRejectedValueOnce(new Error('Signal failed'));
+        mocks.sendSignal.mockReturnValueOnce(
+            new Promise((_resolve, reject) => {
+                rejectSignal = reject;
+            }),
+        );
         mockStreamState({
             messages: [createMessage(AgentMessageType.ANSWER, 'still running')],
             isCompleted: false,
@@ -488,15 +493,25 @@ describe('ModernAgentConversation send handling', () => {
 
         renderConversation({ hideMessageInput: false, interactive: true, allowWorkflowControl: true });
 
-        expect(await screen.findByText('Ask for approval')).not.toBeNull();
-        fireEvent.pointerDown(screen.getByRole('button', { name: 'Agent approval mode' }), {
+        const selector = await screen.findByRole('button', { name: 'Agent approval mode' });
+        expect(selector.textContent).toContain('Ask for approval');
+        fireEvent.pointerDown(selector, {
             button: 0,
             ctrlKey: false,
         });
         fireEvent.click(await screen.findByRole('menuitemradio', { name: /Full control/ }));
 
         await waitFor(() => {
-            expect(screen.getByText('Ask for approval')).not.toBeNull();
+            expect(mocks.sendSignal).toHaveBeenCalledWith('agent-run-1', 'ToolApprovalModeChanged', {
+                mode: 'full_control',
+            });
+            expect(selector.textContent).toContain('Full control');
+        });
+
+        rejectSignal(new Error('Signal failed'));
+
+        await waitFor(() => {
+            expect(selector.textContent).toContain('Ask for approval');
         });
     });
 

--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
@@ -1416,6 +1416,7 @@ function ModernAgentConversationInner({
     const workstreamFetchFailedRef = useRef(false);
     const dragCounterRef = useRef(0);
     const pendingPlaybackScrollRef = useRef(false);
+    const toolApprovalModeChangeVersionRef = useRef(0);
 
     useEffect(() => {
         setToolApprovalMode(initialResolvedToolApprovalMode);
@@ -2040,12 +2041,16 @@ function ModernAgentConversationInner({
     const [mcpDisabled, setMcpDisabled] = useState<string[] | undefined>(undefined);
     useEffect(() => {
         let cancelled = false;
+        const requestVersion = toolApprovalModeChangeVersionRef.current;
         client.agents
             .retrieve(agentRunId)
             .then((run) => {
                 if (!cancelled) {
                     setMcpDisabled(run.disabled_mcp_collections);
-                    if (run.tool_approval_mode !== undefined || run.interactive !== undefined) {
+                    if (
+                        toolApprovalModeChangeVersionRef.current === requestVersion &&
+                        (run.tool_approval_mode !== undefined || run.interactive !== undefined)
+                    ) {
                         setToolApprovalMode(normalizeAgentToolApprovalMode(run.tool_approval_mode, run.interactive));
                     }
                 }
@@ -2081,10 +2086,13 @@ function ModernAgentConversationInner({
     const handleToolApprovalModeChange = useCallback(
         (mode: AgentToolApprovalMode) => {
             const nextMode = normalizeAgentToolApprovalMode(mode, interactive);
+            const previousMode = toolApprovalMode;
+            toolApprovalModeChangeVersionRef.current += 1;
             setToolApprovalMode(nextMode);
             client.agents
                 .sendSignal(agentRunId, 'ToolApprovalModeChanged', { mode: nextMode })
                 .catch((err: unknown) => {
+                    setToolApprovalMode((currentMode) => (currentMode === nextMode ? previousMode : currentMode));
                     toast({
                         status: 'error',
                         title: t('agent.approvalMode.changeFailed'),
@@ -2093,7 +2101,7 @@ function ModernAgentConversationInner({
                     });
                 });
         },
-        [agentRunId, client, interactive, t, toast],
+        [agentRunId, client, interactive, t, toast, toolApprovalMode],
     );
 
     // Drag and drop handlers for full-panel file upload

--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
@@ -1417,6 +1417,7 @@ function ModernAgentConversationInner({
     const dragCounterRef = useRef(0);
     const pendingPlaybackScrollRef = useRef(false);
     const toolApprovalModeChangeVersionRef = useRef(0);
+    const pendingToolApprovalModeChangeRef = useRef<Promise<void> | null>(null);
 
     useEffect(() => {
         setToolApprovalMode(initialResolvedToolApprovalMode);
@@ -1910,6 +1911,13 @@ function ModernAgentConversationInner({
     // Handlers
     // ────────────────────────────────────────────
 
+    const waitForPendingToolApprovalModeChange = useCallback(async () => {
+        const pendingChange = pendingToolApprovalModeChangeRef.current;
+        if (pendingChange) {
+            await pendingChange;
+        }
+    }, []);
+
     // Send a message to the agent
     const handleSendMessage = useCallback(
         (message: string, inputMetadata?: Record<string, unknown>) => {
@@ -1981,12 +1989,15 @@ function ModernAgentConversationInner({
             // buffers the signal until the new run is ready to receive it. We reconnect
             // the stream in place (rather than remounting via onRestart) so the existing
             // timeline is preserved and the new exchange appends seamlessly at the bottom.
-            const deliver = isWorkflowTerminalRef.current
-                ? client.agents.restart(agentRunId).then(() => {
-                      reconnectStream();
-                      return sendUserInput().then(markReceived);
-                  })
-                : sendUserInput().then(markReceived);
+            const deliver = (async () => {
+                await waitForPendingToolApprovalModeChange();
+                if (isWorkflowTerminalRef.current) {
+                    await client.agents.restart(agentRunId);
+                    reconnectStream();
+                }
+                await sendUserInput();
+                markReceived();
+            })();
 
             deliver
                 .catch((err) => {
@@ -2013,6 +2024,7 @@ function ModernAgentConversationInner({
             addOptimisticMessage,
             updateOptimisticMessageStatus,
             t,
+            waitForPendingToolApprovalModeChange,
         ],
     );
 
@@ -2089,8 +2101,9 @@ function ModernAgentConversationInner({
             const previousMode = toolApprovalMode;
             toolApprovalModeChangeVersionRef.current += 1;
             setToolApprovalMode(nextMode);
-            client.agents
+            const signalPromise = client.agents
                 .sendSignal(agentRunId, 'ToolApprovalModeChanged', { mode: nextMode })
+                .then(() => undefined)
                 .catch((err: unknown) => {
                     setToolApprovalMode((currentMode) => (currentMode === nextMode ? previousMode : currentMode));
                     toast({
@@ -2100,6 +2113,12 @@ function ModernAgentConversationInner({
                         duration: 3000,
                     });
                 });
+            pendingToolApprovalModeChangeRef.current = signalPromise;
+            void signalPromise.finally(() => {
+                if (pendingToolApprovalModeChangeRef.current === signalPromise) {
+                    pendingToolApprovalModeChangeRef.current = null;
+                }
+            });
         },
         [agentRunId, client, interactive, t, toast, toolApprovalMode],
     );


### PR DESCRIPTION
## Summary
- Keep the active-run approval mode selector from being overwritten by stale run metadata after a local mode change.
- Revert the selector if the approval mode signal fails instead of leaving the UI in an optimistic state.
- Convert one remaining physical positioning utility in the agent right panel to a logical utility so strict RTL checks pass.

## Test Plan
- [x] pnpm --dir composableai/packages/ui exec vitest run src/features/agent/chat/ModernAgentConversation.test.tsx
- [x] pnpm --dir composableai/packages/ui run lint
- [x] pnpm --dir composableai/packages/ui run typecheck:test
- [x] pnpm --dir composableai/packages/ui run build
- [x] pnpm --prefix apps/composable-ui run lint
- [x] pnpm --prefix apps/composable-ui run build