### PR TITLE
chore(koa-stack): bump version to 0.26.0-dev

### DIFF
--- a/libraries/koa-stack/body/package.json
+++ b/libraries/koa-stack/body/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@koa-stack/body",
-    "version": "0.24.0",
+    "version": "0.26.0-dev",
     "description": "Expose the request body as a promise in koa Context.body",
     "type": "module",
     "scripts": {

--- a/libraries/koa-stack/router/package.json
+++ b/libraries/koa-stack/router/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@koa-stack/router",
-    "version": "0.24.0",
+    "version": "0.26.0-dev",
     "description": "A powerfull koa router using typescript decorations",
     "type": "module",
     "scripts": {

--- a/libraries/koa-stack/server/package.json
+++ b/libraries/koa-stack/server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@koa-stack/server",
-    "version": "0.24.0",
+    "version": "0.26.0-dev",
     "description": " A web server based on koa with advanced routing, lazy body and flexbile error handling",
     "type": "module",
     "scripts": {

--- a/libraries/koa-stack/tests/package.json
+++ b/libraries/koa-stack/tests/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@koa-stack/tests",
-    "version": "0.24.0",
+    "version": "0.26.0-dev",
     "private": true,
     "description": "Tests",
     "type": "module",


### PR DESCRIPTION
## Summary
- Bump all `@koa-stack/*` workspace packages (`body`, `router`, `server`, `tests`) from `0.24.0` to `0.26.0-dev`.
- `@koa-stack` `0.25.0` was published recently (tag `koa-stack/v0.25.0`), so move the mainline development version ahead to `0.26.0-dev` for the next release cycle.
- Version-string change only; no source or dependency changes. Internal packages are consumed via `workspace:*`, so no dependent version ranges need updating.

## Test Plan
- [x] All four `libraries/koa-stack/*/package.json` files parse as valid JSON and report `0.26.0-dev`.
- [ ] Build/lint/test not run — this is a version-metadata-only change with no code impact; `workspace:*` consumers resolve the bumped versions automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>