### PR TITLE
chore(deps, renovate): add renovate support for template pnpm-workspace

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -33,6 +33,15 @@
   ],
   "prConcurrentLimit": 40,
   "labels": ["dependencies"],
+  "npm": {
+    // Extend Renovate's default npm manager configuration to include .template files.
+    "fileMatch": [
+      "/(^|/)package\\.json$/",
+      "/(^|/)pnpm-workspace\\.yaml$/",
+      "/(^|/)pnpm-workspace\\.yaml\\.template$/",
+      "/(^|/)\\.yarnrc\\.yml$/"
+    ]
+  },
   // Security advisories bypass the release-age cooldown defined below so CVE fixes can
   // land immediately. See https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts
   "vulnerabilityAlerts": {

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -35,7 +35,7 @@
   "labels": ["dependencies"],
   "npm": {
     // Extend Renovate's default npm manager configuration to include .template files.
-    "fileMatch": [
+    "managerFilePatterns": [
       "/(^|/)package\\.json$/",
       "/(^|/)pnpm-workspace\\.yaml$/",
       "/(^|/)pnpm-workspace\\.yaml\\.template$/",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "check": "pnpm exec biome check .",
         "check:write": "pnpm exec biome check --write .",
         "ci:local": "pnpm run ci:renovate && pnpm run check && pnpm run build && pnpm run ci:test",
-        "ci:renovate": "npx --yes --package renovate -- renovate-config-validator --strict",
+        "ci:renovate": "npx --yes --package 'renovate@>=43' -- renovate-config-validator --strict",
         "ci:test": "pnpm exec turbo run typecheck:test test --filter='./packages/*' --filter='./llumiverse/*' --filter='./templates/*'",
         "ci:typecheck:test": "pnpm exec turbo run typecheck:test --filter='./packages/*' --filter='./llumiverse/*' --filter='./templates/*'",
         "clean": "rimraf ./node_modules && pnpm -r clean",

--- a/packages/create-plugin/src/process-template.ts
+++ b/packages/create-plugin/src/process-template.ts
@@ -48,15 +48,6 @@ function resolveInternalVersion(
     return latest ? { version: latest, pinned: false } : null;
 }
 
-const DEFAULT_CATALOG_VERSIONS: Record<string, string> = {
-    react: '19.2.7',
-    'react-dom': '19.2.7',
-    '@types/node': '^24.13.2',
-    '@types/react': '19.2.17',
-    '@types/react-dom': '19.2.3',
-    vite: '8.0.16',
-};
-
 /**
  * Escape special regex characters
  */
@@ -211,27 +202,7 @@ export function adjustPackageJson(
             console.log(chalk.gray(`   ✓ Set packageManager to "${packageJson.packageManager}"`));
         }
 
-        // 2. Replace catalog: specs with concrete versions. Generated projects must install
-        // outside this monorepo, and npm does not understand pnpm catalog specs.
-        let catalogReplacements = 0;
-
-        ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'].forEach((depType) => {
-            if (packageJson[depType]) {
-                Object.keys(packageJson[depType]).forEach((pkgName) => {
-                    const version = DEFAULT_CATALOG_VERSIONS[pkgName];
-                    if (version && packageJson[depType][pkgName] === 'catalog:') {
-                        packageJson[depType][pkgName] = version;
-                        catalogReplacements++;
-                    }
-                });
-            }
-        });
-
-        if (catalogReplacements > 0) {
-            console.log(chalk.gray(`   ✓ Resolved ${catalogReplacements} catalog: dependencies to pinned versions`));
-        }
-
-        // 3. Replace workspace:* with pinned versions
+        // 2. Replace workspace:* with pinned versions
         const internalScopes = ['@vertesia/', '@llumiverse/', '@dglabs/'];
         const versionMap = isDev ? undefined : getTemplateVersions();
         let workspaceReplacements = 0;

--- a/packages/create-plugin/src/process-template.ts
+++ b/packages/create-plugin/src/process-template.ts
@@ -48,6 +48,52 @@ function resolveInternalVersion(
     return latest ? { version: latest, pinned: false } : null;
 }
 
+function stripYamlQuotes(value: string): string {
+    const trimmed = value.trim();
+    if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+        return trimmed.slice(1, -1);
+    }
+    return trimmed;
+}
+
+function readTemplateCatalog(projectName: string): Record<string, string> {
+    const workspacePath =
+        ['pnpm-workspace.yaml.template', 'pnpm-workspace.yaml']
+            .map((fileName) => path.join(projectName, fileName))
+            .find((filePath) => fs.existsSync(filePath)) ?? '';
+
+    if (!workspacePath) {
+        return {};
+    }
+
+    const catalog: Record<string, string> = {};
+    let inCatalog = false;
+
+    for (const line of fs.readFileSync(workspacePath, 'utf8').split(/\r?\n/)) {
+        if (!inCatalog) {
+            if (line.trim() === 'catalog:') {
+                inCatalog = true;
+            }
+            continue;
+        }
+
+        if (line.trim() === '' || line.trimStart().startsWith('#')) {
+            continue;
+        }
+
+        if (!line.startsWith(' ') && !line.startsWith('\t')) {
+            break;
+        }
+
+        const match = line.match(/^\s+("?[^":]+"?|[^:]+):\s*(.+?)\s*(?:#.*)?$/);
+        if (match) {
+            catalog[stripYamlQuotes(match[1])] = stripYamlQuotes(match[2]);
+        }
+    }
+
+    return catalog;
+}
+
 /**
  * Escape special regex characters
  */
@@ -202,7 +248,29 @@ export function adjustPackageJson(
             console.log(chalk.gray(`   ✓ Set packageManager to "${packageJson.packageManager}"`));
         }
 
-        // 2. Replace workspace:* with pinned versions
+        // 2. Replace catalog: specs with concrete versions for package managers that do not support pnpm catalogs.
+        let catalogReplacements = 0;
+
+        if (packageManager !== 'pnpm') {
+            const catalog = readTemplateCatalog(projectName);
+
+            ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'].forEach((depType) => {
+                if (packageJson[depType]) {
+                    Object.keys(packageJson[depType]).forEach((pkgName) => {
+                        if (packageJson[depType][pkgName] === 'catalog:' && catalog[pkgName]) {
+                            packageJson[depType][pkgName] = catalog[pkgName];
+                            catalogReplacements++;
+                        }
+                    });
+                }
+            });
+        }
+
+        if (catalogReplacements > 0) {
+            console.log(chalk.gray(`   ✓ Resolved ${catalogReplacements} catalog: dependencies from template catalog`));
+        }
+
+        // 3. Replace workspace:* with pinned versions
         const internalScopes = ['@vertesia/', '@llumiverse/', '@dglabs/'];
         const versionMap = isDev ? undefined : getTemplateVersions();
         let workspaceReplacements = 0;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,7 +139,7 @@ importers:
         version: 4.1.0
       koa-send:
         specifier: ^5.0.1
-        version: 5.0.1(supports-color@8.1.1)
+        version: 5.0.1
       path-to-regexp:
         specifier: ^8.4.2
         version: 8.4.2
@@ -217,7 +217,7 @@ importers:
         version: link:../../tsconfig
       supertest:
         specifier: ^7.2.2
-        version: 7.2.2(supports-color@8.1.1)
+        version: 7.2.2
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -5119,14 +5119,6 @@ packages:
   i18next-resources-for-ts@2.1.0:
     resolution: {integrity: sha512-n5UexwEVt0OoIAhG2MWpSnAVJW1U8mQrQTmXyxc5DMAx+NLhcLZhSMJo/FnUsA5JQ3obTYqTgB7YIuZKWpDgow==}
     hasBin: true
-
-  i18next@26.3.1:
-    resolution: {integrity: sha512-txQqd5EULsqEh9OJqRH15aCaOuy/nLJyhw5EHCSKLKJE1aBbb3Zve2+uQIxgWhPm1QqUQoWyQBm2kfmmIrzkcQ==}
-    peerDependencies:
-      typescript: ^5 || ^6
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   i18next@26.3.3:
     resolution: {integrity: sha512-aYVegyBdXSO93CMMihvr47jI7GHSOcIahMpJX+qzUXDzW4xDJf2uenIA+45vDU+YhiVdcfsql70AC9RVdMNrHg==}
@@ -11135,7 +11127,7 @@ snapshots:
       commander: 14.0.3
       execa: 9.6.1
       glob: 13.0.6
-      i18next: 26.3.1(typescript@6.0.3)
+      i18next: 26.3.3(typescript@6.0.3)
       i18next-resources-for-ts: 2.1.0
       inquirer: 14.0.2(@types/node@24.13.2)
       jiti: 2.7.0
@@ -11144,7 +11136,7 @@ snapshots:
       minimatch: 10.2.5
       ora: 9.4.1
       react: 19.2.7
-      react-i18next: 17.0.8(i18next@26.3.1(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+      react-i18next: 17.0.8(i18next@26.3.3(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       yaml: 2.9.0
     transitivePeerDependencies:
       - '@swc/helpers'
@@ -11161,10 +11153,6 @@ snapshots:
       yaml: 2.9.0
     transitivePeerDependencies:
       - '@swc/helpers'
-
-  i18next@26.3.1(typescript@6.0.3):
-    optionalDependencies:
-      typescript: 6.0.3
 
   i18next@26.3.3(typescript@6.0.3):
     optionalDependencies:
@@ -11366,7 +11354,7 @@ snapshots:
 
   koa-compose@4.1.0: {}
 
-  koa-send@5.0.1(supports-color@8.1.1):
+  koa-send@5.0.1:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       http-errors: 1.8.1
@@ -12331,17 +12319,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
-  react-i18next@17.0.8(i18next@26.3.1(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3):
-    dependencies:
-      '@babel/runtime': 7.29.7
-      html-parse-stringify: 3.0.1
-      i18next: 26.3.1(typescript@6.0.3)
-      react: 19.2.7
-      use-sync-external-store: 1.6.0(react@19.2.7)
-    optionalDependencies:
-      react-dom: 19.2.7(react@19.2.7)
-      typescript: 6.0.3
-
   react-i18next@17.0.8(i18next@26.3.3(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3):
     dependencies:
       '@babel/runtime': 7.29.7
@@ -12820,7 +12797,7 @@ snapshots:
 
   stylis@4.3.6: {}
 
-  superagent@10.3.0(supports-color@8.1.1):
+  superagent@10.3.0:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
@@ -12834,11 +12811,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  supertest@7.2.2(supports-color@8.1.1):
+  supertest@7.2.2:
     dependencies:
       cookie-signature: 1.2.2
       methods: 1.1.2
-      superagent: 10.3.0(supports-color@8.1.1)
+      superagent: 10.3.0
     transitivePeerDependencies:
       - supports-color
 

--- a/templates/plugin-template/pnpm-workspace.yaml.template
+++ b/templates/plugin-template/pnpm-workspace.yaml.template
@@ -9,3 +9,10 @@ catalog:
   "@types/react": "19.2.17"
   "@types/react-dom": "19.2.3"
   vite: "8.0.16"
+overrides:
+  react: "catalog:"
+  react-dom: "catalog:"
+  "@types/node": "catalog:"
+  "@types/react": "catalog:"
+  "@types/react-dom": "catalog:"
+  vite: "catalog:"


### PR DESCRIPTION
## Summary

- Teach Renovate’s npm manager to scan `pnpm-workspace.yaml.template` files.
- Restore plugin-template dependency version ownership to the generated pnpm workspace catalog/overrides.

## Details

The plugin template uses `pnpm-workspace.yaml.template`, which is renamed to `pnpm-workspace.yaml` when a plugin project is scaffolded. Because the source file has a `.template` suffix, Renovate was not detecting catalog entries there, which forced dependency bumps to be mirrored manually in `process-template.ts`.

This PR adds the template workspace file to Renovate’s npm file matching and lets the generated pnpm workspace config own catalog versions directly. The generated project can still use pnpm catalogs/overrides normally after scaffolding.

## Verification

- `pnpm run ci:renovate`
- `pnpm --filter @vertesia/create-plugin run lint`
- `pnpm --filter @vertesia/create-plugin run build`
- `pnpm --filter @vertesia/create-plugin run test`
- `pnpm --filter plugin-template run lint`
- `pnpm --filter plugin-template run build`