### PR TITLE
feat(cli): support result schema overrides

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -130,6 +130,11 @@ program
     .option('--frequency-penalty [frequency-penalty]', 'The frequency penalty value to use')
     .option('--stop-sequence [stop-sequence]', 'A comma separated list of sequences to stop the generation')
     .option(
+        '--result-schema <json>',
+        'Inline JSON schema override for this run. Pass null to explicitly disable the interaction schema.',
+    )
+    .option('--result-schema-file <file>', 'Read the JSON schema override for this run from a file.')
+    .option(
         '--config-mode [config-mode]',
         'The configuration mode to use.Possible values are: "run_and_interaction_config", "run_config_only", "interaction_config_only". Optional. If not specified, "run_and_interaction_config" is used.',
     )

--- a/packages/cli/src/run/executor.ts
+++ b/packages/cli/src/run/executor.ts
@@ -6,7 +6,8 @@ import {
     RunDataStorageLevel,
     type TextFallbackOptions,
 } from '@vertesia/common';
-import { type CliOptions, getStringOption } from '../utils/options.js';
+import { type CliOptions, errorMessage, getStringOption, isRecord } from '../utils/options.js';
+import { readFile } from '../utils/stdio.js';
 
 export type CliExecutionResult = InteractionExecutionResult & {
     runNumber?: number;
@@ -139,6 +140,15 @@ export class ExecutionRequest {
             run_data: convertRunData(options.runData),
         };
         const tags = getStringOption(options.tags)?.split(/\s,*\s*/);
+        const payload: InteractionExecutionPayload = {
+            data: readInteractionData(this.data),
+            config,
+            tags,
+        };
+        const resultSchema = readResultSchema(options);
+        if (resultSchema !== undefined) {
+            payload.result_schema = resultSchema;
+        }
 
         // Create a wrapper for the onChunk callback that checks for abort
         const abortAwareChunkHandler = onChunk
@@ -151,23 +161,11 @@ export class ExecutionRequest {
         let run: CliExecutionResult;
         try {
             if (this.options.byId) {
-                run = await this.client.interactions.execute(
-                    this.interactionSpec,
-                    {
-                        data: readInteractionData(this.data),
-                        config,
-                        tags,
-                    },
-                    abortAwareChunkHandler,
-                );
+                run = await this.client.interactions.execute(this.interactionSpec, payload, abortAwareChunkHandler);
             } else {
                 run = await this.client.interactions.executeByName(
                     this.interactionSpec,
-                    {
-                        data: readInteractionData(this.data),
-                        config,
-                        tags,
-                    },
+                    payload,
                     abortAwareChunkHandler,
                 );
             }
@@ -195,4 +193,31 @@ export class ExecutionRequest {
 
 function readInteractionData(data: unknown): InteractionExecutionPayload['data'] {
     return data as InteractionExecutionPayload['data'];
+}
+
+function readResultSchema(options: CliOptions): InteractionExecutionPayload['result_schema'] | undefined {
+    const inlineSchema = getStringOption(options.resultSchema);
+    const schemaFile = getStringOption(options.resultSchemaFile);
+
+    if (inlineSchema && schemaFile) {
+        throw new Error('Use either --result-schema or --result-schema-file, not both.');
+    }
+    if (!inlineSchema && !schemaFile) {
+        return undefined;
+    }
+
+    const source = inlineSchema ? '--result-schema' : '--result-schema-file';
+    const rawSchema = inlineSchema ?? readFile(schemaFile as string);
+    let schema: unknown;
+    try {
+        schema = JSON.parse(rawSchema);
+    } catch (err: unknown) {
+        throw new Error(`Invalid JSON in ${source}: ${errorMessage(err)}`);
+    }
+
+    if (schema !== null && !isRecord(schema)) {
+        throw new Error(`${source} must be a JSON object or null.`);
+    }
+
+    return schema as InteractionExecutionPayload['result_schema'];
 }

--- a/packages/cli/src/run/index.ts
+++ b/packages/cli/src/run/index.ts
@@ -14,6 +14,8 @@ type RunInteractionOptions = CliOptions<{
     verbose?: boolean;
     jsonl?: boolean;
     dataOnly?: boolean;
+    resultSchema?: string;
+    resultSchemaFile?: string;
 }>;
 
 export default async function runInteraction(


### PR DESCRIPTION
## Summary
- Add `vertesia run --result-schema <json>` for per-run result schema overrides.
- Add `vertesia run --result-schema-file <file>` for schema overrides from disk.
- Forward result schema overrides for both interaction-name and `--by-id` executions, including `null` to explicitly disable the interaction schema.

## Test Plan
- [x] `pnpm --prefix composableai/packages/cli run build`
- [x] `pnpm --prefix composableai/packages/cli run lint`
- [x] `git -C composableai diff --check`
- [x] `node composableai/packages/cli/bin/app.js run --help`
- [x] `node composableai/packages/cli/bin/app.js run sys:WhatColor --data '{"object":"grass"}' --env <env_id> --model 'locations/global/publishers/google/models/gemini-2.5-flash-lite' --result-schema "$RESULT_SCHEMA" --no-stream --verbose`
