### PR TITLE
fix(cli): use canonical OAuth client metadata URL

### DIFF
--- a/packages/cli/src/profiles/oauth.ts
+++ b/packages/cli/src/profiles/oauth.ts
@@ -77,6 +77,14 @@ export function getOAuthClientId(oauthServerUrl: string): string {
     return new URL(OAUTH_CLIENT_METADATA_PATH, withTrailingSlash(oauthServerUrl)).toString();
 }
 
+export function getOAuthClientIdFromMetadata(
+    metadata: Pick<OAuthAuthorizationServerMetadata, 'issuer' | 'token_endpoint'>,
+): string {
+    // Regional STS aliases can advertise canonical endpoints. CIMD client_id values must
+    // match the canonical client metadata document URL, not the alias used for discovery.
+    return getOAuthClientId(new URL(metadata.token_endpoint || metadata.issuer).origin);
+}
+
 export function getOAuthResource(metadata: Pick<OAuthAuthorizationServerMetadata, 'issuer'>): string {
     return new URL(metadata.issuer).toString();
 }
@@ -85,7 +93,7 @@ export async function startOAuthSession(profile: OAuthProfile, signal?: AbortSig
     assertOAuthProfile(profile);
 
     const { metadata, serverUrl } = await discoverAuthorizationServer(profile);
-    const clientId = getOAuthClientId(serverUrl);
+    const clientId = getOAuthClientIdFromMetadata(metadata);
     const resource = getOAuthResource(metadata);
     const scope = getDefaultOAuthScope(metadata);
     const deviceAuthorization = await createDeviceAuthorization(metadata, {
@@ -118,7 +126,7 @@ export async function refreshOAuthSession(
     assertOAuthProfile(profile);
 
     const { metadata, serverUrl } = await discoverAuthorizationServer(profile);
-    const clientId = getOAuthClientId(serverUrl);
+    const clientId = getOAuthClientIdFromMetadata(metadata);
     const resource = bundle?.oauthResource || readTokenRefs(bundle?.accessToken).audience || getOAuthResource(metadata);
     const response = await exchangeRefreshToken(metadata, clientId, refreshToken, resource, options.projectId);
     return buildConfigResult(profile, response, clientId, resource, serverUrl);
@@ -432,6 +440,9 @@ async function readOAuthError(response: Response): Promise<{ error?: string; mes
         const error = typeof parsed.error === 'string' ? parsed.error : undefined;
         if (typeof parsed.error_description === 'string') {
             return { error, message: parsed.error_description };
+        }
+        if (typeof parsed.message === 'string') {
+            return { error, message: parsed.message };
         }
         if (error) {
             return { error, message: error };


### PR DESCRIPTION
## Summary

- Derive the CLI OAuth `client_id` from discovered canonical authorization server metadata instead of the regional discovery URL.
- Keep regional STS aliases such as `sts.us1.vertesia.io` working when their metadata points at canonical `sts.vertesia.io`.
- Surface OAuth error `message` fields when the server does not send `error_description`.

## Test Plan

- `PATH=../node_modules/.bin:$PATH pnpm --filter @vertesia/cli lint`
- `PATH=../node_modules/.bin:$PATH pnpm --filter @vertesia/cli... build`
- Live smoke: device authorization against `https://sts.us1.vertesia.io` returned 200 with canonical client ID `https://sts.vertesia.io/.well-known/oauth-client/vertesia-cli`.

## Notes

- `pnpm --filter @vertesia/cli lint` without PATH failed in this checkout because `biome` was not on the package-local PATH; the command above uses the parent workspace bin.
- This PR targets `release/1.4`; the same fix is already on the mainline branch.
