### PR TITLE
feat: add quota tier lookup (QuotaApi.tier + QuotaTierResponse)

### DIFF
--- a/packages/client/src/QuotaApi.ts
+++ b/packages/client/src/QuotaApi.ts
@@ -1,5 +1,5 @@
 import { ApiTopic, type ClientBase } from '@vertesia/api-fetch-client';
-import type { QuotaStandingResponse } from '@vertesia/common';
+import type { QuotaStandingResponse, QuotaTierResponse } from '@vertesia/common';
 
 export default class QuotaApi extends ApiTopic {
     constructor(parent: ClientBase) {
@@ -12,5 +12,13 @@ export default class QuotaApi extends ApiTopic {
      */
     standing(): Promise<QuotaStandingResponse> {
         return this.get('/standing');
+    }
+
+    /**
+     * The calling account's effective quota tier. A cheap, cacheable lookup used to resolve a
+     * tenant's tier without a direct account-store dependency.
+     */
+    tier(): Promise<QuotaTierResponse> {
+        return this.get('/tier');
     }
 }

--- a/packages/common/src/rate-limiter.ts
+++ b/packages/common/src/rate-limiter.ts
@@ -62,6 +62,13 @@ export interface QuotaStandingAdmissionClass {
     tenant_active: number;
 }
 
+/**
+ * Effective quota tier name after account-level overrides and account-type derivation.
+ * Code-defined tier names are currently `QuotaTier`, but this remains a string because deployments
+ * can introduce quota tiers through configuration.
+ */
+export type QuotaEffectiveTier = string;
+
 export interface QuotaStandingResponse {
     tenant_id: string;
     /**
@@ -75,7 +82,7 @@ export interface QuotaStandingResponse {
      * Tier used to compute the API limits below: explicit account `quota_tier`, else account_type
      * derived tier, else `base_tier` when the account tier could not be resolved.
      */
-    effective_tier: string;
+    effective_tier: QuotaEffectiveTier;
     /** Per-resource API rate-limit standing (effective limits + current usage). */
     api: QuotaStandingResource[];
     /**
@@ -101,5 +108,5 @@ export interface QuotaStandingResponse {
  * account tier cannot be resolved.
  */
 export interface QuotaTierResponse {
-    tier: QuotaStandingResponse['effective_tier'];
+    tier: QuotaEffectiveTier;
 }

--- a/packages/common/src/rate-limiter.ts
+++ b/packages/common/src/rate-limiter.ts
@@ -101,5 +101,5 @@ export interface QuotaStandingResponse {
  * account tier cannot be resolved.
  */
 export interface QuotaTierResponse {
-    tier: string;
+    tier: QuotaStandingResponse['effective_tier'];
 }

--- a/packages/common/src/rate-limiter.ts
+++ b/packages/common/src/rate-limiter.ts
@@ -91,3 +91,15 @@ export interface QuotaStandingResponse {
         note: string;
     };
 }
+
+/**
+ * Lightweight per-account quota tier for the calling account — served by `GET /api/v1/quota/tier`.
+ * A cheap, cacheable read that lets another service (e.g. zeno-server's API rate limiter) resolve
+ * the caller's tier through studio-server instead of reaching into the account store directly.
+ * `tier` is the SAME value {@link QuotaStandingResponse.effective_tier} reports: the account's
+ * explicit `quota_tier`, else its account_type-derived tier, else the deployment base tier when the
+ * account tier cannot be resolved.
+ */
+export interface QuotaTierResponse {
+    tier: string;
+}


### PR DESCRIPTION
## Summary
- Add `QuotaTierResponse { tier: string }` in `@vertesia/common`.
- Add `QuotaApi.tier()` in `@vertesia/client` → `GET /api/v1/quota/tier`.

A lightweight, cacheable read of the calling account's **effective** quota tier (the same value `QuotaStandingResponse.effective_tier` reports: explicit account `quota_tier`, else the account_type-derived tier, else the deployment base tier). This lets a service resolve a tenant's tier through the account-owning API instead of reaching into the account store directly.

## Test Plan
- [x] `@vertesia/common` and `@vertesia/client` build clean (`tsc` + rollup).
- [x] Biome check clean on both changed files.
- [x] Consuming server builds and unit tests pass (verified in the consumer repo).