### PR TITLE
fix: avoid Vite parsing collision with DataApi import method name

### DIFF
--- a/packages/cli/src/data/commands.ts
+++ b/packages/cli/src/data/commands.ts
@@ -58,7 +58,7 @@ export async function importData(
         },
     };
 
-    const job = await client.data.import(storeId, payload);
+    const job = await client.data.importData(storeId, payload);
 
     if (options.json) {
         console.log(JSON.stringify(job, null, 2));

--- a/packages/client/src/store/DataApi.ts
+++ b/packages/client/src/store/DataApi.ts
@@ -255,7 +255,7 @@ export class DataApi extends ApiTopic {
      *
      * @example
      * ```typescript
-     * const job = await client.data.import(storeId, {
+     * const job = await client.data.importData(storeId, {
      *   mode: 'append',
      *   message: 'Monthly data import',
      *   tables: {
@@ -272,7 +272,7 @@ export class DataApi extends ApiTopic {
      * });
      * ```
      */
-    import(id: string, payload: ImportDataPayload): Promise<ImportJob> {
+    importData(id: string, payload: ImportDataPayload): Promise<ImportJob> {
         return this.post(`/${id}/import`, { payload, headers: this.storeHeaders(id) });
     }
 


### PR DESCRIPTION
## Why

`DataApi` exposes many API helpers as client methods; one method was named `import`.

In Vite/Rollup import-analysis, the token sequence `import(` is treated as potential dynamic import syntax. A class method named `import(...)` can therefore be misinterpreted during bundling, producing warnings/errors even though runtime intent is a normal method call.

This does not change request behavior, only the SDK method name surface.

## What changed

- Renamed `DataApi.import(id, payload)` to `DataApi.importData(id, payload)`.
- Kept request endpoint and payload contract unchanged (`POST /data/{id}/import`).
- Updated dependent callsites to use `importData(...)`.
- Preserved all external behavior of the import workflow.

## Impact

- Removes a tooling-level dynamic-import parsing ambiguity in Vite builds.
- Prevents build regressions tied to Vite/Rollup analysis behavior during future dependency updates.
