### PR TITLE
fix: restore infinite-scroll observer re-attachment

### DIFF
--- a/packages/ui/src/core/hooks/useIntersectionObserver.tsx
+++ b/packages/ui/src/core/hooks/useIntersectionObserver.tsx
@@ -45,5 +45,7 @@ export function useIntersectionObserver(
                 observer.unobserve(element);
             }
         };
-    }, [target, threshold]);
+        // opts.deps let callers re-attach the observer once the target element mounts
+        // (e.g. an infinite-scroll sentinel that renders only after the first page loads).
+    }, [target, threshold, ...(opts.deps ?? [])]);
 }


### PR DESCRIPTION
## Summary
- `useIntersectionObserver` stopped wiring `opts.deps` into its effect dependency array (regression from #1333), so the `IntersectionObserver` was created only once at mount — before the load-more sentinel is rendered into the DOM — and was never re-attached.
- As a result, infinite scroll silently broke on every paginated view that renders its sentinel lazily: the loading spinner appeared at the bottom of the list but the next page was never fetched. Affected consumers include the content-object list (`DocumentSearchResults`), `useScrollableSearch`, `ContentObjectTypesSearch`, and `SelectDocument`.
- Fix: restore `opts.deps` in the effect's dependency array (`[target, threshold, ...(opts.deps ?? [])]`) so the observer re-attaches once the target element mounts. The `cbRef`/`optsRef` freshness refs introduced in #1333 are kept.

## Test Plan
- [x] `biome lint packages/ui/src/core/hooks/useIntersectionObserver.tsx` — clean (the spread in the deps array does not trip `useExhaustiveDependencies`)
- [x] `@vertesia/ui` builds successfully
- [ ] Manual: open a content-object list, scroll to the bottom, and confirm the next page loads instead of the spinner spinning indefinitely

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>