### PR TITLE
feat: add content type intake policy support

### DIFF
--- a/.github/bin/test-template-integration.sh
+++ b/.github/bin/test-template-integration.sh
@@ -94,6 +94,9 @@ packages:
     access: $all
     publish: $all
     proxy: npmjs
+  '@*/*':
+    access: $all
+    proxy: npmjs
   '**':
     access: $all
     proxy: npmjs

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -1,6 +1,6 @@
 import type { JSONSchemaType } from 'ajv';
 import type { SupportedIntegrations } from './integrations.js';
-import type { ContentTypeIntakePolicy } from './store/store.js';
+import type { ContentTypeIntakePolicy, IntakeVisionDetail, IntakeVisionProfileSettings } from './store/store.js';
 import type { WorkflowRunStatus } from './store/workflow.js';
 import type { AccountRef } from './user.js';
 
@@ -326,6 +326,13 @@ export interface ProjectIntakeConfiguration {
      * the legacy flat fields below. `identification` is type-specific and ignored here.
      */
     default_policy?: ContentTypeIntakePolicy;
+
+    /**
+     * Project overrides for the platform vision detail profiles used by intake visual
+     * extraction (`low`/`standard`/`high`). Partial: omitted profiles or fields inherit the
+     * platform defaults. Types reference detail NAMES only; the profile settings live here.
+     */
+    vision_profiles?: Partial<Record<IntakeVisionDetail, Partial<IntakeVisionProfileSettings>>>;
 
     /**
      * Generate table-of-content sections during standard document intake.

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -1,5 +1,6 @@
 import type { JSONSchemaType } from 'ajv';
 import type { SupportedIntegrations } from './integrations.js';
+import type { ContentTypeIntakePolicy } from './store/store.js';
 import type { WorkflowRunStatus } from './store/workflow.js';
 import type { AccountRef } from './user.js';
 
@@ -270,6 +271,20 @@ export type ProjectSearchTier = 'standard' | 'performance';
 export type ElasticsearchBackend = 'serverless' | 'hosted';
 
 export interface ProjectIntakeConfiguration {
+    /**
+     * Master switch for the standard intake pipeline. When false, StandardIntake exits as a
+     * no-op WITHOUT touching object status (objects stay in `created`, identifiable as
+     * unprocessed). Defaults to true.
+     */
+    enabled?: boolean;
+
+    /**
+     * Project-level intake policy defaults. Same shape as the per-content-type policy; a
+     * type's `intake` block wins field-by-field over these defaults, which in turn win over
+     * the legacy flat fields below. `identification` is type-specific and ignored here.
+     */
+    default_policy?: ContentTypeIntakePolicy;
+
     /**
      * Generate table-of-content sections during standard document intake.
      * Defaults to false.

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -270,6 +270,42 @@ export const BrowserUseProjectConfigurationSchema: JSONSchemaType<BrowserUseProj
 export type ProjectSearchTier = 'standard' | 'performance';
 export type ElasticsearchBackend = 'serverless' | 'hosted';
 
+/**
+ * Fast pre-conversion type identification (the "sniff") for untyped documents.
+ * The sniff classifies a document from cheap local evidence (first/last page text,
+ * a low-res first-page image, office docProps) BEFORE any conversion, so a
+ * high-confidence match can apply the type's intake policy — including skipping
+ * conversion — without paying for it first.
+ */
+export interface ProjectIntakeSniffConfiguration {
+    /**
+     * Enable the pre-conversion sniff for untyped documents. Defaults to true.
+     * Can be overridden per run with the `sniffEnabled` workflow var.
+     */
+    enabled?: boolean;
+
+    /**
+     * Confidence at or above which the sniffed type is committed and its full policy applied
+     * (including conversion-skip). 0..1, defaults to 0.85.
+     */
+    high_confidence?: number;
+
+    /**
+     * Confidence at or above which the sniffed type is treated as provisional: the document
+     * still converts and the post-conversion selector confirms on neutral evidence.
+     * 0..1, defaults to 0.6. Below this the sniff result is advisory provenance only.
+     */
+    medium_confidence?: number;
+
+    /**
+     * Minimum page count for the sniff LLM call. Below this, conversion is cheap and full
+     * converted text is better selection evidence, so intake uses the standard
+     * convert-then-select path. Documents with unknown page counts are sniffed.
+     * Defaults to 5; 0 means always sniff.
+     */
+    min_pages?: number;
+}
+
 export interface ProjectIntakeConfiguration {
     /**
      * Master switch for the standard intake pipeline. When false, StandardIntake exits as a
@@ -277,6 +313,12 @@ export interface ProjectIntakeConfiguration {
      * unprocessed). Defaults to true.
      */
     enabled?: boolean;
+
+    /**
+     * Fast pre-conversion type identification for untyped documents. Absent means enabled
+     * with platform default thresholds.
+     */
+    sniff?: ProjectIntakeSniffConfiguration;
 
     /**
      * Project-level intake policy defaults. Same shape as the per-content-type policy; a

--- a/packages/common/src/store/store.ts
+++ b/packages/common/src/store/store.ts
@@ -465,6 +465,54 @@ export interface ContentMetadata {
     embedded?: Record<string, unknown>;
     /** Type-detection provenance recorded by the intake sniff pipeline. */
     type_detection?: TypeDetectionMetadata;
+    /** Locate-pass provenance: which pages the document map found relevant. */
+    locate?: LocateMetadata;
+    /** Vision-evidence provenance for the last visual extraction run. */
+    vision_evidence?: VisionEvidenceMetadata;
+}
+
+/**
+ * Provenance persisted at `metadata.locate` when the intake locate (document-map) pass runs.
+ * The page list doubles as navigation metadata for the UI.
+ */
+export interface LocateMetadata {
+    /** Relevant pages proposed by the locate pass, in plan-ranked order (1-based). */
+    pages: number[];
+    /** Detail profile the plan requested for visual extraction. */
+    visual_detail?: 'low' | 'standard' | 'high';
+    /** Whether the plan asked for color rendering. */
+    needs_color?: boolean;
+    /** The model's one-line explanation of the selection. */
+    reason?: string;
+    page_count?: number;
+    /** Pages per contact sheet used for the pass (8 or 16). */
+    detail?: number;
+    sheet_count?: number;
+    located_at: string;
+}
+
+/**
+ * Provenance persisted at `metadata.vision_evidence` whenever intake prepares scoped page
+ * images for visual extraction (design: vision evidence spec — dropped pages are recorded,
+ * never silently batched).
+ */
+export interface VisionEvidenceMetadata {
+    /** Extraction source that requested the evidence. */
+    source_requested?: 'auto' | 'text' | 'vision' | 'mixed';
+    /** Pages rendered and sent as evidence, in ranked order (1-based). */
+    pages_sent: number[];
+    /** Resolved detail profile name. */
+    detail: 'low' | 'standard' | 'high';
+    /** Candidate pages dropped by budget clamping (recorded, not batched). */
+    dropped_pages?: number[];
+    /** The locate plan's reason, when the plan drove the page selection. */
+    plan_reason?: string;
+    /** Which clamps fired (page_count, allowed_details, token budget, page caps, payload). */
+    clamps_applied?: string[];
+    /** Estimated image tokens for the pages sent. */
+    est_tokens?: number;
+    page_count?: number;
+    prepared_at: string;
 }
 
 /**
@@ -779,6 +827,37 @@ export interface ColumnLayout {
 
 export type ContentObjectTypeStatus = 'active' | 'draft';
 
+/** Vision detail level names referenced by intake policies. The rendering profiles behind the
+ * names (dpi, max size, quality, color mode) are PLATFORM-defined and project-overridable —
+ * a type only ever references a detail name. */
+export type IntakeVisionDetail = 'low' | 'standard' | 'high';
+
+/**
+ * Named page scope for intake conversion/extraction: everything or the locate-pass result.
+ * Static page ranges live in the sibling `page_ranges` field (which wins when set) — kept as
+ * a SEPARATE field because scalar-or-collection unions generate unstable API clients.
+ */
+export type IntakePageScope = 'all' | 'located';
+
+/**
+ * Static page ranges: inclusive [start, end] pairs; negative indexes count from the end of
+ * the document ([[1, 2], [-1, -1]] = first two pages plus the last page).
+ */
+export type IntakePageRanges = [number, number][];
+
+/** Rendering settings behind a vision detail name (platform defaults, project-overridable
+ * via `configuration.intake.vision_profiles`). */
+export interface IntakeVisionProfileSettings {
+    /** Render resolution in dots per inch. */
+    dpi: number;
+    /** Maximum height/width of the rendered page image in pixels. */
+    max_hw: number;
+    /** JPEG quality (0-100). */
+    quality: number;
+    /** grayscale renders gray always; auto keeps color when the plan asks for it. */
+    color_mode: 'grayscale' | 'auto';
+}
+
 /**
  * Per-content-type policy for the standard intake workflows.
  */
@@ -791,6 +870,19 @@ export interface ContentTypeIntakePolicy {
         distinguish_from?: string;
         examples?: string[];
     };
+    /**
+     * Document-map ("locate") pass: page thumbnails tiled into labeled contact sheets, one
+     * vision call returns which pages matter for THIS type. The result can scope conversion
+     * and extraction, and doubles as the vision planner for visual extraction.
+     */
+    locate?: {
+        /** What to look for ("commercial terms, payment schedule, signature pages"). */
+        instructions: string;
+        /** Pages per contact sheet: 8 = bigger tiles (headings readable). Default 16. */
+        detail?: 8 | 16;
+        /** Only run when the page count is at least this. Default 8. */
+        min_pages?: number;
+    };
     /** Controls source-to-text conversion before extraction and embedding. */
     text_conversion?: {
         enabled?: boolean;
@@ -801,6 +893,10 @@ export interface ContentTypeIntakePolicy {
         };
         instructions?: string;
         output_format?: 'markdown' | 'text';
+        /** Which pages to convert: everything or the locate result. Default all. */
+        scope?: IntakePageScope;
+        /** Static page ranges to convert (wins over `scope` when set). */
+        page_ranges?: IntakePageRanges;
     };
     /** Controls schema-property extraction after type assignment. */
     extraction?: {
@@ -808,6 +904,24 @@ export interface ContentTypeIntakePolicy {
         source?: 'auto' | 'text' | 'vision' | 'mixed';
         instructions?: string;
         interaction?: string;
+        /** Which pages extraction sees: everything or the locate result. */
+        scope?: IntakePageScope;
+        /** Static page ranges extraction sees (wins over `scope` when set). */
+        page_ranges?: IntakePageRanges;
+        /** Cap on pages sent to extraction. Default 20. */
+        max_pages?: number;
+        /** Vision evidence budget for visual extraction. Detail names reference platform
+         * profiles; the type never defines dpi/quality/resolution. */
+        vision?: {
+            default_detail?: IntakeVisionDetail;
+            allowed_details?: IntakeVisionDetail[];
+            /** PRIMARY budget: estimated image tokens per extraction call. Default 16000. */
+            max_image_tokens?: number;
+            /** Transport guard in megabytes. Default 16. */
+            max_payload_mb?: number;
+            /** Cap on page images per extraction call. Default 8. */
+            max_pages_per_call?: number;
+        };
         verification?: {
             enabled?: boolean;
             model?: string;
@@ -828,8 +942,30 @@ export interface ContentTypeIntakePolicy {
     default_view?: 'auto' | 'text' | 'pdf' | 'image' | 'properties';
 }
 
-/** JSON schema for validating ContentTypeIntakePolicy payloads at API/tool boundaries. */
-export const ContentTypeIntakePolicySchema: JSONSchemaType<ContentTypeIntakePolicy> = {
+/** Reusable sub-schema for IntakePageScope ('all' | 'located'). */
+const IntakePageScopeSchema = {
+    type: 'string',
+    enum: ['all', 'located'],
+    description: "Named pages selection: 'all' or 'located' (the locate-pass result). Default all.",
+    nullable: true,
+};
+
+/** Reusable sub-schema for IntakePageRanges (inclusive [start, end] pairs, negative = from end). */
+const IntakePageRangesSchema = {
+    type: 'array',
+    items: { type: 'array', items: { type: 'integer' }, minItems: 2, maxItems: 2 },
+    description:
+        'Static inclusive [start, end] page ranges; negative indexes count from the end ' +
+        '([[1,2],[-1,-1]] = first two pages plus the last). Wins over scope when set.',
+    nullable: true,
+};
+
+/** JSON schema for validating ContentTypeIntakePolicy payloads at API/tool boundaries.
+ * NOTE: typed via a cast because AJV's strict `JSONSchemaType` mapping cannot express the
+ * `[number, number]` pair items of `page_ranges` as a uniform-items array. The runtime
+ * schema is compiled (and thus validated) by every consumer and by the schema-acceptance
+ * unit test in packages/workflows. */
+export const ContentTypeIntakePolicySchema = {
     type: 'object',
     description:
         'Per-content-type policy for standard intake: type selection, conversion, extraction, rendering, and embeddings.',
@@ -865,6 +1001,32 @@ export const ContentTypeIntakePolicySchema: JSONSchemaType<ContentTypeIntakePoli
                     description: 'Object ids of human-confirmed examples for this type.',
                     nullable: true,
                     items: { type: 'string' },
+                },
+            },
+        },
+        locate: {
+            type: 'object',
+            description:
+                'Document-map pass: labeled page-thumbnail contact sheets and one vision call return which ' +
+                'pages matter for this type. Scopes conversion/extraction and plans visual extraction.',
+            nullable: true,
+            required: ['instructions'],
+            additionalProperties: false,
+            properties: {
+                instructions: {
+                    type: 'string',
+                    description: 'What to look for (e.g. "commercial terms, payment schedule, signature pages").',
+                },
+                detail: {
+                    type: 'integer',
+                    enum: [8, 16],
+                    description: 'Pages per contact sheet: 8 = bigger tiles with readable headings. Default 16.',
+                    nullable: true,
+                },
+                min_pages: {
+                    type: 'number',
+                    description: 'Only run the locate pass when the page count is at least this. Default 8.',
+                    nullable: true,
                 },
             },
         },
@@ -916,6 +1078,8 @@ export const ContentTypeIntakePolicySchema: JSONSchemaType<ContentTypeIntakePoli
                     description: 'Output format for converted text. Prefer markdown for readable documents.',
                     nullable: true,
                 },
+                scope: IntakePageScopeSchema,
+                page_ranges: IntakePageRangesSchema,
             },
         },
         extraction: {
@@ -946,6 +1110,51 @@ export const ContentTypeIntakePolicySchema: JSONSchemaType<ContentTypeIntakePoli
                     type: 'string',
                     description: 'Interaction id used for extraction. Omit to use the system extractor.',
                     nullable: true,
+                },
+                scope: IntakePageScopeSchema,
+                page_ranges: IntakePageRangesSchema,
+                max_pages: {
+                    type: 'number',
+                    description: 'Cap on pages sent to extraction. Default 20.',
+                    nullable: true,
+                },
+                vision: {
+                    type: 'object',
+                    description:
+                        'Vision evidence budget for visual extraction. Detail names reference platform-defined ' +
+                        'profiles; the type never sets dpi, quality, or resolution.',
+                    nullable: true,
+                    required: [],
+                    additionalProperties: false,
+                    properties: {
+                        default_detail: {
+                            type: 'string',
+                            enum: ['low', 'standard', 'high'],
+                            description: 'Detail profile used when the plan does not request one. Default standard.',
+                            nullable: true,
+                        },
+                        allowed_details: {
+                            type: 'array',
+                            items: { type: 'string', enum: ['low', 'standard', 'high'] },
+                            description: 'Detail profiles the plan may request. Others fall back to default_detail.',
+                            nullable: true,
+                        },
+                        max_image_tokens: {
+                            type: 'number',
+                            description: 'PRIMARY budget: estimated image tokens per extraction call. Default 16000.',
+                            nullable: true,
+                        },
+                        max_payload_mb: {
+                            type: 'number',
+                            description: 'Transport guard in megabytes. Default 16.',
+                            nullable: true,
+                        },
+                        max_pages_per_call: {
+                            type: 'number',
+                            description: 'Cap on page images per extraction call. Default 8.',
+                            nullable: true,
+                        },
+                    },
                 },
                 verification: {
                     type: 'object',
@@ -1023,7 +1232,7 @@ export const ContentTypeIntakePolicySchema: JSONSchemaType<ContentTypeIntakePoli
             nullable: true,
         },
     },
-};
+} as unknown as JSONSchemaType<ContentTypeIntakePolicy>;
 
 export interface ContentObjectType extends ContentObjectTypeItem {}
 export interface ContentObjectTypeItem extends BaseObject {

--- a/packages/common/src/store/store.ts
+++ b/packages/common/src/store/store.ts
@@ -688,6 +688,12 @@ interface StoredTypeRef {
      */
     id: string;
     name: string;
+    /**
+     * Display hint from the type's intake policy (`intake.default_view`). Enriched by the
+     * API on single-object reads so clients can pick the initial view without fetching the
+     * type. Absent on list responses and older servers.
+     */
+    default_view?: ContentTypeIntakePolicy['default_view'];
 }
 
 interface InCodeTypeRef {
@@ -697,6 +703,12 @@ interface InCodeTypeRef {
      */
     id: string;
     name: string;
+    /**
+     * Display hint from the type's intake policy (`intake.default_view`). Enriched by the
+     * API on single-object reads so clients can pick the initial view without fetching the
+     * type. Absent on list responses and older servers.
+     */
+    default_view?: ContentTypeIntakePolicy['default_view'];
 }
 
 export interface ComplexSearchPayload extends Omit<SearchPayload, 'query'> {

--- a/packages/common/src/store/store.ts
+++ b/packages/common/src/store/store.ts
@@ -423,6 +423,12 @@ export interface GenerationRunMetadata {
     date: string;
     model: string;
     target?: string;
+    /**
+     * Fingerprint of the inputs used by property extraction (content etag, type + its object
+     * schema, source, instructions, interaction). Lets a later run skip re-extraction when
+     * nothing changed.
+     */
+    extraction_fingerprint?: string;
 }
 
 // Base rendition interface for document and audio
@@ -452,6 +458,38 @@ export interface ContentMetadata {
     /** ETag of text materialized from object properties by intake rendering. */
     rendered_text_etag?: string;
     renditions?: Rendition[];
+    /**
+     * Embedded/technical metadata harvested from the source file by intake
+     * (office docProps, PDF docinfo). Free-form, nature-appropriate keys.
+     */
+    embedded?: Record<string, unknown>;
+    /** Type-detection provenance recorded by the intake sniff pipeline. */
+    type_detection?: TypeDetectionMetadata;
+}
+
+/**
+ * Durable provenance persisted at `metadata.type_detection` whenever the intake sniff pipeline
+ * runs. `method` records which mechanism decides the type: the sniff itself (high confidence),
+ * the post-conversion selector (medium/low/other), or the post-conversion selector because the
+ * document was below the small-doc page threshold.
+ */
+export interface TypeDetectionMetadata {
+    method: 'sniff' | 'post_conversion' | 'post_conversion_small_doc';
+    /** Sniffed type id, or 'other'. */
+    type?: string;
+    type_name?: string;
+    /** Sniff confidence, 0..1. */
+    confidence?: number;
+    band?: 'high' | 'medium' | 'low';
+    rationale?: string;
+    alternates?: string[];
+    /** Which evidence kinds the sniff saw. */
+    evidence?: 'text' | 'image' | 'both';
+    page_count?: number;
+    /** Why the sniff LLM call was skipped (e.g. 'below_min_pages'). */
+    skipped_reason?: string;
+    min_pages?: number;
+    detected_at: string;
 }
 
 // Type-specific metadata interfaces

--- a/packages/common/src/store/store.ts
+++ b/packages/common/src/store/store.ts
@@ -1,3 +1,4 @@
+import type { JSONSchemaType } from 'ajv';
 import type { ComputedFacetResponse } from '../facets.js';
 import type { JSONObject } from '../json.js';
 import type { SearchPayload } from '../payload.js';
@@ -448,6 +449,8 @@ export interface ContentMetadata {
     location?: Location;
     generation_runs?: GenerationRunMetadata[];
     etag?: string;
+    /** ETag of text materialized from object properties by intake rendering. */
+    rendered_text_etag?: string;
     renditions?: Rendition[];
 }
 
@@ -723,9 +726,260 @@ export interface ColumnLayout {
      */
     default?: unknown;
 }
+
+export type ContentObjectTypeStatus = 'active' | 'draft';
+
+/**
+ * Per-content-type policy for the standard intake workflows.
+ */
+export interface ContentTypeIntakePolicy {
+    /** Intake orchestration mode for this type. */
+    mode?: 'programmatic' | 'agentic';
+    /** Guidance used when selecting or creating this content type. */
+    identification?: {
+        guidance?: string;
+        distinguish_from?: string;
+        examples?: string[];
+    };
+    /** Controls source-to-text conversion before extraction and embedding. */
+    text_conversion?: {
+        enabled?: boolean;
+        method?: 'auto' | 'basic' | 'llm' | 'custom';
+        custom?: {
+            interaction?: string;
+            agent?: string;
+        };
+        instructions?: string;
+        output_format?: 'markdown' | 'text';
+    };
+    /** Controls schema-property extraction after type assignment. */
+    extraction?: {
+        enabled?: boolean;
+        source?: 'auto' | 'text' | 'vision' | 'mixed';
+        instructions?: string;
+        interaction?: string;
+        verification?: {
+            enabled?: boolean;
+            model?: string;
+            environment?: string;
+            materiality?: string;
+            threshold?: number;
+            max_retries?: number;
+            on_fail?: 'flag' | 'block';
+        };
+    };
+    /** Handlebars template used to materialize extracted properties into object text. */
+    rendering_template?: string;
+    /** Per-type embedding switches. Unspecified values inherit the project policy. */
+    embeddings?: Partial<Record<SupportedEmbeddingTypes, boolean>>;
+    /** Whether intake should generate a table of contents for matching documents. */
+    generate_toc?: boolean;
+    /** Preferred first view for objects of this type. */
+    default_view?: 'auto' | 'text' | 'pdf' | 'image' | 'properties';
+}
+
+/** JSON schema for validating ContentTypeIntakePolicy payloads at API/tool boundaries. */
+export const ContentTypeIntakePolicySchema: JSONSchemaType<ContentTypeIntakePolicy> = {
+    type: 'object',
+    description:
+        'Per-content-type policy for standard intake: type selection, conversion, extraction, rendering, and embeddings.',
+    required: [],
+    additionalProperties: false,
+    properties: {
+        mode: {
+            type: 'string',
+            enum: ['programmatic', 'agentic'],
+            description:
+                'Intake orchestration mode. Use programmatic unless the user explicitly asks for agentic intake.',
+            nullable: true,
+        },
+        identification: {
+            type: 'object',
+            description: 'Guidance used by automatic type selection to recognize this type before full extraction.',
+            nullable: true,
+            required: [],
+            additionalProperties: false,
+            properties: {
+                guidance: {
+                    type: 'string',
+                    description: 'Classifier-facing description of what this type is and when it should be selected.',
+                    nullable: true,
+                },
+                distinguish_from: {
+                    type: 'string',
+                    description: 'How to distinguish this type from common look-alike document types.',
+                    nullable: true,
+                },
+                examples: {
+                    type: 'array',
+                    description: 'Object ids of human-confirmed examples for this type.',
+                    nullable: true,
+                    items: { type: 'string' },
+                },
+            },
+        },
+        text_conversion: {
+            type: 'object',
+            description: 'Controls source-to-text conversion before extraction, search, and text embeddings.',
+            nullable: true,
+            required: [],
+            additionalProperties: false,
+            properties: {
+                enabled: {
+                    type: 'boolean',
+                    description: 'Set false for extraction-only types that should not create converted markdown/text.',
+                    nullable: true,
+                },
+                method: {
+                    type: 'string',
+                    enum: ['auto', 'basic', 'llm', 'custom'],
+                    description: 'Conversion method. Use auto unless the user asks for a specific converter.',
+                    nullable: true,
+                },
+                custom: {
+                    type: 'object',
+                    description: 'Custom conversion implementation for method=custom.',
+                    nullable: true,
+                    required: [],
+                    additionalProperties: false,
+                    properties: {
+                        interaction: {
+                            type: 'string',
+                            description: 'Interaction id to call for custom conversion.',
+                            nullable: true,
+                        },
+                        agent: {
+                            type: 'string',
+                            description: 'Agent id to launch for custom conversion.',
+                            nullable: true,
+                        },
+                    },
+                },
+                instructions: {
+                    type: 'string',
+                    description: 'Instructions for what source content to preserve during conversion.',
+                    nullable: true,
+                },
+                output_format: {
+                    type: 'string',
+                    enum: ['markdown', 'text'],
+                    description: 'Output format for converted text. Prefer markdown for readable documents.',
+                    nullable: true,
+                },
+            },
+        },
+        extraction: {
+            type: 'object',
+            description: 'Controls structured property extraction against the content type object_schema.',
+            nullable: true,
+            required: [],
+            additionalProperties: false,
+            properties: {
+                enabled: {
+                    type: 'boolean',
+                    description: 'Whether intake should extract structured properties for this type.',
+                    nullable: true,
+                },
+                source: {
+                    type: 'string',
+                    enum: ['auto', 'text', 'vision', 'mixed'],
+                    description:
+                        'Evidence source for extraction: auto chooses text or vision, text sends text only, vision sends image/PDF evidence only, mixed sends both.',
+                    nullable: true,
+                },
+                instructions: {
+                    type: 'string',
+                    description: 'Type-specific extraction instructions such as pages or sections to ignore.',
+                    nullable: true,
+                },
+                interaction: {
+                    type: 'string',
+                    description: 'Interaction id used for extraction. Omit to use the system extractor.',
+                    nullable: true,
+                },
+                verification: {
+                    type: 'object',
+                    description: 'Optional safe-mode verification of extracted values against source evidence.',
+                    nullable: true,
+                    required: [],
+                    additionalProperties: false,
+                    properties: {
+                        enabled: {
+                            type: 'boolean',
+                            description: 'Whether to verify extracted values after extraction.',
+                            nullable: true,
+                        },
+                        model: { type: 'string', description: 'Verifier model override.', nullable: true },
+                        environment: {
+                            type: 'string',
+                            description: 'Verifier environment override.',
+                            nullable: true,
+                        },
+                        materiality: {
+                            type: 'string',
+                            description: 'What errors are material for this type.',
+                            nullable: true,
+                        },
+                        threshold: {
+                            type: 'number',
+                            description: 'Minimum verification confidence before flag/block behavior applies.',
+                            nullable: true,
+                        },
+                        max_retries: {
+                            type: 'number',
+                            description: 'Maximum extraction retries when verification fails.',
+                            nullable: true,
+                        },
+                        on_fail: {
+                            type: 'string',
+                            enum: ['flag', 'block'],
+                            description: 'Failure behavior after retries: flag for review or block property write.',
+                            nullable: true,
+                        },
+                    },
+                },
+            },
+        },
+        rendering_template: {
+            type: 'string',
+            description: 'Handlebars template used to materialize extracted properties into object text.',
+            nullable: true,
+        },
+        embeddings: {
+            type: 'object',
+            description: 'Per-type embedding switches. Omitted fields inherit the project embedding policy.',
+            nullable: true,
+            required: [],
+            additionalProperties: false,
+            properties: {
+                text: { type: 'boolean', description: 'Whether to generate text embeddings.', nullable: true },
+                image: { type: 'boolean', description: 'Whether to generate image embeddings.', nullable: true },
+                properties: {
+                    type: 'boolean',
+                    description: 'Whether to generate property embeddings.',
+                    nullable: true,
+                },
+            },
+        },
+        generate_toc: {
+            type: 'boolean',
+            description: 'Whether intake should generate table-of-contents sections for this type.',
+            nullable: true,
+        },
+        default_view: {
+            type: 'string',
+            enum: ['auto', 'text', 'pdf', 'image', 'properties'],
+            description: 'Preferred first view for objects of this type.',
+            nullable: true,
+        },
+    },
+};
+
 export interface ContentObjectType extends ContentObjectTypeItem {}
 export interface ContentObjectTypeItem extends BaseObject {
+    status?: ContentObjectTypeStatus;
     is_chunkable?: boolean;
+    intake?: ContentTypeIntakePolicy;
     /**
      * This is only included in ContentObjectTypeItem if explicitly requested
      * It is always included in ContentObjectType
@@ -744,7 +998,16 @@ export interface ContentObjectTypeItem extends BaseObject {
 }
 export type InCodeTypeDefinition = Pick<
     ContentObjectTypeItem,
-    'id' | 'name' | 'description' | 'tags' | 'object_schema' | 'table_layout' | 'is_chunkable' | 'strict_mode'
+    | 'id'
+    | 'name'
+    | 'description'
+    | 'tags'
+    | 'object_schema'
+    | 'table_layout'
+    | 'is_chunkable'
+    | 'strict_mode'
+    | 'status'
+    | 'intake'
 >;
 export interface ContentObjectTypeCatalogEntry extends InCodeTypeDefinition {
     updated_by?: string;

--- a/packages/common/src/store/workflow.ts
+++ b/packages/common/src/store/workflow.ts
@@ -7,6 +7,7 @@ import type {
 } from '../interaction.js';
 import type { JSONObject, JSONValue } from '../json.js';
 import type { JSONSchema } from '../json-schema.js';
+import type { SupportedEmbeddingTypes } from '../project.js';
 import type { AgentToolApprovalMode } from './agent-approval.js';
 import type { WorkflowInput } from './dsl-workflow.js';
 
@@ -1391,6 +1392,8 @@ export interface AgentIntakeWorkflowResult {
     collectionIds?: string[];
     /** Whether embeddings were generated */
     hasEmbeddings: boolean;
+    /** Embedding kinds that were actually generated. Skipped or failed activity results are omitted. */
+    generatedEmbeddings?: SupportedEmbeddingTypes[];
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/ui/src/features/store/objects/components/ContentOverview.tsx
+++ b/packages/ui/src/features/store/objects/components/ContentOverview.tsx
@@ -2,6 +2,7 @@ import {
     ContentNature,
     type ContentObject,
     ContentObjectStatus,
+    type ContentObjectTypeItem,
     type DocAnalyzerProgress,
     type DocProcessorOutputFormat,
     type DocumentMetadata,
@@ -33,6 +34,7 @@ import { AudioPanel, ImagePanel, VideoPanel } from '../../../media-viewer';
 import { SimplePdfViewer } from '../../../pdf-viewer';
 import { SecureButton } from '../../../permissions/SecureButton.js';
 import { getWorkflowStatusColor, getWorkflowStatusName, isPreviewableAsPdf } from '../../../utils/index.js';
+import { resolveTypeCached } from '../../types/typeCatalogCache.js';
 import { PropertiesEditorModal } from './PropertiesEditorModal';
 import { TextEditorPanel } from './TextEditorPanel.js';
 import { useObjectText, useOfficePdfConversion, usePdfProcessingStatus } from './useContentPanelHooks.js';
@@ -309,17 +311,51 @@ function PropertiesPanel({
     );
 }
 
-function DataPanel({
-    object,
-    loadText,
-    handleCopyContent,
-    refetch,
-}: {
+type IntakeDefaultView = NonNullable<NonNullable<ContentObjectTypeItem['intake']>['default_view']>;
+
+interface DataPanelProps {
     object: ContentObject;
     loadText: boolean;
     handleCopyContent: (content: string, type: 'text' | 'properties') => Promise<void>;
     refetch?: () => Promise<unknown>;
-}) {
+}
+
+/**
+ * Resolves the object's content-type intake policy BEFORE the initial panel is chosen so
+ * `default_view` can drive it. Renders a spinner until the type is resolved — never the
+ * MIME-guessed panel first (no guess-then-flip). Objects without a type render immediately.
+ */
+function DataPanel(props: DataPanelProps) {
+    const { client } = useUserSession();
+    const typeRef = props.object.type;
+    const typeId = typeRef?.id;
+    // Fast path: single-object reads carry the display hint on the API-enriched type ref.
+    const refView = typeRef?.default_view;
+    // Fallback (list-fed contexts, older servers): session-cached catalog lookup.
+    // null = resolved with no default view; undefined = not resolved yet.
+    const { data: fetchedView } = useFetch<IntakeDefaultView | null>(async () => {
+        if (!typeId || refView) return null;
+        const type = await resolveTypeCached(client, typeId);
+        return type?.intake?.default_view ?? null;
+    }, [typeId, refView]);
+    const defaultView = refView ?? fetchedView;
+    if (typeId && !refView && fetchedView === undefined) {
+        return (
+            <div className="flex h-full items-center justify-center">
+                <Spinner size="lg" />
+            </div>
+        );
+    }
+    return <DataPanelContent {...props} defaultView={defaultView ?? undefined} />;
+}
+
+function DataPanelContent({
+    object,
+    loadText,
+    handleCopyContent,
+    refetch,
+    defaultView,
+}: DataPanelProps & { defaultView?: IntakeDefaultView }) {
     const { t } = useUITranslation();
     const isImage = object?.metadata?.type === ContentNature.Image;
     const isVideo = object?.metadata?.type === ContentNature.Video;
@@ -333,8 +369,25 @@ function DataPanel({
     const metadata = object.metadata as DocumentMetadata;
     const pdfRendition = metadata?.renditions?.find((r) => r.name === PDF_RENDITION_NAME);
 
-    // Determine initial panel view
+    // Determine initial panel view: the type's default_view wins when it applies to this
+    // object; otherwise fall back to the nature/MIME heuristics.
     const getInitialView = (): PanelView => {
+        switch (defaultView) {
+            case 'text':
+                return PanelView.Text;
+            case 'pdf':
+                if (isPdf || isPreviewableAsPdfDoc || pdfRendition) return PanelView.Pdf;
+                break;
+            case 'image':
+                if (isImage) return PanelView.Image;
+                break;
+            case 'properties':
+                // Properties live in the right-hand panel which is always visible; the text
+                // panel shows the rendered property card for extraction-only types.
+                return PanelView.Text;
+            default:
+                break;
+        }
         if (isVideo) return PanelView.Video;
         if (isAudio) return PanelView.Audio;
         if (isImage) return PanelView.Image;

--- a/packages/ui/src/features/store/types/IntakePolicyEditor.tsx
+++ b/packages/ui/src/features/store/types/IntakePolicyEditor.tsx
@@ -1,0 +1,446 @@
+import { type ContentObjectType, type ContentTypeIntakePolicy, ContentTypeIntakePolicySchema } from '@vertesia/common';
+import {
+    Badge,
+    Button,
+    Dropdown,
+    errorMessage,
+    MenuGroup,
+    MenuItem,
+    Panel,
+    useTheme,
+    useToast,
+} from '@vertesia/ui/core';
+import { useUserSession } from '@vertesia/ui/session';
+import { type EditorApi, type Monaco, MonacoEditor } from '@vertesia/ui/widgets';
+import Ajv, { type ErrorObject, type ValidateFunction } from 'ajv';
+import addFormats from 'ajv-formats';
+import { Braces, CheckCircle2, FileText, RotateCcw, Save, WandSparkles } from 'lucide-react';
+import { useMemo, useRef, useState } from 'react';
+
+interface IntakePolicyEditorProps {
+    objectType: ContentObjectType;
+    onIntakeUpdate: (value: ContentTypeIntakePolicy | undefined) => void;
+    readonly?: boolean;
+}
+
+type IntakeExampleKey =
+    | 'minimal'
+    | 'extraction_only'
+    | 'visual_first'
+    | 'structured_spreadsheet'
+    | 'media_no_transcript';
+
+interface IntakeExample {
+    key: IntakeExampleKey;
+    label: string;
+    description: string;
+    value: ContentTypeIntakePolicy;
+}
+
+const INTAKE_EXAMPLES: IntakeExample[] = [
+    {
+        key: 'minimal',
+        label: 'Minimal',
+        description: 'Use project defaults and add only type-selection guidance.',
+        value: {
+            identification: {
+                guidance: 'Documents that match this content type.',
+                distinguish_from: 'Do not select this type for unrelated documents.',
+            },
+        },
+    },
+    {
+        key: 'extraction_only',
+        label: 'Extraction Only',
+        description: 'Extract properties visually, render a compact text summary, and keep the source view.',
+        value: {
+            text_conversion: {
+                enabled: false,
+            },
+            extraction: {
+                enabled: true,
+                source: 'vision',
+                instructions:
+                    'Extract required fields only. Ignore cover pages, appendices, legal boilerplate, and marketing content.',
+            },
+            rendering_template: '# {{title}}\n\n{{summary}}',
+            embeddings: {
+                text: true,
+                properties: true,
+            },
+            default_view: 'pdf',
+        },
+    },
+    {
+        key: 'visual_first',
+        label: 'Visual First',
+        description: 'Use visual evidence for PDFs, scans, PowerPoint files, diagrams, and layout-heavy content.',
+        value: {
+            identification: {
+                guidance: 'Presentation decks or visual reports with slides, charts, diagrams, tables, or callouts.',
+            },
+            text_conversion: {
+                enabled: true,
+                method: 'auto',
+            },
+            extraction: {
+                enabled: true,
+                source: 'auto',
+                instructions:
+                    'Use visual evidence when layout, charts, diagrams, or slide structure contain material information.',
+            },
+            default_view: 'pdf',
+        },
+    },
+    {
+        key: 'structured_spreadsheet',
+        label: 'Spreadsheet Text',
+        description: 'Use structured worksheet text for Excel/CSV files.',
+        value: {
+            text_conversion: {
+                enabled: true,
+                method: 'auto',
+                instructions: 'Preserve sheet names, headers, row labels, totals, and period columns.',
+            },
+            extraction: {
+                enabled: true,
+                source: 'text',
+                instructions: 'Extract values from worksheet text. Do not infer values from charts.',
+            },
+            default_view: 'properties',
+        },
+    },
+    {
+        key: 'media_no_transcript',
+        label: 'Media, No Transcript',
+        description: 'Disable transcription/conversion while preserving property extraction settings.',
+        value: {
+            text_conversion: {
+                enabled: false,
+            },
+            extraction: {
+                enabled: true,
+                source: 'auto',
+                instructions: 'Analyze available metadata and source evidence without creating a transcript.',
+            },
+            default_view: 'properties',
+        },
+    },
+];
+
+const EMPTY_POLICY: ContentTypeIntakePolicy = {};
+
+export function IntakePolicyEditor({ objectType, onIntakeUpdate, readonly = false }: IntakePolicyEditorProps) {
+    const { store } = useUserSession();
+    const toast = useToast();
+    const { theme } = useTheme();
+    const editorRef = useRef<EditorApi | undefined>(undefined);
+    const validatePolicy = useMemo(() => createPolicyValidator(), []);
+
+    const [isUpdating, setUpdating] = useState(false);
+    const [editorValue, setEditorValue] = useState(() => stringifyPolicy(objectType.intake));
+    const [savedValue, setSavedValue] = useState(() => stringifyPolicy(objectType.intake));
+    const [validationMessage, setValidationMessage] = useState<string | undefined>(undefined);
+
+    const isDirty = editorValue !== savedValue;
+    const currentPolicy = useMemo(() => parsePolicyOrUndefined(editorValue), [editorValue]);
+    const summaryPolicy = currentPolicy ?? objectType.intake ?? EMPTY_POLICY;
+
+    const beforeMount = (monaco: Monaco) => {
+        const namespace = monaco as unknown as {
+            languages?: { json?: { jsonDefaults?: { setDiagnosticsOptions(options: unknown): void } } };
+            json?: { jsonDefaults?: { setDiagnosticsOptions(options: unknown): void } };
+        };
+        const jsonDefaults = namespace.languages?.json?.jsonDefaults ?? namespace.json?.jsonDefaults;
+        jsonDefaults?.setDiagnosticsOptions({
+            validate: true,
+            allowComments: false,
+            schemas: [
+                {
+                    uri: 'vertesia://schemas/content-type-intake-policy.json',
+                    fileMatch: ['*'],
+                    schema: ContentTypeIntakePolicySchema,
+                },
+            ],
+        });
+    };
+
+    const validateCurrentEditorValue = () => {
+        const value = editorRef.current?.getValue() ?? editorValue;
+        const result = parseAndValidatePolicy(value, validatePolicy);
+        if (!result.ok) {
+            setValidationMessage(result.message);
+            return undefined;
+        }
+        setValidationMessage(undefined);
+        return result.policy;
+    };
+
+    const onSave = () => {
+        const policy = validateCurrentEditorValue();
+        if (!policy) {
+            return;
+        }
+
+        setUpdating(true);
+        store.types
+            .update(objectType.id, {
+                intake: policy,
+            })
+            .then((response) => {
+                const nextValue = stringifyPolicy(response.intake);
+                setEditorValue(nextValue);
+                setSavedValue(nextValue);
+                onIntakeUpdate(response.intake);
+                toast({
+                    status: 'success',
+                    title: 'Intake policy updated',
+                    description: 'The type intake policy has been saved.',
+                    duration: 2000,
+                });
+            })
+            .catch((err: unknown) => {
+                toast({
+                    status: 'error',
+                    title: 'Failed to update intake policy',
+                    description: errorMessage(err),
+                    duration: 5000,
+                });
+            })
+            .finally(() => {
+                setUpdating(false);
+            });
+    };
+
+    const onValidate = () => {
+        const policy = validateCurrentEditorValue();
+        toast({
+            status: policy ? 'success' : 'error',
+            title: policy ? 'Valid intake policy' : 'Invalid intake policy',
+            description: policy ? 'The JSON is valid and matches the intake policy schema.' : validationMessage,
+            duration: 3000,
+        });
+    };
+
+    const onRevert = () => {
+        setEditorValue(savedValue);
+        editorRef.current?.setValue(savedValue);
+        setValidationMessage(undefined);
+    };
+
+    const onFormat = () => {
+        const policy = validateCurrentEditorValue();
+        if (!policy) {
+            return;
+        }
+        const value = stringifyPolicy(policy);
+        setEditorValue(value);
+        editorRef.current?.setValue(value);
+    };
+
+    const insertExample = (example: IntakeExample) => {
+        const value = stringifyPolicy(example.value);
+        setEditorValue(value);
+        editorRef.current?.setValue(value);
+        setValidationMessage(undefined);
+    };
+
+    const title = (
+        <div className="flex items-center gap-2">
+            <div className="text-base font-semibold">Intake Policy</div>
+            {isDirty && <Badge variant="attention">Unsaved</Badge>}
+        </div>
+    );
+
+    const action = !readonly ? (
+        <>
+            <Dropdown
+                align="right"
+                trigger={
+                    <Button variant="outline" size="sm">
+                        <WandSparkles className="size-4" />
+                        Examples
+                    </Button>
+                }
+            >
+                <MenuGroup label="Insert example">
+                    {INTAKE_EXAMPLES.map((example) => (
+                        <MenuItem key={example.key} onClick={() => insertExample(example)}>
+                            <FileText className="size-4" />
+                            <div className="flex flex-col">
+                                <span>{example.label}</span>
+                                <span className="text-xs text-muted">{example.description}</span>
+                            </div>
+                        </MenuItem>
+                    ))}
+                </MenuGroup>
+            </Dropdown>
+            <Button variant="outline" size="sm" onClick={onFormat}>
+                <Braces className="size-4" />
+                Format
+            </Button>
+            <Button variant="outline" size="sm" onClick={onValidate}>
+                <CheckCircle2 className="size-4" />
+                Validate
+            </Button>
+            <Button variant="outline" size="sm" onClick={onRevert} disabled={!isDirty}>
+                <RotateCcw className="size-4" />
+                Revert
+            </Button>
+            <Button isLoading={isUpdating} size="sm" onClick={onSave} disabled={!isDirty}>
+                <Save className="size-4" />
+                Save
+            </Button>
+        </>
+    ) : undefined;
+
+    return (
+        <Panel title={title} className="bg-background! h-full" action={action}>
+            <div className="flex h-full min-h-0 gap-4">
+                <div className="flex min-w-0 flex-1 flex-col gap-3">
+                    <IntakeSummary policy={summaryPolicy} />
+                    {validationMessage && (
+                        <div className="rounded-sm border border-destructive bg-mixer-destructive/10 px-3 py-2 text-sm text-destructive">
+                            {validationMessage}
+                        </div>
+                    )}
+                    <div className="min-h-0 flex-1 overflow-hidden rounded-sm border">
+                        <MonacoEditor
+                            value={editorValue}
+                            language="json"
+                            editorRef={editorRef}
+                            beforeMount={beforeMount}
+                            onChange={(update) => {
+                                setEditorValue(update.state.doc.toString());
+                                setValidationMessage(undefined);
+                            }}
+                            theme={theme === 'dark' ? 'vs-dark' : 'vs'}
+                            options={{
+                                readOnly: readonly,
+                                minimap: { enabled: false },
+                                scrollBeyondLastLine: false,
+                                wordWrap: 'on',
+                                lineNumbers: 'on',
+                                automaticLayout: true,
+                                formatOnPaste: true,
+                                formatOnType: true,
+                                tabSize: 2,
+                            }}
+                        />
+                    </div>
+                </div>
+                <IntakeHelp />
+            </div>
+        </Panel>
+    );
+}
+
+function IntakeSummary({ policy }: { policy: ContentTypeIntakePolicy }) {
+    const values = [
+        ['Mode', policy.mode ?? 'inherit'],
+        ['Conversion', enabledLabel(policy.text_conversion?.enabled)],
+        ['Method', policy.text_conversion?.method ?? 'inherit'],
+        ['Source', policy.extraction?.source ?? 'inherit'],
+        ['Extraction', enabledLabel(policy.extraction?.enabled)],
+        ['Default View', policy.default_view ?? 'inherit'],
+        ['TOC', enabledLabel(policy.generate_toc)],
+        ['Template', policy.rendering_template ? 'set' : 'inherit'],
+    ];
+
+    return (
+        <div className="flex flex-wrap gap-2">
+            {values.map(([label, value]) => (
+                <Badge key={label} variant="outline" className="gap-1">
+                    <span className="text-muted">{label}:</span>
+                    <span>{value}</span>
+                </Badge>
+            ))}
+        </div>
+    );
+}
+
+function IntakeHelp() {
+    return (
+        <aside className="hidden w-80 shrink-0 overflow-y-auto rounded-sm border bg-mixer-muted/20 p-3 text-sm lg:block">
+            <div className="mb-3 font-semibold">Field Guide</div>
+            <div className="space-y-3 text-muted">
+                <HelpItem label="identification" text="Guidance for automatic type selection before extraction." />
+                <HelpItem
+                    label="text_conversion"
+                    text="Controls markdown/text generation. Set enabled=false for extraction-only types."
+                />
+                <HelpItem
+                    label="extraction.source"
+                    text="auto chooses text or vision. text is text only. vision is image/PDF evidence. mixed sends both."
+                />
+                <HelpItem
+                    label="rendering_template"
+                    text="Handlebars template used to materialize extracted properties into object text."
+                />
+                <HelpItem label="embeddings" text="Optional per-type text/image/properties embedding switches." />
+                <HelpItem label="default_view" text="Preferred first view for objects of this type." />
+            </div>
+        </aside>
+    );
+}
+
+function HelpItem({ label, text }: { label: string; text: string }) {
+    return (
+        <div>
+            <div className="font-medium text-foreground">{label}</div>
+            <div>{text}</div>
+        </div>
+    );
+}
+
+function enabledLabel(value: boolean | undefined) {
+    if (value === true) return 'enabled';
+    if (value === false) return 'disabled';
+    return 'inherit';
+}
+
+function stringifyPolicy(policy: ContentTypeIntakePolicy | undefined) {
+    return JSON.stringify(policy ?? EMPTY_POLICY, null, 2);
+}
+
+function parsePolicyOrUndefined(content: string) {
+    try {
+        return JSON.parse(content) as ContentTypeIntakePolicy;
+    } catch {
+        return undefined;
+    }
+}
+
+function createPolicyValidator() {
+    const ajv = new Ajv({
+        strict: false,
+        allErrors: true,
+    });
+    addFormats(ajv);
+    return ajv.compile(ContentTypeIntakePolicySchema);
+}
+
+function parseAndValidatePolicy(
+    content: string,
+    validatePolicy: ValidateFunction<ContentTypeIntakePolicy>,
+): { ok: true; policy: ContentTypeIntakePolicy } | { ok: false; message: string } {
+    let parsed: unknown;
+    try {
+        parsed = content.trim() ? JSON.parse(content) : {};
+    } catch (err: unknown) {
+        return { ok: false, message: `Invalid JSON: ${errorMessage(err)}` };
+    }
+
+    if (!validatePolicy(parsed)) {
+        return { ok: false, message: formatAjvErrors(validatePolicy.errors) };
+    }
+
+    return { ok: true, policy: parsed as ContentTypeIntakePolicy };
+}
+
+function formatAjvErrors(errors: ErrorObject[] | null | undefined) {
+    if (!errors?.length) {
+        return 'The intake policy does not match the schema.';
+    }
+    return errors.map((err) => `${err.instancePath || '/'} ${err.message ?? 'is invalid'}`).join('\n');
+}

--- a/packages/ui/src/features/store/types/IntakePolicyEditor.tsx
+++ b/packages/ui/src/features/store/types/IntakePolicyEditor.tsx
@@ -18,8 +18,14 @@ import { Braces, CheckCircle2, FileText, RotateCcw, Save, WandSparkles } from 'l
 import { useMemo, useRef, useState } from 'react';
 
 interface IntakePolicyEditorProps {
-    objectType: ContentObjectType;
-    onIntakeUpdate: (value: ContentTypeIntakePolicy | undefined) => void;
+    /** Content type whose intake policy is edited; omit when editing a standalone policy. */
+    objectType?: ContentObjectType;
+    /** Initial policy value when no objectType is given (e.g. the project default policy). */
+    value?: ContentTypeIntakePolicy;
+    /** Custom persistence (e.g. save to project configuration). Returns the saved policy.
+     *  Defaults to saving the objectType's intake when objectType is provided. */
+    onSave?: (policy: ContentTypeIntakePolicy) => Promise<ContentTypeIntakePolicy | undefined>;
+    onIntakeUpdate?: (value: ContentTypeIntakePolicy | undefined) => void;
     readonly?: boolean;
 }
 
@@ -28,7 +34,8 @@ type IntakeExampleKey =
     | 'extraction_only'
     | 'visual_first'
     | 'structured_spreadsheet'
-    | 'media_no_transcript';
+    | 'media_no_transcript'
+    | 'full_reference';
 
 interface IntakeExample {
     key: IntakeExampleKey;
@@ -63,7 +70,7 @@ const INTAKE_EXAMPLES: IntakeExample[] = [
                 instructions:
                     'Extract required fields only. Ignore cover pages, appendices, legal boilerplate, and marketing content.',
             },
-            rendering_template: '# {{title}}\n\n{{summary}}',
+            rendering_template: '# {{properties.title}}\n\n{{properties.summary}}',
             embeddings: {
                 text: true,
                 properties: true,
@@ -126,11 +133,74 @@ const INTAKE_EXAMPLES: IntakeExample[] = [
             default_view: 'properties',
         },
     },
+    {
+        key: 'full_reference',
+        label: 'Full Reference',
+        description: 'Every available option with representative values. Trim to what your type needs.',
+        value: {
+            mode: 'programmatic',
+            identification: {
+                guidance:
+                    'Supplier invoices: billing documents with an invoice number, line items, ' +
+                    'amounts due, tax breakdown, and payment terms.',
+                distinguish_from:
+                    'Quotes and estimates are offers, not payment requests. Credit notes carry ' +
+                    'negative amounts. Receipts confirm a payment already made.',
+                examples: [],
+            },
+            text_conversion: {
+                enabled: true,
+                method: 'auto',
+                instructions: 'Keep the commercial terms and totals. Drop boilerplate and legal footers.',
+                output_format: 'markdown',
+                custom: {
+                    interaction: 'my-project:ConvertSpecialDocument',
+                    agent: 'my-project:DocumentConversionAgent',
+                },
+            },
+            extraction: {
+                enabled: true,
+                source: 'auto',
+                instructions:
+                    'Extract totals from the summary block, not from line items. ' +
+                    'Amounts include currency. Dates use ISO 8601.',
+                interaction: 'sys:ExtractInformation',
+                verification: {
+                    enabled: false,
+                    model: 'publishers/anthropic/models/claude-sonnet',
+                    environment: 'default',
+                    materiality:
+                        'Amounts, dates, identifiers, and party names are material. Typos in free text are not.',
+                    threshold: 0.85,
+                    max_retries: 1,
+                    on_fail: 'flag',
+                },
+            },
+            rendering_template:
+                '# Invoice {{properties.invoice_number}}\n\n' +
+                '- Vendor: {{properties.vendor_name}}\n' +
+                '- Total: {{properties.currency}} {{properties.total_amount}}\n' +
+                '- Due: {{properties.due_date}}',
+            embeddings: {
+                text: true,
+                image: false,
+                properties: true,
+            },
+            generate_toc: false,
+            default_view: 'auto',
+        },
+    },
 ];
 
 const EMPTY_POLICY: ContentTypeIntakePolicy = {};
 
-export function IntakePolicyEditor({ objectType, onIntakeUpdate, readonly = false }: IntakePolicyEditorProps) {
+export function IntakePolicyEditor({
+    objectType,
+    value,
+    onSave: onSaveProp,
+    onIntakeUpdate,
+    readonly = false,
+}: IntakePolicyEditorProps) {
     const { store } = useUserSession();
     const toast = useToast();
     const { theme } = useTheme();
@@ -138,13 +208,14 @@ export function IntakePolicyEditor({ objectType, onIntakeUpdate, readonly = fals
     const validatePolicy = useMemo(() => createPolicyValidator(), []);
 
     const [isUpdating, setUpdating] = useState(false);
-    const [editorValue, setEditorValue] = useState(() => stringifyPolicy(objectType.intake));
-    const [savedValue, setSavedValue] = useState(() => stringifyPolicy(objectType.intake));
+    const initialPolicy = objectType?.intake ?? value;
+    const [editorValue, setEditorValue] = useState(() => stringifyPolicy(initialPolicy));
+    const [savedValue, setSavedValue] = useState(() => stringifyPolicy(initialPolicy));
     const [validationMessage, setValidationMessage] = useState<string | undefined>(undefined);
 
     const isDirty = editorValue !== savedValue;
     const currentPolicy = useMemo(() => parsePolicyOrUndefined(editorValue), [editorValue]);
-    const summaryPolicy = currentPolicy ?? objectType.intake ?? EMPTY_POLICY;
+    const summaryPolicy = currentPolicy ?? initialPolicy ?? EMPTY_POLICY;
 
     const beforeMount = (monaco: Monaco) => {
         const namespace = monaco as unknown as {
@@ -182,16 +253,23 @@ export function IntakePolicyEditor({ objectType, onIntakeUpdate, readonly = fals
             return;
         }
 
+        const persist =
+            onSaveProp ??
+            (objectType
+                ? (next: ContentTypeIntakePolicy) =>
+                      store.types.update(objectType.id, { intake: next }).then((response) => response.intake)
+                : undefined);
+        if (!persist) {
+            return;
+        }
+
         setUpdating(true);
-        store.types
-            .update(objectType.id, {
-                intake: policy,
-            })
-            .then((response) => {
-                const nextValue = stringifyPolicy(response.intake);
+        persist(policy)
+            .then((saved) => {
+                const nextValue = stringifyPolicy(saved ?? policy);
                 setEditorValue(nextValue);
                 setSavedValue(nextValue);
-                onIntakeUpdate(response.intake);
+                onIntakeUpdate?.(saved ?? policy);
                 toast({
                     status: 'success',
                     title: 'Intake policy updated',

--- a/packages/ui/src/features/store/types/index.ts
+++ b/packages/ui/src/features/store/types/index.ts
@@ -1,6 +1,7 @@
 export * from './ContentObjectTypesSearch';
 export * from './ContentObjectTypesTable';
 export * from './CreateOrUpdateTypeModal';
+export * from './IntakePolicyEditor';
 export * from './ObjectSchemaEditor';
 export * from './SelectContentType';
 export * from './SelectContentTypeModal';

--- a/packages/ui/src/features/store/types/index.ts
+++ b/packages/ui/src/features/store/types/index.ts
@@ -9,3 +9,4 @@ export * from './search';
 export * from './TableLayoutEditor';
 export * from './TypeRegistry';
 export * from './TypeRegistryProvider';
+export * from './typeCatalogCache';

--- a/packages/ui/src/features/store/types/typeCatalogCache.ts
+++ b/packages/ui/src/features/store/types/typeCatalogCache.ts
@@ -1,0 +1,45 @@
+import type { VertesiaClient } from '@vertesia/client';
+import type { ContentObjectTypeItem } from '@vertesia/common';
+
+/**
+ * Browser-session cache for content-type catalog lookups, so render-time consumers
+ * (e.g. the document view resolving a type's `default_view`) don't pay a catalog request
+ * per document view.
+ *
+ * Scoped per VertesiaClient instance (WeakMap), so switching project/session naturally
+ * starts a fresh cache. Entries are cached promises to dedupe concurrent lookups; failed
+ * lookups self-evict so the next view retries. In-app type edits must call
+ * `invalidateTypeCache` — edits made elsewhere (assistant, another tab) are picked up on
+ * the next session.
+ */
+const cachePerClient = new WeakMap<VertesiaClient, Map<string, Promise<ContentObjectTypeItem | undefined>>>();
+
+export function resolveTypeCached(client: VertesiaClient, typeId: string): Promise<ContentObjectTypeItem | undefined> {
+    let cache = cachePerClient.get(client);
+    if (!cache) {
+        cache = new Map();
+        cachePerClient.set(client, cache);
+    }
+    let entry = cache.get(typeId);
+    if (!entry) {
+        entry = client.types.catalog.resolve(typeId).then(
+            (type) => type ?? undefined,
+            () => {
+                cachePerClient.get(client)?.delete(typeId);
+                return undefined;
+            },
+        );
+        cache.set(typeId, entry);
+    }
+    return entry;
+}
+
+export function invalidateTypeCache(client: VertesiaClient, typeId?: string): void {
+    const cache = cachePerClient.get(client);
+    if (!cache) return;
+    if (typeId) {
+        cache.delete(typeId);
+    } else {
+        cache.clear();
+    }
+}

--- a/packages/workflow/src/activities/generateDocumentProperties.test.ts
+++ b/packages/workflow/src/activities/generateDocumentProperties.test.ts
@@ -272,6 +272,132 @@ describe('generateDocumentProperties', () => {
         );
     });
 
+    describe('scoped vision evidence (evidence_images contract)', () => {
+        const evidence = [
+            { source: 'vision/etag-1/standard/page-7.jpeg', type: 'image/jpeg', name: 'page-7.jpeg' },
+            { source: 'vision/etag-1/standard/page-3.jpeg', type: 'image/jpeg', name: 'page-3.jpeg' },
+        ];
+
+        it('sends scratch page refs as images and never the store ref for vision', async () => {
+            await mockSetup({ text: 'PDF text content', contentType: 'application/pdf' });
+            mockExtractionResult({ title: 'Scoped' });
+
+            const result: GenerateDocumentPropertiesResult = await testEnv.run(
+                generateDocumentProperties,
+                payload({ source: 'vision', evidence_images: evidence }),
+            );
+
+            expect(result).toEqual({ status: 'completed' });
+            expect(executeInteractionFromActivity).toHaveBeenCalledWith(
+                expect.anything(),
+                'sys:ExtractInformation',
+                expect.anything(),
+                expect.objectContaining({
+                    content: undefined,
+                    image: undefined,
+                    images: evidence,
+                }),
+                false,
+            );
+        });
+
+        it('sends text AND scratch page refs for mixed', async () => {
+            await mockSetup({ text: 'PDF text content', contentType: 'application/pdf' });
+            mockExtractionResult({ title: 'Mixed scoped' });
+
+            await testEnv.run(generateDocumentProperties, payload({ source: 'mixed', evidence_images: evidence }));
+
+            expect(executeInteractionFromActivity).toHaveBeenCalledWith(
+                expect.anything(),
+                'sys:ExtractInformation',
+                expect.anything(),
+                expect.objectContaining({
+                    content: 'PDF text content',
+                    image: undefined,
+                    images: evidence,
+                }),
+                false,
+            );
+        });
+
+        it('fails with no-source (no store-ref fallback) when the provided evidence is empty and no text exists', async () => {
+            await mockSetup({ contentType: 'application/pdf' });
+
+            const result: GenerateDocumentPropertiesResult = await testEnv.run(
+                generateDocumentProperties,
+                payload({ source: 'vision', evidence_images: [] }),
+            );
+
+            expect(result).toEqual({ status: 'failed', error: 'no-source' });
+            expect(executeInteractionFromActivity).not.toHaveBeenCalled();
+        });
+
+        it('extracts from text only when the provided evidence is empty for mixed', async () => {
+            await mockSetup({ text: 'PDF text content', contentType: 'application/pdf' });
+            mockExtractionResult({ title: 'Text only' });
+
+            const result: GenerateDocumentPropertiesResult = await testEnv.run(
+                generateDocumentProperties,
+                payload({ source: 'mixed', evidence_images: [] }),
+            );
+
+            expect(result).toEqual({ status: 'completed' });
+            expect(executeInteractionFromActivity).toHaveBeenCalledWith(
+                expect.anything(),
+                'sys:ExtractInformation',
+                expect.anything(),
+                expect.objectContaining({
+                    content: 'PDF text content',
+                    image: undefined,
+                    images: undefined,
+                }),
+                false,
+            );
+        });
+
+        it('ignores evidence images for the text source', async () => {
+            await mockSetup({ text: 'PDF text content', contentType: 'application/pdf' });
+            mockExtractionResult({ title: 'Text' });
+
+            await testEnv.run(generateDocumentProperties, payload({ source: 'text', evidence_images: evidence }));
+
+            expect(executeInteractionFromActivity).toHaveBeenCalledWith(
+                expect.anything(),
+                'sys:ExtractInformation',
+                expect.anything(),
+                expect.objectContaining({
+                    content: 'PDF text content',
+                    image: undefined,
+                    images: undefined,
+                }),
+                false,
+            );
+        });
+
+        it('folds the evidence refs into the extraction fingerprint (absent = legacy hash)', () => {
+            const base = {
+                content_etag: 'etag-1',
+                type_id: 'type-1',
+                source: 'vision' as const,
+                interactionName: 'sys:ExtractInformation',
+                object_schema: DEFAULT_OBJECT_SCHEMA,
+            };
+            const legacy = computeExtractionFingerprint(base);
+            const withEvidence = computeExtractionFingerprint({
+                ...base,
+                evidence: ['vision/etag-1/standard/page-7.jpeg'],
+            });
+            const withOtherEvidence = computeExtractionFingerprint({
+                ...base,
+                evidence: ['vision/etag-1/high/page-7.jpeg'],
+            });
+            expect(withEvidence).not.toBe(legacy);
+            expect(withEvidence).not.toBe(withOtherEvidence);
+            // undefined evidence must keep previously stored legacy hashes valid
+            expect(computeExtractionFingerprint({ ...base, evidence: undefined })).toBe(legacy);
+        });
+    });
+
     it('updates properties without writing title or description into object text', async () => {
         const { update } = await mockSetup({
             text: 'source text',

--- a/packages/workflow/src/activities/generateDocumentProperties.test.ts
+++ b/packages/workflow/src/activities/generateDocumentProperties.test.ts
@@ -3,6 +3,7 @@ import type { VertesiaClient } from '@vertesia/client';
 import {
     ContentEventName,
     type DSLActivityExecutionPayload,
+    type GenerationRunMetadata,
     PDF_RENDITION_NAME,
     type Rendition,
 } from '@vertesia/common';
@@ -10,6 +11,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ActivityContext } from '../dsl/setup/ActivityContext.js';
 import { executeInteractionFromActivity } from './executeInteraction.js';
 import {
+    computeExtractionFingerprint,
     type GenerateDocumentPropertiesParams,
     type GenerateDocumentPropertiesResult,
     generateDocumentProperties,
@@ -47,6 +49,7 @@ function mockExtractionResult(properties: Record<string, unknown>) {
 
 function payload(
     params: GenerateDocumentPropertiesParams,
+    vars: Record<string, unknown> = {},
 ): DSLActivityExecutionPayload<GenerateDocumentPropertiesParams> {
     return {
         auth_token: 'mock-token',
@@ -58,16 +61,26 @@ function payload(
         event: ContentEventName.create,
         objectIds: ['object-1'],
         input: { inputType: 'objectIds', objectIds: ['object-1'] },
-        vars: {},
+        vars,
         activity: { name: 'generateDocumentProperties', params: {} },
     };
 }
 
+const DEFAULT_OBJECT_SCHEMA = {
+    type: 'object',
+    properties: {
+        title: { type: 'string' },
+    },
+};
+
 async function mockSetup(options: {
     text?: string;
     contentType?: string;
+    contentEtag?: string;
     objectSchema?: Record<string, unknown>;
     renditions?: Rendition[];
+    properties?: Record<string, unknown>;
+    generationRuns?: GenerationRunMetadata[];
 }) {
     const { setupActivity } = await import('../dsl/setup/ActivityContext.js');
     const update = vi.fn(async () => ({}));
@@ -75,23 +88,21 @@ async function mockSetup(options: {
         id: 'object-1',
         text: options.text,
         text_etag: 'source-etag',
+        properties: options.properties,
         content: {
             type: options.contentType,
+            etag: options.contentEtag,
         },
         metadata: {
             renditions: options.renditions,
+            generation_runs: options.generationRuns,
         },
         type: { id: 'type-1', name: 'Invoice', ref_type: 'stored' },
     }));
     const resolveType = vi.fn(async () => ({
         id: 'type-1',
         name: 'Invoice',
-        object_schema: options.objectSchema ?? {
-            type: 'object',
-            properties: {
-                title: { type: 'string' },
-            },
-        },
+        object_schema: options.objectSchema ?? DEFAULT_OBJECT_SCHEMA,
     }));
 
     vi.mocked(setupActivity).mockImplementation(
@@ -288,5 +299,180 @@ describe('generateDocumentProperties', () => {
             }),
             { suppressWorkflows: true },
         );
+    });
+
+    describe('skip_if_fresh freshness guard', () => {
+        const CONTENT_ETAG = 'content-etag-1';
+        const freshFingerprint = computeExtractionFingerprint({
+            content_etag: CONTENT_ETAG,
+            type_id: 'type-1',
+            source: 'auto',
+            instructions: undefined,
+            interactionName: 'sys:ExtractInformation',
+            object_schema: DEFAULT_OBJECT_SCHEMA,
+        });
+
+        function freshSetupOptions(overrides: Parameters<typeof mockSetup>[0] = {}) {
+            return {
+                text: 'source text',
+                contentType: 'text/plain',
+                contentEtag: CONTENT_ETAG,
+                properties: { title: 'Statement' },
+                generationRuns: [
+                    {
+                        id: 'run-0',
+                        date: '2026-01-01T00:00:00.000Z',
+                        model: 'model-1',
+                        extraction_fingerprint: freshFingerprint,
+                    },
+                ],
+                ...overrides,
+            };
+        }
+
+        it('skips extraction when the stored fingerprint matches and properties are present', async () => {
+            const { update } = await mockSetup(freshSetupOptions());
+
+            const result: GenerateDocumentPropertiesResult = await testEnv.run(
+                generateDocumentProperties,
+                payload({ skip_if_fresh: true }),
+            );
+
+            expect(result).toEqual({
+                document: 'object-1',
+                status: 'skipped',
+                message: expect.stringContaining('fresh'),
+            });
+            expect(executeInteractionFromActivity).not.toHaveBeenCalled();
+            expect(update).not.toHaveBeenCalled();
+        });
+
+        it('scans backwards past generation runs written without a fingerprint', async () => {
+            await mockSetup(
+                freshSetupOptions({
+                    generationRuns: [
+                        {
+                            id: 'run-0',
+                            date: '2026-01-01T00:00:00.000Z',
+                            model: 'model-1',
+                            extraction_fingerprint: freshFingerprint,
+                        },
+                        { id: 'run-1', date: '2026-01-02T00:00:00.000Z', model: 'model-2' },
+                    ],
+                }),
+            );
+
+            const result: GenerateDocumentPropertiesResult = await testEnv.run(
+                generateDocumentProperties,
+                payload({ skip_if_fresh: true }),
+            );
+
+            expect(result).toMatchObject({ status: 'skipped' });
+            expect(executeInteractionFromActivity).not.toHaveBeenCalled();
+        });
+
+        it('re-extracts by default: the guard is opt-in', async () => {
+            await mockSetup(freshSetupOptions());
+            mockExtractionResult({ title: 'Statement' });
+
+            const result: GenerateDocumentPropertiesResult = await testEnv.run(generateDocumentProperties, payload({}));
+
+            expect(result).toEqual({ status: 'completed' });
+            expect(executeInteractionFromActivity).toHaveBeenCalled();
+        });
+
+        it('re-extracts when the stored fingerprint is stale', async () => {
+            await mockSetup(
+                freshSetupOptions({
+                    generationRuns: [
+                        {
+                            id: 'run-0',
+                            date: '2026-01-01T00:00:00.000Z',
+                            model: 'model-1',
+                            extraction_fingerprint: 'stale-fingerprint',
+                        },
+                    ],
+                }),
+            );
+            mockExtractionResult({ title: 'Statement' });
+
+            const result: GenerateDocumentPropertiesResult = await testEnv.run(
+                generateDocumentProperties,
+                payload({ skip_if_fresh: true }),
+            );
+
+            expect(result).toEqual({ status: 'completed' });
+            expect(executeInteractionFromActivity).toHaveBeenCalled();
+        });
+
+        it('re-extracts when the type schema changed under the same type id', async () => {
+            await mockSetup(
+                freshSetupOptions({
+                    objectSchema: {
+                        type: 'object',
+                        properties: {
+                            title: { type: 'string' },
+                            total: { type: 'number' },
+                        },
+                    },
+                }),
+            );
+            mockExtractionResult({ title: 'Statement', total: 12 });
+
+            const result: GenerateDocumentPropertiesResult = await testEnv.run(
+                generateDocumentProperties,
+                payload({ skip_if_fresh: true }),
+            );
+
+            expect(result).toEqual({ status: 'completed' });
+            expect(executeInteractionFromActivity).toHaveBeenCalled();
+        });
+
+        it('re-extracts when the fingerprint matches but the object has no properties', async () => {
+            await mockSetup(freshSetupOptions({ properties: {} }));
+            mockExtractionResult({ title: 'Statement' });
+
+            const result: GenerateDocumentPropertiesResult = await testEnv.run(
+                generateDocumentProperties,
+                payload({ skip_if_fresh: true }),
+            );
+
+            expect(result).toEqual({ status: 'completed' });
+            expect(executeInteractionFromActivity).toHaveBeenCalled();
+        });
+
+        it('re-extracts when payload vars carry forceGeneration', async () => {
+            await mockSetup(freshSetupOptions());
+            mockExtractionResult({ title: 'Statement' });
+
+            const result: GenerateDocumentPropertiesResult = await testEnv.run(
+                generateDocumentProperties,
+                payload({ skip_if_fresh: true }, { forceGeneration: true }),
+            );
+
+            expect(result).toEqual({ status: 'completed' });
+            expect(executeInteractionFromActivity).toHaveBeenCalled();
+        });
+
+        it('persists the extraction fingerprint in the generation run info after a successful extraction', async () => {
+            const { update } = await mockSetup(freshSetupOptions({ generationRuns: undefined }));
+            mockExtractionResult({ title: 'Statement' });
+
+            const result: GenerateDocumentPropertiesResult = await testEnv.run(
+                generateDocumentProperties,
+                payload({ skip_if_fresh: true }),
+            );
+
+            expect(result).toEqual({ status: 'completed' });
+            expect(update).toHaveBeenCalledWith(
+                'object-1',
+                expect.objectContaining({
+                    generation_run_info: expect.objectContaining({
+                        extraction_fingerprint: freshFingerprint,
+                    }),
+                }),
+                { suppressWorkflows: true },
+            );
+        });
     });
 });

--- a/packages/workflow/src/activities/generateDocumentProperties.test.ts
+++ b/packages/workflow/src/activities/generateDocumentProperties.test.ts
@@ -1,0 +1,292 @@
+import { MockActivityEnvironment } from '@temporalio/testing';
+import type { VertesiaClient } from '@vertesia/client';
+import {
+    ContentEventName,
+    type DSLActivityExecutionPayload,
+    PDF_RENDITION_NAME,
+    type Rendition,
+} from '@vertesia/common';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ActivityContext } from '../dsl/setup/ActivityContext.js';
+import { executeInteractionFromActivity } from './executeInteraction.js';
+import {
+    type GenerateDocumentPropertiesParams,
+    type GenerateDocumentPropertiesResult,
+    generateDocumentProperties,
+} from './generateDocumentProperties.js';
+
+vi.mock('../dsl/setup/ActivityContext.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../dsl/setup/ActivityContext.js')>();
+    return { ...actual, setupActivity: vi.fn() };
+});
+
+vi.mock('./executeInteraction.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('./executeInteraction.js')>();
+    return { ...actual, executeInteractionFromActivity: vi.fn() };
+});
+
+let testEnv: MockActivityEnvironment;
+
+beforeAll(() => {
+    testEnv = new MockActivityEnvironment();
+});
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+function mockExtractionResult(properties: Record<string, unknown>) {
+    vi.mocked(executeInteractionFromActivity).mockResolvedValue({
+        id: 'run-1',
+        modelId: 'model-1',
+        result: {
+            object: vi.fn(() => properties),
+        },
+    } as unknown as Awaited<ReturnType<typeof executeInteractionFromActivity>>);
+}
+
+function payload(
+    params: GenerateDocumentPropertiesParams,
+): DSLActivityExecutionPayload<GenerateDocumentPropertiesParams> {
+    return {
+        auth_token: 'mock-token',
+        account_id: 'test-account',
+        project_id: 'test-project',
+        params,
+        config: { studio_url: 'http://mock-studio', store_url: 'http://mock-store' },
+        workflow_name: 'test-workflow',
+        event: ContentEventName.create,
+        objectIds: ['object-1'],
+        input: { inputType: 'objectIds', objectIds: ['object-1'] },
+        vars: {},
+        activity: { name: 'generateDocumentProperties', params: {} },
+    };
+}
+
+async function mockSetup(options: {
+    text?: string;
+    contentType?: string;
+    objectSchema?: Record<string, unknown>;
+    renditions?: Rendition[];
+}) {
+    const { setupActivity } = await import('../dsl/setup/ActivityContext.js');
+    const update = vi.fn(async () => ({}));
+    const retrieveObject = vi.fn(async () => ({
+        id: 'object-1',
+        text: options.text,
+        text_etag: 'source-etag',
+        content: {
+            type: options.contentType,
+        },
+        metadata: {
+            renditions: options.renditions,
+        },
+        type: { id: 'type-1', name: 'Invoice', ref_type: 'stored' },
+    }));
+    const resolveType = vi.fn(async () => ({
+        id: 'type-1',
+        name: 'Invoice',
+        object_schema: options.objectSchema ?? {
+            type: 'object',
+            properties: {
+                title: { type: 'string' },
+            },
+        },
+    }));
+
+    vi.mocked(setupActivity).mockImplementation(
+        async (activityPayload) =>
+            ({
+                objectId: 'object-1',
+                params: activityPayload.params,
+                fetchProject: vi.fn(async () => ({ configuration: {} })),
+                client: {
+                    objects: {
+                        retrieve: retrieveObject,
+                        update,
+                    },
+                    types: {
+                        catalog: {
+                            resolve: resolveType,
+                        },
+                    },
+                } as unknown as VertesiaClient,
+            }) as unknown as ActivityContext<GenerateDocumentPropertiesParams>,
+    );
+
+    return { retrieveObject, resolveType, update };
+}
+
+describe('generateDocumentProperties', () => {
+    it('does not execute extraction when no text or supported vision source is available', async () => {
+        await mockSetup({
+            contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        });
+
+        const result: GenerateDocumentPropertiesResult = await testEnv.run(
+            generateDocumentProperties,
+            payload({ source: 'vision' }),
+        );
+
+        expect(result).toEqual({ status: 'failed', error: 'no-source' });
+        expect(executeInteractionFromActivity).not.toHaveBeenCalled();
+    });
+
+    it('uses a PDF rendition as vision evidence for non-visual source documents', async () => {
+        const pdfRendition = {
+            name: PDF_RENDITION_NAME,
+            content: {
+                name: 'slides.pdf',
+                source: 'renditions/source-etag/slides.pdf',
+                type: 'application/pdf',
+            },
+        };
+        await mockSetup({
+            contentType: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+            renditions: [pdfRendition],
+        });
+        mockExtractionResult({ title: 'Presentation' });
+
+        const result: GenerateDocumentPropertiesResult = await testEnv.run(
+            generateDocumentProperties,
+            payload({ source: 'vision' }),
+        );
+
+        expect(result).toEqual({ status: 'completed' });
+        expect(executeInteractionFromActivity).toHaveBeenCalledWith(
+            expect.anything(),
+            'sys:ExtractInformation',
+            expect.anything(),
+            expect.objectContaining({
+                content: undefined,
+                image: pdfRendition.content,
+            }),
+            false,
+        );
+    });
+
+    it.each([
+        {
+            source: 'auto' as const,
+            text: 'PDF text content',
+            expectedContent: 'PDF text content',
+            expectedImage: undefined,
+        },
+        { source: 'auto' as const, text: undefined, expectedContent: undefined, expectedImage: 'store:object-1' },
+        {
+            source: 'text' as const,
+            text: 'PDF text content',
+            expectedContent: 'PDF text content',
+            expectedImage: undefined,
+        },
+        {
+            source: 'vision' as const,
+            text: 'PDF text content',
+            expectedContent: undefined,
+            expectedImage: 'store:object-1',
+        },
+        { source: 'vision' as const, text: undefined, expectedContent: undefined, expectedImage: 'store:object-1' },
+        {
+            source: 'mixed' as const,
+            text: 'PDF text content',
+            expectedContent: 'PDF text content',
+            expectedImage: 'store:object-1',
+        },
+        { source: 'mixed' as const, text: undefined, expectedContent: undefined, expectedImage: 'store:object-1' },
+    ])('uses $source extraction source with text=$text', async ({ source, text, expectedContent, expectedImage }) => {
+        await mockSetup({
+            text,
+            contentType: 'application/pdf',
+        });
+        mockExtractionResult({ title: source });
+
+        const result: GenerateDocumentPropertiesResult = await testEnv.run(
+            generateDocumentProperties,
+            payload({ source }),
+        );
+
+        expect(result).toEqual({ status: 'completed' });
+        expect(executeInteractionFromActivity).toHaveBeenCalledWith(
+            expect.anything(),
+            'sys:ExtractInformation',
+            expect.anything(),
+            expect.objectContaining({
+                content: expectedContent,
+                image: expectedImage,
+            }),
+            false,
+        );
+    });
+
+    it.each([
+        { source: 'text' as const, text: undefined },
+        { source: 'text' as const, text: '   ' },
+    ])('fails for $source extraction when text is absent or whitespace-only', async ({ source, text }) => {
+        await mockSetup({
+            text,
+            contentType: 'application/pdf',
+        });
+
+        const result: GenerateDocumentPropertiesResult = await testEnv.run(
+            generateDocumentProperties,
+            payload({ source }),
+        );
+
+        expect(result).toEqual({ status: 'failed', error: 'no-source' });
+        expect(executeInteractionFromActivity).not.toHaveBeenCalled();
+    });
+
+    it('accepts deprecated use_vision as a mixed source alias', async () => {
+        await mockSetup({
+            text: 'PDF text content',
+            contentType: 'application/pdf',
+        });
+        mockExtractionResult({ title: 'Mixed alias' });
+
+        const result: GenerateDocumentPropertiesResult = await testEnv.run(
+            generateDocumentProperties,
+            payload({ use_vision: true }),
+        );
+
+        expect(result).toEqual({ status: 'completed' });
+        expect(executeInteractionFromActivity).toHaveBeenCalledWith(
+            expect.anything(),
+            'sys:ExtractInformation',
+            expect.anything(),
+            expect.objectContaining({
+                content: 'PDF text content',
+                image: 'store:object-1',
+            }),
+            false,
+        );
+    });
+
+    it('updates properties without writing title or description into object text', async () => {
+        const { update } = await mockSetup({
+            text: 'source text',
+            contentType: 'text/plain',
+        });
+        mockExtractionResult({ title: 'Statement', description: 'Summary' });
+
+        const result: GenerateDocumentPropertiesResult = await testEnv.run(generateDocumentProperties, payload({}));
+
+        expect(result).toEqual({ status: 'completed' });
+        expect(update).toHaveBeenCalledWith(
+            'object-1',
+            expect.not.objectContaining({
+                text: expect.anything(),
+            }),
+            { suppressWorkflows: true },
+        );
+        expect(update).toHaveBeenCalledWith(
+            'object-1',
+            expect.objectContaining({
+                properties: {
+                    title: 'Statement',
+                    description: 'Summary',
+                },
+            }),
+            { suppressWorkflows: true },
+        );
+    });
+});

--- a/packages/workflow/src/activities/generateDocumentProperties.ts
+++ b/packages/workflow/src/activities/generateDocumentProperties.ts
@@ -47,6 +47,18 @@ export interface GenerateDocumentPropertiesParams extends InteractionExecutionPa
     instructions?: string;
 
     /**
+     * Scoped page-image evidence prepared by intake (`prepareVisionEvidence` scratch refs).
+     * When the param is PRESENT (even as an empty array) and the source calls for visual
+     * evidence, these refs are the ONLY visual evidence used — never the whole-object
+     * `store:{id}` ref, which resolves to ALL pages near-full-res through the rendition
+     * generate-and-poll path. An empty array means intake prepared no usable evidence
+     * (budget-impossible or no renderable source): extraction then runs text-only or fails
+     * with no-source instead of shipping an over-budget payload.
+     * Absent = legacy behavior for existing DSL callers.
+     */
+    evidence_images?: ContentSource[];
+
+    /**
      * Opt-in freshness guard. When true, the activity computes a fingerprint of the extraction
      * inputs (content etag, type + its object schema, source, instructions, interaction name)
      * and returns `{ status: 'skipped' }` without executing the interaction when the fingerprint
@@ -76,6 +88,9 @@ export function computeExtractionFingerprint(input: {
     interactionName: string;
     /** The type's object_schema: a schema edit under the same type id must invalidate the fingerprint. */
     object_schema?: unknown;
+    /** Scoped vision evidence refs: a different page/profile selection must invalidate the fingerprint.
+     *  Undefined (legacy callers) keeps previously stored hashes valid. */
+    evidence?: string[];
 }): string {
     return md5(
         JSON.stringify({
@@ -85,6 +100,7 @@ export function computeExtractionFingerprint(input: {
             instructions: input.instructions,
             interactionName: input.interactionName,
             object_schema: input.object_schema,
+            ...(input.evidence ? { evidence: input.evidence } : {}),
         }),
     );
 }
@@ -140,6 +156,8 @@ export async function generateDocumentProperties(
     }
 
     const source = params.source ?? (params.use_vision ? 'mixed' : 'auto');
+    const evidenceProvided = Array.isArray(params.evidence_images);
+    const evidenceImages = params.evidence_images?.length ? params.evidence_images : undefined;
 
     const extractionFingerprint = computeExtractionFingerprint({
         content_etag: doc.content?.etag,
@@ -148,6 +166,7 @@ export async function generateDocumentProperties(
         instructions: params.instructions,
         interactionName,
         object_schema: type.object_schema,
+        evidence: evidenceImages?.map((image) => image.source ?? image.name ?? ''),
     });
 
     if (params.skip_if_fresh && !payload.vars?.forceGeneration) {
@@ -188,10 +207,15 @@ export async function generateDocumentProperties(
         hasRealText && (source === 'auto' || source === 'text' || source === 'mixed')
             ? truncByMaxTokens(doc.text ?? '', params.truncate || 30000)
             : undefined;
-    const imageRef =
-        source === 'vision' || source === 'mixed' || (source === 'auto' && !content) ? getImageRef() : undefined;
+    const needsVisualEvidence = source === 'vision' || source === 'mixed' || (source === 'auto' && !content);
+    // Scoped scratch page refs win over the whole-object store: ref (which resolves to ALL
+    // pages near-full-res through the rendition generate-and-poll path). A PRESENT param —
+    // even empty — disables the store-ref fallback entirely: intake decided what evidence
+    // (if any) may be sent.
+    const scopedImages = needsVisualEvidence ? evidenceImages : undefined;
+    const imageRef = needsVisualEvidence && !evidenceProvided ? getImageRef() : undefined;
 
-    if (!content && !imageRef) {
+    if (!content && !imageRef && !scopedImages) {
         log.warn(`Object ${objectId} has no text or supported vision source`);
         return { status: 'failed', error: 'no-source' };
     }
@@ -199,6 +223,7 @@ export async function generateDocumentProperties(
     const promptData = {
         content: content,
         image: imageRef,
+        images: scopedImages,
         extraction_instructions: params.instructions,
         human_context: project?.configuration?.human_context ?? undefined,
     };

--- a/packages/workflow/src/activities/generateDocumentProperties.ts
+++ b/packages/workflow/src/activities/generateDocumentProperties.ts
@@ -1,18 +1,22 @@
 import { ApplicationFailure, log } from '@temporalio/activity';
-import type { DSLActivityExecutionPayload, DSLActivitySpec, JSONObject } from '@vertesia/common';
+import {
+    type ContentSource,
+    type DSLActivityExecutionPayload,
+    type DSLActivitySpec,
+    type JSONObject,
+    PDF_RENDITION_NAME,
+    type Rendition,
+} from '@vertesia/common';
 import { setupActivity } from '../dsl/setup/ActivityContext.js';
 import { type TruncateSpec, truncByMaxTokens } from '../utils/tokens.js';
 import { executeInteractionFromActivity, type InteractionExecutionParams } from './executeInteraction.js';
 
 const INT_EXTRACT_INFORMATION = 'sys:ExtractInformation';
 
+export type GenerateDocumentPropertiesSource = 'auto' | 'text' | 'vision' | 'mixed';
+
 interface RetryableError extends Error {
     retryable?: boolean;
-}
-
-interface GeneratedPropertiesSummary {
-    title?: unknown;
-    description?: unknown;
 }
 
 function toRetryableError(error: unknown): RetryableError {
@@ -31,57 +35,96 @@ export interface GenerateDocumentPropertiesParams extends InteractionExecutionPa
 
     interactionName?: string;
 
+    /**
+     * @deprecated Use source: 'mixed'. Accepted for backward compatibility with existing DSL callers.
+     */
     use_vision?: boolean;
+
+    source?: GenerateDocumentPropertiesSource;
+
+    instructions?: string;
 }
 export interface GenerateDocumentProperties extends DSLActivitySpec<GenerateDocumentPropertiesParams> {
     name: 'generateDocumentProperties';
 }
+export type GenerateDocumentPropertiesResult =
+    | { status: 'completed' }
+    | { status: 'failed'; error: string }
+    | { document: string; status: 'skipped'; message: string };
+
+function getPdfRenditionContent(doc: { metadata?: { renditions?: unknown } }): ContentSource | undefined {
+    const renditions = doc.metadata?.renditions;
+    if (!Array.isArray(renditions)) {
+        return undefined;
+    }
+    const pdfRendition = renditions.find(
+        (rendition): rendition is Rendition =>
+            typeof rendition === 'object' &&
+            rendition !== null &&
+            (rendition as { name?: unknown }).name === PDF_RENDITION_NAME &&
+            typeof (rendition as { content?: { source?: unknown } }).content?.source === 'string',
+    );
+    return pdfRendition?.content;
+}
 
 export async function generateDocumentProperties(
     payload: DSLActivityExecutionPayload<GenerateDocumentPropertiesParams>,
-) {
+): Promise<GenerateDocumentPropertiesResult> {
     const context = await setupActivity<GenerateDocumentPropertiesParams>(payload);
     const { params, client, objectId } = context;
     const interactionName = params.interactionName ?? INT_EXTRACT_INFORMATION;
 
     const project = await context.fetchProject();
 
-    const doc = await client.objects.retrieve(objectId, '+text');
+    const doc = await client.objects.retrieve(objectId, '+text +metadata +content');
     const type = doc.type ? await client.types.catalog.resolve(doc.type) : undefined;
-
-    if (!doc?.text && !params.use_vision && !doc?.content?.type?.startsWith('image/')) {
-        log.warn(`Object ${objectId} not found or text is empty`);
-        return { status: 'failed', error: 'no-text' };
-    }
 
     if (!type?.object_schema) {
         log.info(`Object ${objectId} has no schema`);
         return { document: objectId, status: 'skipped', message: 'no schema defined on type' };
     }
 
-    const getImageRef = () => {
+    const source = params.source ?? (params.use_vision ? 'mixed' : 'auto');
+    const getImageRef = (): string | ContentSource | undefined => {
         if (doc.content?.type?.startsWith('image/')) {
             return `store:${doc.id}`;
         }
 
-        if (params.use_vision && doc.content?.type?.startsWith('application/pdf')) {
+        if (doc.content?.type?.startsWith('application/pdf')) {
             return `store:${doc.id}`;
+        }
+
+        const pdfRendition = getPdfRenditionContent(doc);
+        if (pdfRendition?.type?.startsWith('application/pdf')) {
+            return pdfRendition;
         }
 
         log.info(`Object ${objectId} is not an image or pdf`);
         return undefined;
     };
 
-    const content = doc.text ? truncByMaxTokens(doc.text, params.truncate || 30000) : undefined;
+    const hasRealText = !!doc.text?.trim();
+    const content =
+        hasRealText && (source === 'auto' || source === 'text' || source === 'mixed')
+            ? truncByMaxTokens(doc.text ?? '', params.truncate || 30000)
+            : undefined;
+    const imageRef =
+        source === 'vision' || source === 'mixed' || (source === 'auto' && !content) ? getImageRef() : undefined;
+
+    if (!content && !imageRef) {
+        log.warn(`Object ${objectId} has no text or supported vision source`);
+        return { status: 'failed', error: 'no-source' };
+    }
 
     const promptData = {
         content: content,
-        image: getImageRef() ?? undefined,
+        image: imageRef,
+        extraction_instructions: params.instructions,
         human_context: project?.configuration?.human_context ?? undefined,
     };
 
     log.info(
-        ` Extracting information from object ${objectId} with type ${type.name}`,
+        `Extracting information from object ${objectId} with type ${type.name}`,
         payload.debug_mode ? { params } : undefined,
     );
 
@@ -125,34 +168,11 @@ export async function generateDocumentProperties(
         throw error;
     }
 
-    const getText = () => {
-        if (doc.text) {
-            return undefined;
-        }
-        let text = '';
-        const jsonResult = infoRes.result.object<GeneratedPropertiesSummary>();
-        if (typeof jsonResult.title === 'string') {
-            text += `${jsonResult.title}\n`;
-        }
-        if (typeof jsonResult.description === 'string') {
-            text += jsonResult.description;
-        }
-        if (text) {
-            return text;
-        } else {
-            return undefined;
-        }
-    };
-
     log.info(`Extracted information from object ${objectId} with type ${type.name}`, { runId: infoRes.id });
     await client.objects.update(
         doc.id,
         {
-            properties: {
-                ...infoRes.result.object<JSONObject>(),
-                ...(doc.text_etag !== undefined ? { etag: doc.text_etag } : {}),
-            },
-            text: getText(),
+            properties: infoRes.result.object<JSONObject>(),
             generation_run_info: {
                 id: infoRes.id,
                 date: new Date().toISOString(),

--- a/packages/workflow/src/activities/generateDocumentProperties.ts
+++ b/packages/workflow/src/activities/generateDocumentProperties.ts
@@ -1,5 +1,6 @@
 import { ApplicationFailure, log } from '@temporalio/activity';
 import {
+    type ContentMetadata,
     type ContentSource,
     type DSLActivityExecutionPayload,
     type DSLActivitySpec,
@@ -8,6 +9,7 @@ import {
     type Rendition,
 } from '@vertesia/common';
 import { setupActivity } from '../dsl/setup/ActivityContext.js';
+import { md5 } from '../utils/blobs.js';
 import { type TruncateSpec, truncByMaxTokens } from '../utils/tokens.js';
 import { executeInteractionFromActivity, type InteractionExecutionParams } from './executeInteraction.js';
 
@@ -43,6 +45,16 @@ export interface GenerateDocumentPropertiesParams extends InteractionExecutionPa
     source?: GenerateDocumentPropertiesSource;
 
     instructions?: string;
+
+    /**
+     * Opt-in freshness guard. When true, the activity computes a fingerprint of the extraction
+     * inputs (content etag, type + its object schema, source, instructions, interaction name)
+     * and returns `{ status: 'skipped' }` without executing the interaction when the fingerprint
+     * stored by a previous successful extraction matches and the object already has non-empty
+     * properties. Defaults to false so shared DSL callers keep the always-extract behavior.
+     * `payload.vars.forceGeneration` bypasses the skip.
+     */
+    skip_if_fresh?: boolean;
 }
 export interface GenerateDocumentProperties extends DSLActivitySpec<GenerateDocumentPropertiesParams> {
     name: 'generateDocumentProperties';
@@ -51,6 +63,49 @@ export type GenerateDocumentPropertiesResult =
     | { status: 'completed' }
     | { status: 'failed'; error: string }
     | { document: string; status: 'skipped'; message: string };
+
+/**
+ * Stable fingerprint of the inputs that determine the extraction output. Key order is fixed by
+ * the object literal so the hash is deterministic.
+ */
+export function computeExtractionFingerprint(input: {
+    content_etag?: string;
+    type_id?: string;
+    source: GenerateDocumentPropertiesSource;
+    instructions?: string;
+    interactionName: string;
+    /** The type's object_schema: a schema edit under the same type id must invalidate the fingerprint. */
+    object_schema?: unknown;
+}): string {
+    return md5(
+        JSON.stringify({
+            content_etag: input.content_etag,
+            type_id: input.type_id,
+            source: input.source,
+            instructions: input.instructions,
+            interactionName: input.interactionName,
+            object_schema: input.object_schema,
+        }),
+    );
+}
+
+/**
+ * The fingerprint is persisted inside the generation run info of the last successful extraction
+ * (the server appends it to `metadata.generation_runs`). Other writers append runs without a
+ * fingerprint, so scan backwards for the most recent extraction entry.
+ */
+function getStoredExtractionFingerprint(metadata: ContentMetadata | undefined): string | undefined {
+    const runs = metadata?.generation_runs;
+    if (!Array.isArray(runs)) {
+        return undefined;
+    }
+    for (let i = runs.length - 1; i >= 0; i--) {
+        if (runs[i]?.extraction_fingerprint) {
+            return runs[i].extraction_fingerprint;
+        }
+    }
+    return undefined;
+}
 
 function getPdfRenditionContent(doc: { metadata?: { renditions?: unknown } }): ContentSource | undefined {
     const renditions = doc.metadata?.renditions;
@@ -85,6 +140,31 @@ export async function generateDocumentProperties(
     }
 
     const source = params.source ?? (params.use_vision ? 'mixed' : 'auto');
+
+    const extractionFingerprint = computeExtractionFingerprint({
+        content_etag: doc.content?.etag,
+        type_id: type.id,
+        source,
+        instructions: params.instructions,
+        interactionName,
+        object_schema: type.object_schema,
+    });
+
+    if (params.skip_if_fresh && !payload.vars?.forceGeneration) {
+        const storedFingerprint = getStoredExtractionFingerprint(doc.metadata);
+        const hasProperties = !!doc.properties && Object.keys(doc.properties).length > 0;
+        if (storedFingerprint === extractionFingerprint && hasProperties) {
+            log.info(`Skipping property extraction for ${objectId}: extraction inputs unchanged`, {
+                extractionFingerprint,
+            });
+            return {
+                document: objectId,
+                status: 'skipped',
+                message: 'properties are fresh (extraction fingerprint matches)',
+            };
+        }
+    }
+
     const getImageRef = (): string | ContentSource | undefined => {
         if (doc.content?.type?.startsWith('image/')) {
             return `store:${doc.id}`;
@@ -177,6 +257,7 @@ export async function generateDocumentProperties(
                 id: infoRes.id,
                 date: new Date().toISOString(),
                 model: infoRes.modelId ?? '',
+                extraction_fingerprint: extractionFingerprint,
             },
         },
         { suppressWorkflows: true },

--- a/packages/workflow/src/activities/generateOrAssignContentType.test.ts
+++ b/packages/workflow/src/activities/generateOrAssignContentType.test.ts
@@ -1,0 +1,192 @@
+import { MockActivityEnvironment } from '@temporalio/testing';
+import type { VertesiaClient } from '@vertesia/client';
+import {
+    ContentEventName,
+    type ContentObjectTypeItem,
+    type DSLActivityExecutionPayload,
+    PDF_RENDITION_NAME,
+    type Rendition,
+} from '@vertesia/common';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ActivityContext } from '../dsl/setup/ActivityContext.js';
+import { executeInteractionFromActivity } from './executeInteraction.js';
+import {
+    type GenerateOrAssignContentTypeParams,
+    type GenerateOrAssignContentTypeResult,
+    generateOrAssignContentType,
+} from './generateOrAssignContentType.js';
+
+vi.mock('../dsl/setup/ActivityContext.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../dsl/setup/ActivityContext.js')>();
+    return { ...actual, setupActivity: vi.fn() };
+});
+
+vi.mock('./executeInteraction.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('./executeInteraction.js')>();
+    return { ...actual, executeInteractionFromActivity: vi.fn() };
+});
+
+let testEnv: MockActivityEnvironment;
+
+beforeAll(() => {
+    testEnv = new MockActivityEnvironment();
+});
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+function payload(
+    params: GenerateOrAssignContentTypeParams,
+): DSLActivityExecutionPayload<GenerateOrAssignContentTypeParams> {
+    return {
+        account_id: 'test-account',
+        activity: { name: 'generateOrAssignContentType', params: {} },
+        auth_token: 'mock-token',
+        config: { studio_url: 'http://mock-studio', store_url: 'http://mock-store' },
+        event: ContentEventName.create,
+        input: { inputType: 'objectIds', objectIds: ['object-1'] },
+        objectIds: ['object-1'],
+        params,
+        project_id: 'test-project',
+        vars: {},
+        workflow_name: 'test-workflow',
+    };
+}
+
+function typeItem(name: string, status?: ContentObjectTypeItem['status']): ContentObjectTypeItem {
+    return {
+        id: `type-${name}`,
+        name,
+        status,
+    } as ContentObjectTypeItem;
+}
+
+function mockSelectionResult(documentType: string) {
+    vi.mocked(executeInteractionFromActivity).mockResolvedValue({
+        id: 'run-1',
+        modelId: 'model-1',
+        result: {
+            object: vi.fn(() => ({ document_type: documentType })),
+        },
+    } as unknown as Awaited<ReturnType<typeof executeInteractionFromActivity>>);
+}
+
+async function mockSetup(
+    types: ContentObjectTypeItem[],
+    options: {
+        contentType?: string;
+        renditions?: Rendition[];
+        text?: string;
+    } = {},
+) {
+    const { setupActivity } = await import('../dsl/setup/ActivityContext.js');
+    const update = vi.fn(() => Promise.resolve({}));
+    const retrieveObject = vi.fn(() =>
+        Promise.resolve({
+            id: 'object-1',
+            content: { type: options.contentType ?? 'text/plain' },
+            metadata: { renditions: options.renditions },
+            text: options.text ?? 'Document text',
+        }),
+    );
+    const listTypes = vi.fn(() => Promise.resolve(types));
+
+    vi.mocked(setupActivity).mockImplementation((activityPayload) =>
+        Promise.resolve({
+            client: {
+                objects: {
+                    retrieve: retrieveObject,
+                    update,
+                },
+                types: {
+                    catalog: {
+                        list: listTypes,
+                    },
+                },
+            } as unknown as VertesiaClient,
+            fetchProject: vi.fn(() => Promise.resolve({ configuration: {} })),
+            objectId: 'object-1',
+            params: activityPayload.params,
+        } as unknown as ActivityContext<GenerateOrAssignContentTypeParams>),
+    );
+
+    return { listTypes, update };
+}
+
+describe('generateOrAssignContentType', () => {
+    it('excludes draft types from selection and does not assign them if returned by the model', async () => {
+        const { update } = await mockSetup([
+            typeItem('Invoice', 'active'),
+            typeItem('DraftInvoice', 'draft'),
+            typeItem('DocumentPart', 'active'),
+            typeItem('GenericDocument', 'active'),
+            typeItem('Rendition', 'active'),
+        ]);
+        mockSelectionResult('DraftInvoice');
+
+        const result: GenerateOrAssignContentTypeResult = await testEnv.run(
+            generateOrAssignContentType,
+            payload({ allowNewContentTypes: false }),
+        );
+
+        expect(executeInteractionFromActivity).toHaveBeenCalledWith(
+            expect.anything(),
+            'sys:SelectDocumentType',
+            expect.objectContaining({ allowNewContentTypes: false }),
+            expect.objectContaining({
+                existing_types: [
+                    expect.objectContaining({ name: 'Invoice' }),
+                    expect.objectContaining({ name: 'GenericDocument' }),
+                ],
+            }),
+        );
+        expect(update).toHaveBeenCalledWith('object-1', { type: 'sys:GenericDocument' });
+        expect(result).toEqual({
+            id: 'sys:GenericDocument',
+            isNew: false,
+            name: 'GenericDocument',
+        });
+    });
+
+    it('uses a PDF rendition as visual evidence for PowerPoint type selection', async () => {
+        const pdfRendition = {
+            name: PDF_RENDITION_NAME,
+            content: {
+                name: 'slides.pdf',
+                source: 'renditions/source-etag/slides.pdf',
+                type: 'application/pdf',
+            },
+        };
+        const { update } = await mockSetup(
+            [typeItem('MarketPresentation', 'active'), typeItem('GenericDocument', 'active')],
+            {
+                contentType: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+                renditions: [pdfRendition],
+                text: '',
+            },
+        );
+        mockSelectionResult('MarketPresentation');
+
+        const result: GenerateOrAssignContentTypeResult = await testEnv.run(
+            generateOrAssignContentType,
+            payload({ allowNewContentTypes: false }),
+        );
+
+        expect(executeInteractionFromActivity).toHaveBeenCalledWith(
+            expect.anything(),
+            'sys:SelectDocumentType',
+            expect.objectContaining({ allowNewContentTypes: false }),
+            expect.objectContaining({
+                content: undefined,
+                image: pdfRendition.content,
+            }),
+        );
+        expect(update).toHaveBeenCalledWith('object-1', { type: 'type-MarketPresentation' });
+        expect(result).toEqual({
+            id: 'type-MarketPresentation',
+            isNew: false,
+            name: 'MarketPresentation',
+        });
+    });
+});

--- a/packages/workflow/src/activities/generateOrAssignContentType.test.ts
+++ b/packages/workflow/src/activities/generateOrAssignContentType.test.ts
@@ -141,7 +141,7 @@ describe('generateOrAssignContentType', () => {
                 ],
             }),
         );
-        expect(update).toHaveBeenCalledWith('object-1', { type: 'sys:GenericDocument' });
+        expect(update).toHaveBeenCalledWith('object-1', { type: 'sys:GenericDocument' }, { suppressWorkflows: true });
         expect(result).toEqual({
             id: 'sys:GenericDocument',
             isNew: false,
@@ -182,7 +182,11 @@ describe('generateOrAssignContentType', () => {
                 image: pdfRendition.content,
             }),
         );
-        expect(update).toHaveBeenCalledWith('object-1', { type: 'type-MarketPresentation' });
+        expect(update).toHaveBeenCalledWith(
+            'object-1',
+            { type: 'type-MarketPresentation' },
+            { suppressWorkflows: true },
+        );
         expect(result).toEqual({
             id: 'type-MarketPresentation',
             isNew: false,

--- a/packages/workflow/src/activities/generateOrAssignContentType.ts
+++ b/packages/workflow/src/activities/generateOrAssignContentType.ts
@@ -1,10 +1,13 @@
 import { ApplicationFailure, log } from '@temporalio/activity';
 import {
     type ContentObjectTypeItem,
+    type ContentSource,
     type CreateContentObjectTypePayload,
     type DSLActivityExecutionPayload,
     type DSLActivitySpec,
     ImageRenditionFormat,
+    PDF_RENDITION_NAME,
+    type Rendition,
 } from '@vertesia/common';
 import { type ActivityContext, setupActivity } from '../dsl/setup/ActivityContext.js';
 import { type TruncateSpec, truncByMaxTokens } from '../utils/tokens.js';
@@ -75,9 +78,39 @@ export interface GenerateOrAssignContentType extends DSLActivitySpec<GenerateOrA
     name: 'generateOrAssignContentType';
 }
 
+export type GenerateOrAssignContentTypeResult =
+    | {
+          status: 'skipped';
+          message: string;
+      }
+    | {
+          status: 'failed';
+          error: 'no-text';
+      }
+    | {
+          id: string;
+          name: string;
+          isNew: boolean;
+      };
+
+function getPdfRenditionContent(doc: { metadata?: { renditions?: unknown } }): ContentSource | undefined {
+    const renditions = doc.metadata?.renditions;
+    if (!Array.isArray(renditions)) {
+        return undefined;
+    }
+    const pdfRendition = renditions.find(
+        (rendition): rendition is Rendition =>
+            typeof rendition === 'object' &&
+            rendition !== null &&
+            (rendition as { name?: unknown }).name === PDF_RENDITION_NAME &&
+            typeof (rendition as { content?: { source?: unknown } }).content?.source === 'string',
+    );
+    return pdfRendition?.content;
+}
+
 export async function generateOrAssignContentType(
     payload: DSLActivityExecutionPayload<GenerateOrAssignContentTypeParams>,
-) {
+): Promise<GenerateOrAssignContentTypeResult> {
     const context = await setupActivity<GenerateOrAssignContentTypeParams>(payload);
     const { params, client, objectId } = context;
 
@@ -85,7 +118,7 @@ export async function generateOrAssignContentType(
 
     log.debug(`SelectDocumentType for object: ${objectId}`, { payload });
 
-    const object = await client.objects.retrieve(objectId, '+text');
+    const object = await client.objects.retrieve(objectId, '+text +metadata +content');
 
     //Expects object.type to be null on first ingestion of content
     //User initiated Content Type change via the Composable UI,
@@ -99,12 +132,13 @@ export async function generateOrAssignContentType(
         };
     }
 
-    if (
-        !object ||
-        (!object.text &&
-            !object.content?.type?.startsWith('image/') &&
-            !object.content?.type?.startsWith('application/pdf'))
-    ) {
+    const pdfRendition = getPdfRenditionContent(object);
+    const hasVisionSource =
+        object.content?.type?.startsWith('image/') ||
+        object.content?.type?.startsWith('application/pdf') ||
+        !!pdfRendition?.type?.startsWith('application/pdf');
+
+    if (!object || (!object.text && !hasVisionSource)) {
         log.info(`Object ${objectId} not found or text is empty and not an image`, {
             object,
         });
@@ -116,10 +150,13 @@ export async function generateOrAssignContentType(
     });
 
     //make a list of all existing types, and add hints if any
-    const existing_types = types.filter((t) => !['DocumentPart', 'Rendition'].includes(t.name));
+    const existing_types = types.filter((t) => !['DocumentPart', 'Rendition'].includes(t.name) && t.status !== 'draft');
     const content = object.text ? truncByMaxTokens(object.text, params.truncate || 30000) : undefined;
 
-    const getImage = async () => {
+    const getImage = async (): Promise<string | ContentSource | undefined> => {
+        if (pdfRendition?.type?.startsWith('application/pdf')) {
+            return pdfRendition;
+        }
         if (object.content?.type?.includes('pdf') && object.text?.length && object.text?.length < 100) {
             return `store:${objectId}`;
         }
@@ -180,20 +217,30 @@ export async function generateOrAssignContentType(
     log.debug(`Selected Content Type Result: ${JSON.stringify(jsonResult)}`);
 
     //if type is not identified or not present in the database, generate a new type
-    let selectedType: { id: string; name: string } | undefined;
+    let selectedType: { id: string; name: string; isNew: boolean } | undefined;
 
-    selectedType = types.find((t) => t.name === jsonResult.document_type);
+    const existingMatch = existing_types.find((t) => t.name === jsonResult.document_type);
+    if (existingMatch) {
+        selectedType = { id: existingMatch.id, name: existingMatch.name, isNew: false };
+    }
 
     if (!selectedType) {
         if (params.allowNewContentTypes === false) {
             // Type generation is disabled (handled separately, e.g. via the Studio Assistant), so
             // fall back to the project's default type (or sys:GenericDocument) rather than leaving
             // the document untyped.
+            if (jsonResult.document_type) {
+                log.warn('Document type selection returned an ineligible or unknown type; assigning fallback', {
+                    objectId,
+                    selectedDocumentType: jsonResult.document_type,
+                    eligibleTypes: existing_types.map((type) => type.name),
+                });
+            }
             selectedType = await resolveFallbackType(context, params.fallbackTypeId, jsonResult.document_type);
         } else {
             log.warn('Document type not identified: starting type generation');
             const newType = await generateNewType(context, existing_types, content, fileRef);
-            selectedType = { id: newType.id, name: newType.name };
+            selectedType = { id: newType.id, name: newType.name, isNew: true };
         }
     }
 
@@ -210,7 +257,7 @@ export async function generateOrAssignContentType(
     return {
         id: selectedType.id,
         name: selectedType.name,
-        isNew: !types.find((t) => t.name === selectedType.name),
+        isNew: selectedType.isNew,
     };
 }
 
@@ -222,7 +269,7 @@ async function resolveFallbackType(
     context: ActivityContext<GenerateOrAssignContentTypeParams>,
     fallbackTypeId: string | undefined,
     selectedDocumentType: unknown,
-): Promise<{ id: string; name: string }> {
+): Promise<{ id: string; name: string; isNew: false }> {
     if (fallbackTypeId && fallbackTypeId !== GENERIC_DOCUMENT_TYPE_ID) {
         try {
             const resolved = await context.client.types.catalog.resolve(fallbackTypeId);
@@ -230,7 +277,7 @@ async function resolveFallbackType(
                 fallbackTypeId,
                 selectedDocumentType,
             });
-            return { id: resolved.id ?? fallbackTypeId, name: resolved.name ?? fallbackTypeId };
+            return { id: resolved.id ?? fallbackTypeId, name: resolved.name ?? fallbackTypeId, isNew: false };
         } catch (error) {
             log.warn('Configured default content type not resolvable; using GenericDocument', {
                 fallbackTypeId,
@@ -239,14 +286,14 @@ async function resolveFallbackType(
         }
     }
     log.info('Document type not identified; assigning GenericDocument fallback', { selectedDocumentType });
-    return { id: GENERIC_DOCUMENT_TYPE_ID, name: GENERIC_DOCUMENT_TYPE_NAME };
+    return { id: GENERIC_DOCUMENT_TYPE_ID, name: GENERIC_DOCUMENT_TYPE_NAME, isNew: false };
 }
 
 async function generateNewType(
     context: ActivityContext<GenerateOrAssignContentTypeParams>,
     existing_types: ContentObjectTypeItem[],
     content?: string,
-    fileRef?: string,
+    fileRef?: string | ContentSource,
 ) {
     const { client, params } = context;
 

--- a/packages/workflow/src/activities/generateOrAssignContentType.ts
+++ b/packages/workflow/src/activities/generateOrAssignContentType.ts
@@ -1,3 +1,4 @@
+import type { JSONSchema } from '@llumiverse/common';
 import { ApplicationFailure, log } from '@temporalio/activity';
 import {
     type ContentObjectTypeItem,
@@ -177,18 +178,48 @@ export async function generateOrAssignContentType(
 
     const fileRef = await getImage();
 
+    // Slim catalog for the selection prompt: names + identification guidance only, NO schemas
+    // (design intake-v2 §3). The full list (with schemas) is still used for matching and for
+    // new-type generation below.
+    const selectionCatalog = existing_types.map((t) => ({
+        id: t.id,
+        name: t.name,
+        description: t.description,
+        guidance: t.intake?.identification?.guidance,
+        distinguish_from: t.intake?.identification?.distinguish_from,
+    }));
+
+    // Closed-world output: constrain the result to the eligible type names + 'other', which
+    // removes the exact-string-match fragility on the model's answer.
+    const selectionResultSchema: JSONSchema = {
+        type: 'object',
+        properties: {
+            document_type: {
+                type: 'string',
+                enum: [...existing_types.map((t) => t.name), 'other'],
+                description: "Name of the matching document type, or 'other' when none matches.",
+            },
+        },
+        required: ['document_type'],
+    };
+
     log.info(
-        'Execute SelectDocumentType interaction on content with \nexisting types - passing full types: ' +
-            existing_types.filter((t) => !t.tags?.includes('system')),
+        'Execute SelectDocumentType interaction on content with \nexisting types - passing slim catalog: ' +
+            existing_types.filter((t) => !t.tags?.includes('system')).map((t) => t.name),
     );
 
     let res: Awaited<ReturnType<typeof executeInteractionFromActivity>>;
     try {
-        res = await executeInteractionFromActivity(client, interactionName, params, {
-            existing_types,
-            content,
-            image: fileRef,
-        });
+        res = await executeInteractionFromActivity(
+            client,
+            interactionName,
+            { ...params, result_schema: selectionResultSchema },
+            {
+                existing_types: selectionCatalog,
+                content,
+                image: fileRef,
+            },
+        );
     } catch (error: unknown) {
         const selectionError = toRetryableError(error);
         log.error(`Failed to select document type`, { error: selectionError, retryable: selectionError.retryable });
@@ -228,8 +259,9 @@ export async function generateOrAssignContentType(
         if (params.allowNewContentTypes === false) {
             // Type generation is disabled (handled separately, e.g. via the Studio Assistant), so
             // fall back to the project's default type (or sys:GenericDocument) rather than leaving
-            // the document untyped.
-            if (jsonResult.document_type) {
+            // the document untyped. 'other' is the constrained schema's first-class no-match
+            // answer, not a selection defect — only warn on anything else.
+            if (jsonResult.document_type && jsonResult.document_type !== 'other') {
                 log.warn('Document type selection returned an ineligible or unknown type; assigning fallback', {
                     objectId,
                     selectedDocumentType: jsonResult.document_type,
@@ -249,10 +281,16 @@ export async function generateOrAssignContentType(
         throw new Error(`Type not found: ${jsonResult.document_type}`);
     }
 
-    //update object with selected type
-    await client.objects.update(objectId, {
-        type: selectedType.id,
-    });
+    // Update object with selected type. Suppress workflow triggers: this is an intake-internal
+    // self-write — type updates now emit dirty.type and match the StandardIntake trigger, so an
+    // unsuppressed write here would recursively re-run intake on every type assignment.
+    await client.objects.update(
+        objectId,
+        {
+            type: selectedType.id,
+        },
+        { suppressWorkflows: true },
+    );
 
     return {
         id: selectedType.id,


### PR DESCRIPTION
## Summary
- Add shared content type intake policy fields and JSON schema for type-driven text conversion, extraction, rendering, and embedding behavior.
- Update workflow activities to use explicit text, vision, mixed, and auto extraction sources with fallback type assignment behavior.
- Add schema-backed intake policy editor UI exports for content type configuration.
- Fix the template smoke Verdaccio config so public scoped transitive packages proxy to npm while Vertesia/Llumiverse scopes stay local.

## Test Plan
- ../../node_modules/.bin/tsc -p tsconfig.json --noEmit (packages/common)
- ../../node_modules/.bin/tsc -p tsconfig.json --noEmit (packages/ui)
- ../../node_modules/.bin/tsc -p tsconfig.json --noEmit (packages/client)
- ../../node_modules/.bin/tsc -p tsconfig.test.json --noEmit (packages/workflow)
- ./node_modules/.bin/vitest run src/activities/generateDocumentProperties.test.ts src/activities/generateOrAssignContentType.test.ts (packages/workflow)
- ./.github/bin/test-template-integration.sh --release-type snapshot --template "Vertesia Plugin"
- CI for a72a8629: Check codebase, Unit tests, Template smoke test (Plugin), CodeQL, and zizmor passed.
