### PR TITLE
feat(common): add the css_rebuild manifest opt-in

### DIFF
--- a/packages/common/src/apps.ts
+++ b/packages/common/src/apps.ts
@@ -32,21 +32,6 @@ export interface AppUINavItem {
     preferredSection?: (typeof PREFERRED_SECTIONS)[number];
 }
 
-/**
- * Metadata a UI plugin module exports next to its inline `css` export, describing the
- * payload that build produced. Emitted automatically by the plugin-builder; plugins
- * built without it can hand-write the export.
- */
-export interface AppCssMeta {
-    /**
-     * The isolation modes this build's payloads support. The manifest picks the mode
-     * (`AppUIConfig.isolation`); this lists the modes the build can honor. 'css' means
-     * the inline css export keeps its cascade layers and omits the preflight, so a host
-     * can inject it into its own document as is.
-     */
-    supports?: ('shadow' | 'css')[];
-}
-
 export interface AppUIConfig {
     /**
      * The source URL of the app. The src can be a template which contain
@@ -62,9 +47,8 @@ export interface AppUIConfig {
      */
     isolation?: 'shadow' | 'css';
     /**
-     * When true the host renders a legacy build's css in compatibility mode: it rebuilds
-     * the payload from the plugin stylesheet at load time when the inline css export
-     * cannot be trusted. Defaults to false: the plugin css installs exactly as declared.
+     * When true the host modifies the app's css at load time to attempt to fix broken
+     * or missing styles. Only takes effect in css isolation mode. Defaults to false.
      */
     legacy_css_compat?: boolean;
     /**

--- a/packages/common/src/apps.ts
+++ b/packages/common/src/apps.ts
@@ -50,7 +50,7 @@ export interface AppUIConfig {
      * When true the host modifies the app's css at load time to attempt to fix broken
      * or missing styles. Only takes effect in css isolation mode. Defaults to false.
      */
-    legacy_css_compat?: boolean;
+    css_rebuild?: boolean;
     /**
      * Navigation items for the app's sidebar UI.
      * Only applicable for apps with UI capability in shell contexts (ie. CompositeApp shell).

--- a/packages/common/src/apps.ts
+++ b/packages/common/src/apps.ts
@@ -32,6 +32,21 @@ export interface AppUINavItem {
     preferredSection?: (typeof PREFERRED_SECTIONS)[number];
 }
 
+/**
+ * Metadata a UI plugin module exports next to its inline `css` export, describing the
+ * payload that build produced. Emitted automatically by the plugin-builder; plugins
+ * built without it can hand-write the export.
+ */
+export interface AppCssMeta {
+    /**
+     * The isolation modes this build's payloads support. The manifest picks the mode
+     * (`AppUIConfig.isolation`); this lists the modes the build can honor. 'css' means
+     * the inline css export keeps its cascade layers and omits the preflight, so a host
+     * can inject it into its own document as is.
+     */
+    supports?: ('shadow' | 'css')[];
+}
+
 export interface AppUIConfig {
     /**
      * The source URL of the app. The src can be a template which contain
@@ -40,11 +55,18 @@ export interface AppUIConfig {
      */
     src: string;
     /**
-     * The isolation strategy. If not specified it defaults to shadow
+     * The isolation strategy. If not specified it defaults to shadow.
      * - shadow - use Shadow DOM to fully isolate the plugin from the host.
-     * - css - use CSS processing (like prefixing or other isolation techniques). Ligther but plugins may conflict with the host
+     * - css - inject the plugin's styles (minus the preflight) into the host document;
+     *   lighter but styles may conflict with the host.
      */
     isolation?: 'shadow' | 'css';
+    /**
+     * When true the host renders a legacy build's css in compatibility mode: it rebuilds
+     * the payload from the plugin stylesheet at load time when the inline css export
+     * cannot be trusted. Defaults to false: the plugin css installs exactly as declared.
+     */
+    legacy_css_compat?: boolean;
     /**
      * Navigation items for the app's sidebar UI.
      * Only applicable for apps with UI capability in shell contexts (ie. CompositeApp shell).


### PR DESCRIPTION
## Summary

Adds one additive, default-off field to `@vertesia/common`:

- **`AppUIConfig.css_rebuild`** (default `false`) — a manifest opt-in. When true, the host modifies the app's css at load time to attempt to fix broken or missing styles. Only takes effect in css isolation mode.

Type-only; no runtime behavior lives in this package. The host that consumes it ships in the Vertesia web app off this same maintenance line. The build-tool fix that makes future builds correct at the source ships separately on the main line (#1699).

## Verification

- `@vertesia/common` builds; lint clean. The field is optional and default-off — no existing consumer changes.

## Test Plan

- [x] Build `@vertesia/common`
- [x] Confirm the field is optional and default-off (no behavior change for existing manifests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JpAEfftYG74jVAFhZ87EcD
