### PR TITLE
fix: disable timeouts for bulk indexing

### DIFF
--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -147,6 +147,59 @@ describe('Test Vertesia Client', () => {
     });
 });
 
+describe('Indexing API zeno-bulk requests', () => {
+    test('does not apply the client default timeout to indexShard', async () => {
+        const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+        let capturedRequest: Request | undefined;
+        const fetchImpl = vi.fn(async (input: RequestInfo, _init?: RequestInit) => {
+            capturedRequest = input instanceof Request ? input : new Request(input);
+            return new Response(
+                JSON.stringify({
+                    status: 'done',
+                    projects_done: 1,
+                    projects_total: 1,
+                    scanned: 0,
+                    written: 0,
+                    errors: 0,
+                    read_docs_s: 0,
+                    write_docs_s: 0,
+                    read_mb: 0,
+                    write_mb: 0,
+                    duration_sec: 0,
+                }),
+                {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' },
+                },
+            );
+        });
+
+        try {
+            const client = new VertesiaClient({
+                serverUrl: 'https://api.us1.vertesia.io',
+                storeUrl: 'https://api.us1.vertesia.io',
+                tokenServerUrl: 'https://sts.us1.vertesia.io',
+                apikey: 'test-token',
+                timeout: 60_000,
+                fetch: fetchImpl,
+            });
+
+            await client.store.indexing.indexShard({
+                tenant_id: 'abcdef_123456',
+                target_index: 'target-index',
+                shard_min: '',
+                shard_max: 'z',
+            });
+
+            expect(timeoutSpy).not.toHaveBeenCalled();
+            expect(fetchImpl).toHaveBeenCalledTimes(1);
+            expect(capturedRequest?.url).toBe('https://api.us1.vertesia.io/reindex/shard');
+        } finally {
+            timeoutSpy.mockRestore();
+        }
+    });
+});
+
 describe('isTokenExpired', () => {
     // EXPIRATION_THRESHOLD inside client.ts is 60000ms (60s). Tokens with `exp`
     // less than 60s in the future are treated as expired so the caller refreshes

--- a/packages/client/src/store/IndexingApi.ts
+++ b/packages/client/src/store/IndexingApi.ts
@@ -298,8 +298,8 @@ export class IndexingApi extends ApiTopic {
     /**
      * POST to a zeno-bulk endpoint. Resolves the path against the zeno-bulk base URL.
      */
-    private zenoBulkPost<T>(path: string, body: object): Promise<T> {
-        return this.client.post(this.zenoBulkBaseUrl + path, { payload: body });
+    private zenoBulkPost<T>(path: string, body: object, timeoutMs?: number | false | null): Promise<T> {
+        return this.client.post(this.zenoBulkBaseUrl + path, { payload: body, timeoutMs });
     }
 
     /**
@@ -325,7 +325,7 @@ export class IndexingApi extends ApiTopic {
      * The Go service reads from MongoDB and writes to ES directly.
      */
     indexShard(params: IndexShardParams): Promise<IndexShardResult> {
-        return this.zenoBulkPost('/reindex/shard', { params } satisfies IndexShardRequest);
+        return this.zenoBulkPost('/reindex/shard', { params } satisfies IndexShardRequest, false);
     }
 
     /**
@@ -383,7 +383,7 @@ export class IndexingApi extends ApiTopic {
         } satisfies ReindexViaBulkRequest;
 
         if (!onEvent) {
-            return this.client.post(bulkUrl, { payload: { params } });
+            return this.client.post(bulkUrl, { payload: { params }, timeoutMs: false });
         }
 
         // SSE mode: stream progress events from zeno-bulk
@@ -394,6 +394,7 @@ export class IndexingApi extends ApiTopic {
             bulkUrl,
             {
                 payload: { params },
+                timeoutMs: false,
             },
             (event) => {
                 onEvent(event);


### PR DESCRIPTION
## Summary
- Disable inherited request timeouts for long-running zeno-bulk reindex calls.
- Add a regression test that indexShard does not apply a client default timeout.

## Test Plan
- [ ] `pnpm --filter @vertesia/client typecheck:test` (blocked locally: release worktree has no `node_modules`; dependency-ready checkout still fails on existing `@llumiverse/common` / `QuotaTierResponse` resolution errors)
- [ ] `pnpm --filter @vertesia/client lint` (blocked locally: `biome` not found)
- [ ] `pnpm --dir composableai/packages/client exec vitest run src/client.test.ts` (blocked locally before tests run by existing `@llumiverse/common` entry resolution issue)