### PR TITLE
fix(agent): clear uploaded file from composer on send

### DIFF
--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.test.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
-import { type AgentMessage, AgentMessageType } from '@vertesia/common';
+import { type AgentMessage, AgentMessageType, type ConversationFile, FileProcessingStatus } from '@vertesia/common';
 import type React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../__tests__/test-utils.js';
@@ -245,6 +245,7 @@ describe('ModernAgentConversation send handling', () => {
             hasProcessingFiles: false,
             handleFileUpload: vi.fn(),
             removeProcessingFile: vi.fn(),
+            clearProcessingFiles: vi.fn(),
         });
     });
 
@@ -283,6 +284,53 @@ describe('ModernAgentConversation send handling', () => {
         expect(mocks.restart.mock.invocationCallOrder[0]).toBeLessThan(mocks.sendSignal.mock.invocationCallOrder[0]);
         expect(mocks.reconnect.mock.invocationCallOrder[0]).toBeLessThan(mocks.sendSignal.mock.invocationCallOrder[0]);
         expect(mocks.updateOptimisticMessageStatus).toHaveBeenCalledWith(expect.any(String), 'received');
+    });
+
+    it('binds ready uploaded files into the sent message and clears them after send', async () => {
+        const clearProcessingFiles = vi.fn();
+        const readyFile: ConversationFile = {
+            id: 'file-1',
+            name: 'report.pdf',
+            content_type: 'application/pdf',
+            size: 10,
+            status: FileProcessingStatus.READY,
+            artifact_path: 'files/report.pdf',
+            reference: 'artifact:files/report.pdf',
+            started_at: 1_000,
+        };
+        mocks.useFileProcessing.mockReturnValue({
+            processingFiles: new Map([[readyFile.id, readyFile]]),
+            hasProcessingFiles: false,
+            handleFileUpload: vi.fn(),
+            removeProcessingFile: vi.fn(),
+            clearProcessingFiles,
+        });
+        mockStreamState({
+            messages: [createMessage(AgentMessageType.COMPLETE, 'done')],
+            agentRunStatus: 'COMPLETED',
+        });
+
+        renderConversation({ onRestart: vi.fn() });
+
+        fireEvent.click(screen.getByRole('button', { name: 'inline send' }));
+
+        await waitFor(() => {
+            expect(mocks.sendSignal).toHaveBeenCalledWith(
+                'agent-run-1',
+                'UserInput',
+                expect.objectContaining({
+                    message: expect.stringContaining('Uploaded artifacts:'),
+                }),
+            );
+        });
+
+        const userInputCall = mocks.sendSignal.mock.calls.find((call) => call[1] === 'UserInput');
+        expect((userInputCall?.[2] as { message: string }).message).toContain(
+            '[report.pdf](artifact:files/report.pdf)',
+        );
+        await waitFor(() => {
+            expect(clearProcessingFiles).toHaveBeenCalledTimes(1);
+        });
     });
 
     it('does not restart or send from a terminal run that cannot continue', () => {

--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
@@ -7,6 +7,7 @@ import {
     type CompletedWorkstreamEntry,
     type ConversationFile,
     type ConversationFileRef,
+    FileProcessingStatus,
     type McpConnectUxConfig,
     normalizeAgentToolApprovalMode,
     type Plan,
@@ -1359,12 +1360,8 @@ function ModernAgentConversationInner({
         updateDocumentTitle,
     } = useDocumentPanel(messages);
 
-    const { processingFiles, hasProcessingFiles, handleFileUpload, removeProcessingFile } = useFileProcessing(
-        client,
-        agentRunId,
-        serverFileUpdates,
-        toast,
-    );
+    const { processingFiles, hasProcessingFiles, handleFileUpload, removeProcessingFile, clearProcessingFiles } =
+        useFileProcessing(client, agentRunId, serverFileUpdates, toast);
     const canUploadFiles = interactive && !hideFileUpload;
 
     const handleRemoveProcessingFile = useCallback(
@@ -1428,6 +1425,8 @@ function ModernAgentConversationInner({
     isSendingRef.current = isSending;
     const hasProcessingFilesRef = useRef(hasProcessingFiles);
     hasProcessingFilesRef.current = hasProcessingFiles;
+    const processingFilesRef = useRef(processingFiles);
+    processingFilesRef.current = processingFiles;
 
     const lastMainMessage = useMemo(() => {
         const mainMessages = messages.filter((m) => (m.workstream_id || 'main') === 'main');
@@ -1951,6 +1950,24 @@ function ModernAgentConversationInner({
                 messageContent = [trimmed, '', 'Attachments:', ...lines].join('\n');
             }
 
+            // Bind ready uploaded files to this message: embed them as an "Uploaded artifacts:"
+            // markdown block so they render underneath the sent bubble (parsed by
+            // parseUserMessageAttachments) and get cleared from the composer on send.
+            const uploadedArtifactLines = Array.from(processingFilesRef.current.values())
+                .filter((file) => file.status === FileProcessingStatus.READY)
+                .map((file) => {
+                    const href = file.reference?.startsWith('artifact:')
+                        ? file.reference
+                        : file.artifact_path
+                          ? `artifact:${file.artifact_path}`
+                          : undefined;
+                    return href ? `[${file.name}](${href})` : undefined;
+                })
+                .filter((line): line is string => Boolean(line));
+            if (uploadedArtifactLines.length > 0) {
+                messageContent = [messageContent, '', 'Uploaded artifacts:', ...uploadedArtifactLines].join('\n');
+            }
+
             const messageId = `msg-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
 
             const optimisticMessage: AgentMessage = {
@@ -1982,6 +1999,7 @@ function ModernAgentConversationInner({
             const markReceived = () => {
                 updateOptimisticMessageStatus(messageId, 'received');
                 onAttachmentsSent?.();
+                clearProcessingFiles();
             };
 
             // When the workflow has already completed, restart it first so it resumes
@@ -2020,6 +2038,7 @@ function ModernAgentConversationInner({
             getAttachedDocs,
             getMessageContext,
             onAttachmentsSent,
+            clearProcessingFiles,
             reconnectStream,
             addOptimisticMessage,
             updateOptimisticMessageStatus,

--- a/packages/ui/src/features/agent/chat/hooks/useFileProcessing.test.tsx
+++ b/packages/ui/src/features/agent/chat/hooks/useFileProcessing.test.tsx
@@ -50,6 +50,33 @@ describe('useFileProcessing', () => {
         expect(result.current.processingFiles.has('file-1')).toBe(false);
     });
 
+    it('clears files on send without signaling FileRemoved and suppresses the server echo', async () => {
+        const client = createClient();
+        const toast = vi.fn();
+        const serverFileUpdates = new Map([['file-1', createReadyFile('file-1')]]);
+        const { result, rerender } = renderHook(
+            ({ updates }) => useFileProcessing(client, 'agent-run-1', updates, toast),
+            {
+                initialProps: { updates: serverFileUpdates },
+            },
+        );
+
+        expect(result.current.processingFiles.has('file-1')).toBe(true);
+
+        act(() => {
+            result.current.clearProcessingFiles();
+        });
+
+        // The agent already received the file via FileUploaded, so sending the message
+        // consumes it rather than retracting it — no FileRemoved signal.
+        expect(client.agents.sendSignal).not.toHaveBeenCalled();
+        expect(result.current.processingFiles.has('file-1')).toBe(false);
+
+        // A subsequent server echo for the same file must not re-add the chip.
+        rerender({ updates: new Map([['file-1', createReadyFile('file-1')]]) });
+        expect(result.current.processingFiles.has('file-1')).toBe(false);
+    });
+
     it('does not signal an upload that was removed before upload completion', async () => {
         const client = createClient();
         const uploadArtifact = vi.mocked(client.agents.uploadArtifact);

--- a/packages/ui/src/features/agent/chat/hooks/useFileProcessing.test.tsx
+++ b/packages/ui/src/features/agent/chat/hooks/useFileProcessing.test.tsx
@@ -77,6 +77,49 @@ describe('useFileProcessing', () => {
         expect(result.current.processingFiles.has('file-1')).toBe(false);
     });
 
+    it('preserves local artifact_path/reference when a server update omits them', async () => {
+        const client = createClient();
+        const toast = vi.fn();
+        const { result, rerender } = renderHook(
+            ({ updates }) => useFileProcessing(client, 'agent-run-1', updates, toast),
+            {
+                initialProps: { updates: new Map<string, ConversationFile>() },
+            },
+        );
+
+        const file = new File(['pdf'], 'report.pdf', { type: 'application/pdf' });
+        await act(async () => {
+            await result.current.handleFileUpload([file]);
+        });
+
+        const [fileId, local] = Array.from(result.current.processingFiles.entries())[0];
+        expect(local.artifact_path).toBe('files/report.pdf');
+        expect(local.reference).toBe('artifact:files/report.pdf');
+
+        // Server echoes READY but drops artifact_path/reference — the merge must backfill
+        // them from the local optimistic entry so the sent-message embed still resolves.
+        rerender({
+            updates: new Map<string, ConversationFile>([
+                [
+                    fileId,
+                    {
+                        id: fileId,
+                        name: 'report.pdf',
+                        content_type: 'application/pdf',
+                        size: 0,
+                        status: FileProcessingStatus.READY,
+                        started_at: 1_000,
+                    },
+                ],
+            ]),
+        });
+
+        const merged = result.current.processingFiles.get(fileId);
+        expect(merged?.status).toBe(FileProcessingStatus.READY);
+        expect(merged?.artifact_path).toBe('files/report.pdf');
+        expect(merged?.reference).toBe('artifact:files/report.pdf');
+    });
+
     it('does not signal an upload that was removed before upload completion', async () => {
         const client = createClient();
         const uploadArtifact = vi.mocked(client.agents.uploadArtifact);

--- a/packages/ui/src/features/agent/chat/hooks/useFileProcessing.ts
+++ b/packages/ui/src/features/agent/chat/hooks/useFileProcessing.ts
@@ -8,6 +8,7 @@ export interface UseFileProcessingResult {
     hasProcessingFiles: boolean;
     handleFileUpload: (files: File[]) => Promise<void>;
     removeProcessingFile: (fileId: string) => Promise<void>;
+    clearProcessingFiles: () => void;
 }
 
 type ToastFn = (opts: {
@@ -58,6 +59,12 @@ export function useFileProcessing(
     const removedFileIdsRef = useRef<Set<string>>(new Set());
     const previewUrlsRef = useRef<Map<string, string>>(new Map());
     const previousAgentRunId = useRef(agentRunId);
+    // Kept current so clearProcessingFiles() can read the latest tracked ids
+    // imperatively without being re-created on every render.
+    const localFilesRef = useRef(localFiles);
+    localFilesRef.current = localFiles;
+    const serverFileUpdatesRef = useRef(serverFileUpdates);
+    serverFileUpdatesRef.current = serverFileUpdates;
 
     const revokePreviewUrl = useCallback((fileId: string) => {
         const previewUrl = previewUrlsRef.current.get(fileId);
@@ -224,5 +231,23 @@ export function useFileProcessing(
         [agentRunId, client, revokePreviewUrl, t, toast],
     );
 
-    return { processingFiles, hasProcessingFiles, handleFileUpload, removeProcessingFile };
+    // Clears the composer's uploaded-file chips after a message is sent. Unlike
+    // removeProcessingFile, this does NOT signal FileRemoved — the agent already
+    // received these files via FileUploaded, so the message consumes them rather
+    // than retracting them. The ids are added to removedFileIds so the server echo
+    // in the merge above cannot re-add a chip once the message has been sent.
+    const clearProcessingFiles = useCallback(() => {
+        previewUrlsRef.current.forEach(revokePreviewUrlValue);
+        previewUrlsRef.current.clear();
+        setRemovedFileIds((prev) => {
+            const next = new Set(prev);
+            for (const id of serverFileUpdatesRef.current.keys()) next.add(id);
+            for (const id of localFilesRef.current.keys()) next.add(id);
+            removedFileIdsRef.current = next;
+            return next;
+        });
+        setLocalFiles(new Map());
+    }, []);
+
+    return { processingFiles, hasProcessingFiles, handleFileUpload, removeProcessingFile, clearProcessingFiles };
 }

--- a/packages/ui/src/features/agent/chat/hooks/useFileProcessing.ts
+++ b/packages/ui/src/features/agent/chat/hooks/useFileProcessing.ts
@@ -104,11 +104,17 @@ export function useFileProcessing(
         });
         serverFileUpdates.forEach((file, id) => {
             if (!removedFileIds.has(id)) {
-                const localPreviewUrl = (localFiles.get(id) as LocalConversationFile | undefined)?.preview_url;
-                merged.set(
-                    id,
-                    localPreviewUrl ? ({ ...file, preview_url: localPreviewUrl } as LocalConversationFile) : file,
-                );
+                // Server updates are authoritative for status, but may omit fields the local
+                // optimistic entry already knows: preview_url is never sent by the server, and
+                // artifact_path/reference can be absent on some updates. Backfill them from local
+                // so the sent-message embed and thumbnail resolution keep working.
+                const local = localFiles.get(id) as LocalConversationFile | undefined;
+                merged.set(id, {
+                    ...file,
+                    artifact_path: file.artifact_path ?? local?.artifact_path,
+                    reference: file.reference ?? local?.reference,
+                    ...(local?.preview_url ? { preview_url: local.preview_url } : {}),
+                } as LocalConversationFile);
             }
         });
         return merged;


### PR DESCRIPTION
## Summary

In the agent chat composer, a file uploaded via the upload button / drag-drop / paste was tracked separately from attached store documents and was **never cleared on send**. The "Ready" chip stayed pinned in the prompt box after the message was sent, and because its remove (✕) button was still live it could fire a `FileRemoved` signal — letting the user retract a file the agent had already received (files are signaled to the agent via `FileUploaded` at upload time, not at send time).

This aligns uploaded files with how attached store documents already behave:

- On send, ready uploaded files are bound to the outgoing message and embedded as an `Uploaded artifacts:` markdown block (already recognized by `parseUserMessageAttachments` + `artifact:` hrefs), so they render **underneath the sent bubble**.
- New `clearProcessingFiles()` in `useFileProcessing` clears the composer chips and revokes preview URLs **without** signaling `FileRemoved`, and adds the ids to the removed set so the server echo can't re-add a chip after send.
- The uploaded file remains available in the server-fetched Artifacts tab.

## Changes

- `useFileProcessing.ts` — add `clearProcessingFiles()` (echo-suppressing, no `FileRemoved` signal).
- `ModernAgentConversation.tsx` — embed ready uploaded files as `Uploaded artifacts:` in the sent message and call `clearProcessingFiles()` on receive.
- `useFileProcessing.test.tsx` — test that clear does not signal `FileRemoved` and suppresses the server echo.

## Test Plan

- [x] `tsc -p tsconfig.json --noEmit` — pass
- [x] `tsc -p tsconfig.test.json --noEmit` — pass
- [x] `biome lint` on changed files — clean
- [x] `vitest run src/features/agent/chat` — 205 pass; added `useFileProcessing` case → 4/4 in that file
- [x] `pnpm build` (@vertesia/ui, checks + rollup) — pass
- [ ] Manual: upload a doc, send a prompt → chip leaves the box, doc renders under the sent message, no longer removable
