### PR TITLE
fix(ui): restore percentage panel sizing after react-resizable-panels v4

### DIFF
--- a/packages/ui/src/core/components/shadcn/resizeable.test.tsx
+++ b/packages/ui/src/core/components/shadcn/resizeable.test.tsx
@@ -1,0 +1,75 @@
+import { render } from '@testing-library/react';
+import type React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Capture the props the wrapper forwards to the underlying react-resizable-panels
+// primitive, and stub out its layout machinery so the assertions run in jsdom.
+const mocks = vi.hoisted(() => ({ panelProps: vi.fn() }));
+
+vi.mock('react-resizable-panels', () => ({
+    Group: ({ children }: { children?: React.ReactNode }) => <div data-testid="group">{children}</div>,
+    Panel: (props: Record<string, unknown>) => {
+        mocks.panelProps(props);
+        return <div data-testid="panel" />;
+    },
+    Separator: ({ children }: { children?: React.ReactNode }) => <div data-testid="separator">{children}</div>,
+}));
+
+import { ResizablePanel, ResizablePanelGroup } from './resizeable';
+
+function forwardedPanelProps() {
+    return mocks.panelProps.mock.calls[0]?.[0] as Record<string, unknown>;
+}
+
+describe('ResizablePanel size coercion', () => {
+    beforeEach(() => {
+        mocks.panelProps.mockClear();
+    });
+
+    // Regression guard for the react-resizable-panels v3 -> v4 upgrade: v4 treats bare
+    // numeric sizes as PIXELS (v3 and below treated them as percentages). Every call site
+    // passes percentage-intended numbers, so the wrapper must re-add the "%" unit — without
+    // it, panels get clamped to a few pixels and the split can no longer be resized.
+    it('coerces bare numeric sizes to percentage strings', () => {
+        render(
+            <ResizablePanelGroup direction="horizontal">
+                <ResizablePanel defaultSize={50} minSize={20} maxSize={80} collapsedSize={5} />
+            </ResizablePanelGroup>,
+        );
+
+        expect(mocks.panelProps).toHaveBeenCalledTimes(1);
+        expect(forwardedPanelProps()).toMatchObject({
+            defaultSize: '50%',
+            minSize: '20%',
+            maxSize: '80%',
+            collapsedSize: '5%',
+        });
+    });
+
+    it('passes explicit unit strings through unchanged', () => {
+        render(
+            <ResizablePanelGroup direction="horizontal">
+                <ResizablePanel defaultSize="300px" minSize="10rem" maxSize="50%" />
+            </ResizablePanelGroup>,
+        );
+
+        expect(forwardedPanelProps()).toMatchObject({
+            defaultSize: '300px',
+            minSize: '10rem',
+            maxSize: '50%',
+        });
+    });
+
+    it('leaves unspecified sizes undefined', () => {
+        render(
+            <ResizablePanelGroup direction="horizontal">
+                <ResizablePanel />
+            </ResizablePanelGroup>,
+        );
+
+        const props = forwardedPanelProps();
+        expect(props.defaultSize).toBeUndefined();
+        expect(props.minSize).toBeUndefined();
+        expect(props.maxSize).toBeUndefined();
+    });
+});

--- a/packages/ui/src/core/components/shadcn/resizeable.test.tsx
+++ b/packages/ui/src/core/components/shadcn/resizeable.test.tsx
@@ -53,6 +53,7 @@ describe('ResizablePanel size coercion', () => {
             </ResizablePanelGroup>,
         );
 
+        expect(mocks.panelProps).toHaveBeenCalledTimes(1);
         expect(forwardedPanelProps()).toMatchObject({
             defaultSize: '300px',
             minSize: '10rem',
@@ -67,6 +68,7 @@ describe('ResizablePanel size coercion', () => {
             </ResizablePanelGroup>,
         );
 
+        expect(mocks.panelProps).toHaveBeenCalledTimes(1);
         const props = forwardedPanelProps();
         expect(props.defaultSize).toBeUndefined();
         expect(props.minSize).toBeUndefined();

--- a/packages/ui/src/core/components/shadcn/resizeable.tsx
+++ b/packages/ui/src/core/components/shadcn/resizeable.tsx
@@ -23,8 +23,34 @@ function ResizablePanelGroup({ className, direction = 'horizontal', orientation,
     );
 }
 
-function ResizablePanel({ ...props }: React.ComponentProps<typeof ResizablePrimitive.Panel>) {
-    return <ResizablePrimitive.Panel data-slot="resizable-panel" {...props} />;
+/**
+ * react-resizable-panels v4 treats bare numeric sizes as **pixels**; earlier majors
+ * (v3 and below) treated them as **percentages** of the group. Every call site in this
+ * codebase passes percentage-intended numbers (e.g. `defaultSize={50}`), so coerce bare
+ * numbers to percentage strings to preserve that contract after the v3→v4 upgrade.
+ * Explicit unit strings ("300px", "50%", "10rem", ...) are passed through untouched.
+ */
+function toPercentSize(value: number | string | undefined): number | string | undefined {
+    return typeof value === 'number' ? `${value}%` : value;
+}
+
+function ResizablePanel({
+    defaultSize,
+    minSize,
+    maxSize,
+    collapsedSize,
+    ...props
+}: React.ComponentProps<typeof ResizablePrimitive.Panel>) {
+    return (
+        <ResizablePrimitive.Panel
+            data-slot="resizable-panel"
+            defaultSize={toPercentSize(defaultSize)}
+            minSize={toPercentSize(minSize)}
+            maxSize={toPercentSize(maxSize)}
+            collapsedSize={toPercentSize(collapsedSize)}
+            {...props}
+        />
+    );
 }
 
 function ResizableHandle({


### PR DESCRIPTION
## Summary

`react-resizable-panels` v4 interprets bare numeric `Panel` sizes as **pixels**, whereas v3 and earlier treated them as **percentages** of the group. Every call site in this package passes percentage-intended numbers (e.g. `defaultSize={50}`), so after the v3→v4 upgrade panels were clamped to a few pixels and split views could no longer be resized. This affected all resizable layouts, including the PDF viewer (`MagicPdfView`), the store object overview, and the prompt template editor.

The `ResizablePanel` wrapper now coerces bare numeric sizes (`defaultSize`/`minSize`/`maxSize`/`collapsedSize`) to percentage strings, restoring the previous contract for every consumer with a single change. Explicit unit strings (`"300px"`, `"50%"`, `"10rem"`, ...) pass through untouched.

## Changes

- `core/components/shadcn/resizeable.tsx` — coerce bare numeric panel sizes to percentage strings.
- `core/components/shadcn/resizeable.test.tsx` — unit tests: numbers → `"%"`, unit strings pass through, undefined stays undefined.

## Test Plan

- [x] `vitest run src/core/components/shadcn/resizeable.test.tsx` — 3/3 pass
- [x] `tsc -p tsconfig.json --noEmit` and `tsc -p tsconfig.test.json --noEmit` — pass
- [x] `biome lint` on changed files — clean
- [x] `pnpm build` (@vertesia/ui) — pass
- [ ] Manual: open a split view (PDF viewer / content overview / template editor) and drag the handle — resizes smoothly

## Notes

A drag-resize Playwright test was considered but deferred: `MagicPdfView` only renders for a PDF content object with a completed rendition + extraction pipeline (slow/flaky to seed in E2E), and the regression lives entirely in the shared wrapper — the unit tests guard it deterministically for every consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>