### PR TITLE
fix: Make user.externalId optional

### DIFF
--- a/packages/common/src/user.ts
+++ b/packages/common/src/user.ts
@@ -7,7 +7,7 @@ export interface UserWithAccounts extends User {
 
 export interface User {
     id: string;
-    externalId: string;
+    externalId?: string;
     email: string;
     name: string;
     username?: string;


### PR DESCRIPTION
This is a consistency fix.

- Makes `User.externalId` optional in the shared type.
- Aligns the TypeScript contract with actual usage, which already allow missing values.

Checks:
- `pnpm --dir composableai/packages/common lint`
- `pnpm --dir composableai/packages/common typecheck:test`
- `pnpm --dir composableai/packages/common build` (blocked by missing local `rollup` binary in this environment)
