### PR TITLE
fix(process): validate human_task field name, type, and select options

### DIFF
--- a/packages/common/src/store/process-validation.test.ts
+++ b/packages/common/src/store/process-validation.test.ts
@@ -410,6 +410,68 @@ describe('process definition validation', () => {
         expect(result.errors).toContain('human_task node "review" is missing task');
     });
 
+    it('rejects human_task fields that use "id" instead of "name"', () => {
+        const definition = validDefinition();
+        definition.nodes.review.task = {
+            title: 'Review',
+            fields: [{ id: 'approved', type: 'boolean' } as unknown as { name: string; type: 'boolean' }],
+        };
+
+        const result = getProcessDefinitionValidationResult(definition);
+
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain(
+            'human_task node "review" task.fields[0].name must be a non-empty string (not "id")',
+        );
+    });
+
+    it('rejects human_task fields with an unsupported type', () => {
+        const definition = validDefinition();
+        definition.nodes.review.task = {
+            title: 'Review',
+            fields: [{ name: 'approved', type: 'date' } as unknown as { name: string; type: 'string' }],
+        };
+
+        const result = getProcessDefinitionValidationResult(definition);
+
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain(
+            'human_task node "review" task.fields[0].type must be one of string, number, boolean, select, text',
+        );
+    });
+
+    it('rejects select fields without options', () => {
+        const definition = validDefinition();
+        definition.nodes.review.task = {
+            title: 'Review',
+            fields: [{ name: 'decision', type: 'select' }],
+        };
+
+        const result = getProcessDefinitionValidationResult(definition);
+
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain(
+            'human_task node "review" task.fields[0] of type "select" requires a non-empty options[] array',
+        );
+    });
+
+    it('accepts human_task select fields with options', () => {
+        const definition = validDefinition();
+        definition.nodes.review.task = {
+            title: 'Review',
+            fields: [
+                {
+                    name: 'decision',
+                    type: 'select',
+                    options: ['approved', 'rejected'],
+                    required: true,
+                },
+            ],
+        };
+
+        expect(() => validateProcessDefinitionBody(definition)).not.toThrow();
+    });
+
     it('rejects overly deep guard rules', () => {
         const definition = validDefinition();
         let guard: Record<string, unknown> = { var: 'approved' };

--- a/packages/common/src/store/process-validation.ts
+++ b/packages/common/src/store/process-validation.ts
@@ -113,6 +113,24 @@ function validateNodeDefinition(
             errors.push(`human_task node "${nodeId}" task title is missing`);
         } else if (!Array.isArray(node.task.fields)) {
             errors.push(`human_task node "${nodeId}" task fields must be an array`);
+        } else {
+            const allowedTypes = ['string', 'number', 'boolean', 'select', 'text'];
+            (node.task.fields as unknown[]).forEach((field, i) => {
+                const path = `human_task node "${nodeId}" task.fields[${i}]`;
+                if (!isRecord(field)) {
+                    errors.push(`${path} must be an object`);
+                    return;
+                }
+                if (typeof field.name !== 'string' || field.name.length === 0) {
+                    errors.push(`${path}.name must be a non-empty string (not "id")`);
+                }
+                if (typeof field.type !== 'string' || !allowedTypes.includes(field.type)) {
+                    errors.push(`${path}.type must be one of ${allowedTypes.join(', ')}`);
+                }
+                if (field.type === 'select' && !(Array.isArray(field.options) && field.options.length > 0)) {
+                    errors.push(`${path} of type "select" requires a non-empty options[] array`);
+                }
+            });
         }
     }
     if (node.type === 'tool') {


### PR DESCRIPTION
Extend process definition validation to inspect each entry in task.fields:
- name must be a non-empty string (not "id")
- type must be one of string, number, boolean, select, text
- select requires a non-empty options[] array

Previously the server only checked that fields was an array, which allowed process definitions with malformed fields to be saved and then fail at runtime when the createProcessHumanTask activity forwarded them to POST /tasks (which strictly requires name).