### PR TITLE
chore(build): add output cleanup helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "ci:test": "pnpm exec turbo run typecheck:test test --filter='./packages/*' --filter='./llumiverse/*' --filter='./templates/*'",
         "ci:typecheck:test": "pnpm exec turbo run typecheck:test --filter='./packages/*' --filter='./llumiverse/*' --filter='./templates/*'",
         "clean": "rimraf ./node_modules && pnpm -r clean",
-        "clean:outputs": "pnpm -r exec rm -rf ./lib ./dist ./.next ./tsconfig.tsbuildinfo ./.tsbuildinfo",
+        "clean:outputs": "pnpm -r exec rimraf ./lib ./dist ./.next ./tsconfig.tsbuildinfo ./.tsbuildinfo",
         "format": "pnpm exec biome format --write .",
         "format:check": "pnpm exec biome format .",
         "lint": "pnpm exec biome lint",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "ci:test": "pnpm exec turbo run typecheck:test test --filter='./packages/*' --filter='./llumiverse/*' --filter='./templates/*'",
         "ci:typecheck:test": "pnpm exec turbo run typecheck:test --filter='./packages/*' --filter='./llumiverse/*' --filter='./templates/*'",
         "clean": "rimraf ./node_modules && pnpm -r clean",
-        "clean:outputs": "pnpm -r exec rimraf ./lib ./dist ./.next ./tsconfig.tsbuildinfo ./.tsbuildinfo",
+        "clean:outputs": "pnpm -r exec rm -rf ./lib ./dist ./.next ./tsconfig.tsbuildinfo ./.tsbuildinfo",
         "format": "pnpm exec biome format --write .",
         "format:check": "pnpm exec biome format .",
         "lint": "pnpm exec biome lint",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "ci:test": "pnpm exec turbo run typecheck:test test --filter='./packages/*' --filter='./llumiverse/*' --filter='./templates/*'",
         "ci:typecheck:test": "pnpm exec turbo run typecheck:test --filter='./packages/*' --filter='./llumiverse/*' --filter='./templates/*'",
         "clean": "rimraf ./node_modules && pnpm -r clean",
+        "clean:outputs": "pnpm -r exec rimraf ./lib ./dist ./.next ./tsconfig.tsbuildinfo ./.tsbuildinfo",
         "format": "pnpm exec biome format --write .",
         "format:check": "pnpm exec biome format .",
         "lint": "pnpm exec biome lint",


### PR DESCRIPTION
## Summary
- Add a standalone clean:outputs helper for clearing generated workspace outputs when needed.
- Update the llumiverse submodule to include build graph refinements.

## Submodule Changes
- llumiverse: https://github.com/vertesia/llumiverse/pull/521

## Test Plan
- pnpm --dir composableai/llumiverse build
- pnpm --dir composableai/llumiverse typecheck:test
- pnpm run ci:build