### PR TITLE
fix(ui): gracefully overflow and prevent disappearing workstream header tabs

### DIFF
--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
@@ -2464,6 +2464,7 @@ function ModernAgentConversationInner({
             ) : (
                 <AllMessagesMixed
                     messages={displayedMessages}
+                    workstreamSourceMessages={messages}
                     bottomRef={bottomRef as React.RefObject<HTMLDivElement>}
                     isCompleted={displayedIsCompleted}
                     plan={getActivePlan.plan}

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/AllMessagesMixed.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/AllMessagesMixed.tsx
@@ -2328,8 +2328,43 @@ class MessageErrorBoundary extends Component<{ children: ReactNode }, { hasError
     }
 }
 
+// Sort chronologically, drop document-panel events + hidden types, and dedupe adjacent
+// identical messages. Shared by the rendered transcript and the workstream tab derivation.
+function sortAndDedupeMessages(messages: AgentMessage[], hiddenMessageTypes?: AgentMessageType[]): AgentMessage[] {
+    const filtered = messages.filter(
+        (message) => !isDocumentPanelEventMessage(message) && !hiddenMessageTypes?.includes(message.type),
+    );
+
+    const sorted = [...filtered].sort((a, b) => {
+        const timeA = typeof a.timestamp === 'number' ? a.timestamp : new Date(a.timestamp).getTime();
+        const timeB = typeof b.timestamp === 'number' ? b.timestamp : new Date(b.timestamp).getTime();
+        return timeA - timeB;
+    });
+
+    const deduped: AgentMessage[] = [];
+    for (const msg of sorted) {
+        const previous = deduped[deduped.length - 1];
+        if (previous && shouldCollapseAdjacentRenderedMessage(previous, msg)) {
+            continue;
+        }
+
+        if (previous && shouldDedupeAdjacentCompletedToolMessage(previous, msg)) {
+            continue;
+        }
+        deduped.push(msg);
+    }
+    return deduped;
+}
+
 interface AllMessagesMixedProps {
     messages: AgentMessage[];
+    /**
+     * Full, workstream-unfiltered message set used to derive the workstream tab list, per-tab
+     * counts, and completion status. Falls back to `messages` when omitted. The parent filters
+     * `messages` down to the active workstream, so deriving the tab list from `messages` alone
+     * makes the tabs collapse (and vanish once `main` is selected) as you navigate between them.
+     */
+    workstreamSourceMessages?: AgentMessage[];
     bottomRef: React.RefObject<HTMLDivElement>;
     viewMode?: 'stacked' | 'sliding';
     isCompleted?: boolean;
@@ -2397,6 +2432,7 @@ const SCROLL_THROTTLE_MS = 100; // Max 10 scrolls per second
 
 function AllMessagesMixedComponent({
     messages,
+    workstreamSourceMessages,
     bottomRef,
     viewMode = 'stacked',
     isCompleted = false,
@@ -2536,36 +2572,26 @@ function AllMessagesMixedComponent({
 
     // Sort all messages chronologically and dedupe adjacent identical messages
     // Low-signal messages are suppressed at the source (server-side) via shouldSuppressLowSignalMessage
-    const sortedMessages = React.useMemo(() => {
-        const filtered = messages.filter(
-            (message) => !isDocumentPanelEventMessage(message) && !hiddenMessageTypes?.includes(message.type),
-        );
+    const sortedMessages = React.useMemo(
+        () => sortAndDedupeMessages(messages, hiddenMessageTypes),
+        [messages, hiddenMessageTypes],
+    );
 
-        const sorted = [...filtered].sort((a, b) => {
-            const timeA = typeof a.timestamp === 'number' ? a.timestamp : new Date(a.timestamp).getTime();
-            const timeB = typeof b.timestamp === 'number' ? b.timestamp : new Date(b.timestamp).getTime();
-            return timeA - timeB;
-        });
-
-        const deduped: AgentMessage[] = [];
-        for (const msg of sorted) {
-            const previous = deduped[deduped.length - 1];
-            if (previous && shouldCollapseAdjacentRenderedMessage(previous, msg)) {
-                continue;
-            }
-
-            if (previous && shouldDedupeAdjacentCompletedToolMessage(previous, msg)) {
-                continue;
-            }
-            deduped.push(msg);
-        }
-        return deduped;
-    }, [messages, hiddenMessageTypes]);
+    // The workstream tabs are navigation over the WHOLE conversation, so derive them from the
+    // unfiltered source rather than `messages` (which the parent filters to the active workstream).
+    // Falling back to `sortedMessages` keeps callers that don't pass the source working unchanged.
+    const workstreamSourceSorted = React.useMemo(
+        () =>
+            workstreamSourceMessages
+                ? sortAndDedupeMessages(workstreamSourceMessages, hiddenMessageTypes)
+                : sortedMessages,
+        [workstreamSourceMessages, hiddenMessageTypes, sortedMessages],
+    );
 
     const workstreams = React.useMemo(() => {
-        const extractedWorkstreams = extractWorkstreams(sortedMessages);
+        const extractedWorkstreams = extractWorkstreams(workstreamSourceSorted);
 
-        sortedMessages.forEach((message) => {
+        workstreamSourceSorted.forEach((message) => {
             const details = getWorkstreamLaunchDetails(message) ?? getWorkstreamActivityDetails(message);
             if (!details) return;
             extractedWorkstreams.set(
@@ -2575,7 +2601,7 @@ function AllMessagesMixedComponent({
         });
 
         return extractedWorkstreams;
-    }, [sortedMessages]);
+    }, [workstreamSourceSorted]);
 
     const activeWorkstreamName = React.useMemo(() => {
         if (activeWorkstream === 'all') return undefined;
@@ -2616,17 +2642,17 @@ function AllMessagesMixedComponent({
         }
     }, [activeWorkstream, workstreams, setActiveWorkstream]);
 
-    // Count messages per workstream
+    // Count messages per workstream (from the full source so counts don't shrink to the active tab)
     const workstreamCounts = React.useMemo(() => {
         const counts = new Map<string, number>();
-        counts.set('all', sortedMessages.length);
+        counts.set('all', workstreamSourceSorted.length);
 
         // Count main messages
-        const mainMessages = filterMessagesByWorkstream(sortedMessages, 'main');
+        const mainMessages = filterMessagesByWorkstream(workstreamSourceSorted, 'main');
         counts.set('main', mainMessages.length);
 
         // Count other workstreams
-        sortedMessages.forEach((msg) => {
+        workstreamSourceSorted.forEach((msg) => {
             const workstreamId = getWorkstreamId(msg);
             if (workstreamId !== 'main') {
                 counts.set(workstreamId, (counts.get(workstreamId) || 0) + 1);
@@ -2634,7 +2660,7 @@ function AllMessagesMixedComponent({
         });
 
         return counts;
-    }, [sortedMessages]);
+    }, [workstreamSourceSorted]);
 
     // Filter messages based on active workstream
     const displayMessages = React.useMemo(() => {
@@ -2869,7 +2895,7 @@ function AllMessagesMixedComponent({
         // Group messages by workstream
         const workstreamMessages = new Map<string, AgentMessage[]>();
 
-        sortedMessages.forEach((message) => {
+        workstreamSourceSorted.forEach((message) => {
             const workstreamId = getWorkstreamId(message);
             if (!workstreamMessages.has(workstreamId)) {
                 workstreamMessages.set(workstreamId, []);
@@ -2905,7 +2931,7 @@ function AllMessagesMixedComponent({
         }
 
         return statusMap;
-    }, [sortedMessages]);
+    }, [workstreamSourceSorted]);
 
     return (
         <div

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/WorkstreamTabs.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/WorkstreamTabs.tsx
@@ -1,7 +1,8 @@
 import type { AgentMessage } from '@vertesia/common';
-import { Button, cn } from '@vertesia/ui/core';
+import { cn, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@vertesia/ui/core';
 import { i18nInstance, NAMESPACE, useUITranslation } from '@vertesia/ui/i18n';
-import { CheckCircle, Clock } from 'lucide-react';
+import { CheckCircle, ChevronDown, Clock } from 'lucide-react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { getWorkstreamId } from './utils';
 
 interface WorkstreamTabsProps {
@@ -10,6 +11,324 @@ interface WorkstreamTabsProps {
     onSelectWorkstream: (id: string) => void;
     count?: Map<string, number>; // Optional count of messages per workstream
     completionStatus?: Map<string, boolean>; // Optional completion status per workstream
+}
+
+// Tab-item styling for the header workstream bar: filled `bg-info` active pill with
+// count badges and completion icons (distinct from the right panel's underline tabs).
+const TAB_ITEM_BASE =
+    'flex items-center gap-1.5 px-2 py-1 text-xs font-medium whitespace-nowrap transition-colors border-b-2 shrink-0 cursor-pointer';
+const TAB_ITEM_INACTIVE = 'border-transparent text-muted hover:bg-muted';
+const TAB_ITEM_ACTIVE = 'border-info bg-info text-info';
+const TAB_GAP_PX = 4; // matches the `gap-1` between tab items
+
+// Shorten long workstream names for the tab row.
+function truncateName(name: string) {
+    return name.length > 20 ? `${name.substring(0, 18)}...` : name;
+}
+
+type WorkstreamEntry = [id: string, name: string];
+
+interface WorkstreamMoreMenuProps {
+    /** The overflowed workstream entries to list inside the menu. */
+    items: WorkstreamEntry[];
+    current: string;
+    onSelect: (id: string) => void;
+    label: string;
+    /** Whether the active workstream is one of the overflowed entries. */
+    active: boolean;
+    count?: Map<string, number>;
+    completionStatus?: Map<string, boolean>;
+}
+
+/** Trailing "More" dropdown of overflowed workstream tabs; opens on hover, click, or keyboard. */
+function WorkstreamMoreMenu({
+    items,
+    current,
+    onSelect,
+    label,
+    active,
+    count,
+    completionStatus,
+}: WorkstreamMoreMenuProps) {
+    const [open, setOpen] = useState(false);
+    const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const openedByHover = useRef(false);
+
+    const cancelClose = () => {
+        if (closeTimer.current) {
+            clearTimeout(closeTimer.current);
+            closeTimer.current = null;
+        }
+    };
+    const openOnHover = () => {
+        cancelClose();
+        openedByHover.current = true;
+        setOpen(true);
+    };
+    // Delay the close so the pointer can travel across the gap onto the menu.
+    const closeAfterDelay = () => {
+        cancelClose();
+        closeTimer.current = setTimeout(() => setOpen(false), 150);
+    };
+
+    // Clear any pending close timer on unmount.
+    useEffect(() => () => clearTimeout(closeTimer.current ?? undefined), []);
+
+    return (
+        // Non-modal: a modal menu sets body `pointer-events: none` while open, which makes
+        // the hover open/close flap. It still closes on outside-click / Escape.
+        <DropdownMenu
+            modal={false}
+            open={open}
+            onOpenChange={(next) => {
+                // Fired by click / keyboard / dismiss (not by hover); keep our state in sync.
+                cancelClose();
+                if (next) openedByHover.current = false;
+                setOpen(next);
+            }}
+        >
+            <DropdownMenuTrigger asChild>
+                {/* Tab-bar primitive: raw button is the menu trigger (asChild). */}
+                <button
+                    type="button"
+                    onMouseEnter={openOnHover}
+                    onMouseLeave={closeAfterDelay}
+                    className={cn(TAB_ITEM_BASE, active ? TAB_ITEM_ACTIVE : TAB_ITEM_INACTIVE)}
+                >
+                    {label}
+                    <ChevronDown className="ms-0.5 size-3.5" />
+                </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+                align="end"
+                className="w-max"
+                onMouseEnter={cancelClose}
+                onMouseLeave={closeAfterDelay}
+                onCloseAutoFocus={(e) => {
+                    // Keep hover-opens from returning the focus ring to the trigger.
+                    if (openedByHover.current) e.preventDefault();
+                }}
+            >
+                {items.map(([id, name]) => {
+                    // biome-ignore lint/style/noNonNullAssertion: guarded by count?.has(id).
+                    const showCount = count?.has(id) && count.get(id)! > 0;
+                    return (
+                        <DropdownMenuItem
+                            key={id}
+                            onClick={() => onSelect(id)}
+                            className={cn('flex items-center gap-2', id === current && 'text-info')}
+                        >
+                            <span className="truncate">{name}</span>
+                            {showCount && (
+                                <span className="ms-auto inline-flex items-center gap-1">
+                                    <span className="inline-flex items-center justify-center rounded-full bg-muted px-1.5 text-[10px] text-muted">
+                                        {count?.get(id)}
+                                    </span>
+                                    {completionStatus &&
+                                        id !== 'all' &&
+                                        (completionStatus.get(id) ? (
+                                            <CheckCircle className="size-3 text-success" />
+                                        ) : (
+                                            <Clock className="size-3 text-attention" />
+                                        ))}
+                                </span>
+                            )}
+                        </DropdownMenuItem>
+                    );
+                })}
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+}
+
+interface WorkstreamOverflowBarProps {
+    entries: WorkstreamEntry[];
+    activeWorkstream: string;
+    onSelectWorkstream: (id: string) => void;
+    count?: Map<string, number>;
+    completionStatus?: Map<string, boolean>;
+}
+
+/**
+ * Workstream tabs as a horizontal row; any that don't fit collapse into a trailing
+ * "More" dropdown. The visible/overflow split is measured from a hidden full-width row,
+ * and the active tab is always promoted into view so it can never hide in the menu.
+ */
+function WorkstreamOverflowBar({
+    entries,
+    activeWorkstream,
+    onSelectWorkstream,
+    count,
+    completionStatus,
+}: WorkstreamOverflowBarProps) {
+    const { t } = useUITranslation();
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+    const moreRef = useRef<HTMLButtonElement | null>(null);
+    // `count` leading tabs are shown. When `promote` is set, the active tab is pulled
+    // into the last slot (before More) and `count` counts the tabs shown before it.
+    const [layout, setLayout] = useState<{ count: number; promote: boolean }>({
+        count: entries.length,
+        promote: false,
+    });
+
+    const recompute = () => {
+        const container = containerRef.current;
+        if (!container) return;
+        const containerWidth = container.clientWidth;
+        const widths = entries.map((_, i) => itemRefs.current[i]?.offsetWidth ?? 0);
+        const totalAll = widths.reduce((sum, w) => sum + w, 0) + TAB_GAP_PX * Math.max(0, entries.length - 1);
+
+        // How many tabs (in order, optionally skipping one) fit within `available`.
+        const fitCount = (available: number, skipIndex: number) => {
+            let used = 0;
+            let fitted = 0;
+            for (let i = 0; i < entries.length; i++) {
+                if (i === skipIndex) continue;
+                const cand = used + (fitted > 0 ? TAB_GAP_PX : 0) + widths[i];
+                if (cand > available) break;
+                used = cand;
+                fitted += 1;
+            }
+            return fitted;
+        };
+
+        let next: { count: number; promote: boolean };
+        if (totalAll <= containerWidth) {
+            next = { count: entries.length, promote: false };
+        } else {
+            const moreWidth = moreRef.current?.offsetWidth ?? 0;
+            const naturalCount = Math.max(1, fitCount(containerWidth - moreWidth - TAB_GAP_PX, -1));
+            const activeIndex = entries.findIndex(([id]) => id === activeWorkstream);
+            if (activeIndex < 0 || activeIndex < naturalCount) {
+                next = { count: naturalCount, promote: false };
+            } else {
+                // Active tab overflowed: reserve its slot at the end, fit leading tabs before it.
+                const leadAvailable = containerWidth - moreWidth - widths[activeIndex] - TAB_GAP_PX * 2;
+                next = { count: fitCount(leadAvailable, activeIndex), promote: true };
+            }
+        }
+        setLayout((prev) => (prev.count === next.count && prev.promote === next.promote ? prev : next));
+    };
+
+    // Re-measure after every render (tab/label changes) and on container resize.
+    const recomputeRef = useRef(recompute);
+    recomputeRef.current = recompute;
+    useLayoutEffect(() => {
+        recomputeRef.current();
+    });
+    useEffect(() => {
+        const container = containerRef.current;
+        if (!container || typeof ResizeObserver === 'undefined') return;
+        const observer = new ResizeObserver(() => recomputeRef.current());
+        observer.observe(container);
+        return () => observer.disconnect();
+    }, []);
+
+    const activeIndex = entries.findIndex(([id]) => id === activeWorkstream);
+    let visible: WorkstreamEntry[];
+    let overflow: WorkstreamEntry[];
+    if (layout.promote && activeIndex >= 0) {
+        // Pull the active tab into the last visible slot; the tab it displaces overflows.
+        const others = entries.filter((_, i) => i !== activeIndex);
+        visible = [...others.slice(0, layout.count), entries[activeIndex]];
+        overflow = others.slice(layout.count);
+    } else {
+        visible = entries.slice(0, layout.count);
+        overflow = entries.slice(layout.count);
+    }
+    const activeInOverflow = overflow.some(([id]) => id === activeWorkstream);
+    const moreLabel = t('agent.moreTabs');
+
+    // Inner tab content (name + count badge + completion icon), shared by the hidden
+    // measurement row and the visible row so their measured widths match.
+    const renderTabInner = (id: string, name: string, isActive: boolean) => {
+        // biome-ignore lint/style/noNonNullAssertion: guarded by count?.has(id).
+        const showCount = count?.has(id) && count.get(id)! > 0;
+        return (
+            <>
+                {truncateName(name)}
+                {showCount && (
+                    <span className="flex items-center gap-1">
+                        <span
+                            className={cn(
+                                'inline-flex items-center justify-center p-1 text-xs rounded-full',
+                                isActive ? 'bg-info text-info' : 'bg-muted text-muted',
+                            )}
+                        >
+                            {count?.get(id)}
+                        </span>
+                        {/* Show completion status indicator if we have it and it's not 'all' */}
+                        {completionStatus &&
+                            id !== 'all' &&
+                            (completionStatus.get(id) ? (
+                                <CheckCircle className="size-3 text-success" />
+                            ) : (
+                                <Clock className="size-3 text-attention" />
+                            ))}
+                    </span>
+                )}
+            </>
+        );
+    };
+
+    return (
+        <div ref={containerRef} className="relative mb-1 bg-muted border-b border-muted/20">
+            {/* Hidden measurement row: all tabs + More at natural width, kept separate
+                from the visible row so measuring can't feed back into the layout. */}
+            <div aria-hidden className="pointer-events-none invisible absolute start-0 top-0 flex w-max gap-1">
+                {entries.map(([id, name], i) => (
+                    <button
+                        type="button"
+                        key={id}
+                        tabIndex={-1}
+                        ref={(el) => {
+                            itemRefs.current[i] = el;
+                        }}
+                        className={cn(TAB_ITEM_BASE, TAB_ITEM_INACTIVE)}
+                    >
+                        {renderTabInner(id, name, false)}
+                    </button>
+                ))}
+                <button type="button" tabIndex={-1} ref={moreRef} className={cn(TAB_ITEM_BASE, TAB_ITEM_INACTIVE)}>
+                    {moreLabel}
+                    <ChevronDown className="ms-0.5 size-3.5" />
+                </button>
+            </div>
+
+            {/* Visible row */}
+            <div className="flex gap-1 overflow-hidden">
+                {visible.map(([id, name]) => {
+                    const isActive = activeWorkstream === id;
+                    return (
+                        // Tab-bar primitive: raw button mirrors the filled active-pill styling.
+                        <button
+                            type="button"
+                            key={id}
+                            aria-current={isActive ? 'page' : undefined}
+                            onClick={() => onSelectWorkstream(id)}
+                            title={name.length > 20 ? name : undefined}
+                            className={cn(TAB_ITEM_BASE, isActive ? TAB_ITEM_ACTIVE : TAB_ITEM_INACTIVE)}
+                        >
+                            {renderTabInner(id, name, isActive)}
+                        </button>
+                    );
+                })}
+
+                {overflow.length > 0 && (
+                    <WorkstreamMoreMenu
+                        items={overflow}
+                        current={activeWorkstream}
+                        onSelect={onSelectWorkstream}
+                        label={moreLabel}
+                        active={activeInOverflow}
+                        count={count}
+                        completionStatus={completionStatus}
+                    />
+                )}
+            </div>
+        </div>
+    );
 }
 
 /**
@@ -58,46 +377,13 @@ export default function WorkstreamTabs({
     }
 
     return (
-        <div className="flex overflow-x-auto gap-1 mb-1 bg-muted border-b border-muted/20 sticky top-0 z-10">
-            {sortedWorkstreams.map(([id, name]) => (
-                <Button
-                    variant="unstyled"
-                    key={id}
-                    className={cn(
-                        'px-2 py-1 text-xs font-medium whitespace-nowrap transition-colors flex items-center gap-1.5',
-                        activeWorkstream === id
-                            ? 'bg-info text-info border-b-2 border-info'
-                            : 'text-muted hover:bg-muted border-b-2 border-transparent',
-                    )}
-                    onClick={() => onSelectWorkstream(id)}
-                    title={name.length > 20 ? name : undefined}
-                >
-                    {/* Shorten long names for better UI */}
-                    {name.length > 20 ? `${name.substring(0, 18)}...` : name}
-                    {/* biome-ignore lint/style/noNonNullAssertion: intentional non-null assertion; TS can't prove narrowing here */}
-                    {count?.has(id) && count.get(id)! > 0 && (
-                        <div className="flex items-center gap-1">
-                            <span
-                                className={cn(
-                                    'inline-flex items-center justify-center p-1 text-xs rounded-full',
-                                    activeWorkstream === id ? 'bg-info text-info' : 'bg-muted text-muted',
-                                )}
-                            >
-                                {count.get(id)}
-                            </span>
-                            {/* Show completion status indicator if we have it and it's not 'all' */}
-                            {completionStatus &&
-                                id !== 'all' &&
-                                (completionStatus.get(id) ? (
-                                    <CheckCircle className="size-3 text-success" />
-                                ) : (
-                                    <Clock className="size-3 text-attention" />
-                                ))}
-                        </div>
-                    )}
-                </Button>
-            ))}
-        </div>
+        <WorkstreamOverflowBar
+            entries={sortedWorkstreams}
+            activeWorkstream={activeWorkstream}
+            onSelectWorkstream={onSelectWorkstream}
+            count={count}
+            completionStatus={completionStatus}
+        />
     );
 }
 


### PR DESCRIPTION
## TL;DR

- Workstream header tabs could overflow off-screen with no way to reach them — they now collapse into a trailing "More" menu, same overflow pattern as the side panel's tabs.
- Selecting a workstream (e.g. Main) made the whole tab bar vanish — tabs are now derived from the full conversation instead of the active workstream's filtered view, so the bar and its counts stay put.

## Summary

Two fixes to the workstream header tabs in the agent conversation (stacked/verbose view), where a run with many parallel workstreams made tabs unreachable or made the whole bar disappear:

- **Overflow gracefully into a "More" menu** (`WorkstreamTabs.tsx`): the bar was a plain `overflow-x-auto` flex row, so tabs past the container width scrolled off-screen with no reachable affordance (no visible scrollbar, no overflow menu). Ported the measured-overflow pattern already used by the right panel's tab bar: a hidden measurement row drives a measure→collapse split, overflowed tabs land in a trailing "More" dropdown (hover/click/keyboard, non-modal, 150ms close grace), and the active tab is promoted into the last visible slot so it can never hide inside the menu. The bar's existing look is preserved (filled active pill, count badges, completion icons, name truncation).
- **Derive the tab list from the full conversation, not the active filter** (`AllMessagesMixed.tsx`, `ModernAgentConversation.tsx`): the tab list, per-tab counts, and completion status were computed from `messages`, which the parent pre-filters to the active workstream. Switching tabs shrank the bar to the current view, and selecting **Main** dropped the derived set to ≤2 workstreams — hiding the entire bar with no way back. `ModernAgentConversation` now passes the unfiltered set via a new optional `workstreamSourceMessages` prop, and the tab derivation uses it while the transcript stays filtered. The prop falls back to `messages`, so existing callers are unchanged.

## Notes for review

- The second commit's only relocation of existing code is the 23-line sort/dedupe memo body extracted verbatim to `sortAndDedupeMessages` (needed by both the transcript and the tab derivation). `git show --color-moved=dimmed-zebra f0c3a98` renders it as moved lines, not new logic.
- `extractWorkstreams`, `filterMessagesByWorkstream`, the ≤2-workstream empty state, and the `WorkstreamTabs` props contract are all unchanged.

## Verification

- `pnpm build` in `packages/ui` (locale check, strict RTL-class check, `tsc`, rollup): ✅
- `pnpm lint` in `packages/ui` (Biome, 485 files + RTL check): ✅ clean
- `vitest run src/features/agent/chat`: ✅ 13 files, 208 tests passed
- Manual browser verification against a live agent run with 30 workstreams: tabs collapse into "More" instead of scrolling off-screen; selecting an overflowed workstream promotes it into view; switching Ws→Main keeps the full bar with stable counts (previously the bar vanished entirely).


## Screenshots

### Overflow Behavior

<img width="1701" height="1216" alt="image" src="https://github.com/user-attachments/assets/2fc5907e-3d35-447b-94e6-9e6fe70cbf0d" />

### Tab Selection

<img width="1698" height="1212" alt="image" src="https://github.com/user-attachments/assets/b72c353c-edba-4daa-899d-635fe0a9b5b7" />
