### PR TITLE
fix(agent-ui): keyboard Enter no longer clears composer text while files upload

### DIFF
--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageInput.test.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageInput.test.tsx
@@ -54,6 +54,31 @@ describe('MessageInput', () => {
         expect(onFilesSelected).toHaveBeenCalledWith([file]);
     });
 
+    it('does not send or clear the text when Enter is pressed while files are still processing', () => {
+        const onSend = vi.fn();
+        renderWithProviders(<MessageInput onSend={onSend} onFilesSelected={vi.fn()} hasProcessingFiles />);
+
+        const textbox = screen.getByRole('textbox') as HTMLTextAreaElement;
+        fireEvent.change(textbox, { target: { value: 'please analyze this' } });
+        fireEvent.keyDown(textbox, { key: 'Enter' });
+
+        expect(onSend).not.toHaveBeenCalled();
+        // The typed text must be retained so the user doesn't have to re-type it.
+        expect(textbox.value).toBe('please analyze this');
+    });
+
+    it('sends and clears the text on Enter once files have finished processing', () => {
+        const onSend = vi.fn();
+        renderWithProviders(<MessageInput onSend={onSend} onFilesSelected={vi.fn()} />);
+
+        const textbox = screen.getByRole('textbox') as HTMLTextAreaElement;
+        fireEvent.change(textbox, { target: { value: 'please analyze this' } });
+        fireEvent.keyDown(textbox, { key: 'Enter' });
+
+        expect(onSend).toHaveBeenCalledWith('please analyze this');
+        expect(textbox.value).toBe('');
+    });
+
     it('renders attachment actions before the MCP slot', () => {
         renderWithProviders(<MessageInput onSend={vi.fn()} mcpSlot={<button type="button">MCP</button>} isCompleted />);
 

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageInput.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageInput.tsx
@@ -346,7 +346,11 @@ export default function MessageInput({
 
     const handleSend = () => {
         const message = value.trim();
-        if (!message || disabled || isSending) return;
+        // Mirror the send button's disabled condition so the keyboard (Enter) path can't
+        // dispatch a send that the parent will reject while files are still uploading —
+        // otherwise the text would be cleared below and lost. The disabled button + its
+        // "wait for files" tooltip already explain why Enter does nothing here.
+        if (!message || disabled || isSending || hasProcessingFiles) return;
 
         onSend(message);
         setValue('');


### PR DESCRIPTION
## Summary

In the agent chat composer (`MessageInput`), the send **button** is correctly disabled while attached files are still uploading or processing (`hasProcessingFiles`). But `handleSend` — which the **Enter** key calls — did not check that condition:

- Pressing Enter while files were processing dispatched `onSend(...)` and immediately cleared the textarea (`setValue('')`).
- The parent then rejected the send with a "Files Still Processing" warning and returned without sending.
- Net effect: the message was **not** sent **and** the typed text was destroyed, forcing the user to re-type.

This adds `hasProcessingFiles` to `handleSend`'s guard so the keyboard path matches the button. Enter is now a no-op while files process: nothing is sent and the text is retained; the already-disabled button and its "wait for files to finish processing" tooltip explain why. The parent-level warning toast is kept as a safety net for inline-action callers that reach the send handler directly.

## Test Plan

- [x] Added regression tests in `MessageInput.test.tsx`:
  - Enter while `hasProcessingFiles` → `onSend` not called, textarea text preserved
  - Enter after processing finishes → `onSend` called, textarea cleared (unchanged behavior)
- [x] `vitest run` for `MessageInput.test.tsx` — 11 passed
- [x] Full agent-chat suite (`src/features/agent/chat/`) — 210 passed
- [x] `biome check` on changed files — clean
- [x] `typecheck:test` — clean
- [x] `pnpm build` for `@vertesia/ui` — clean