### PR TITLE
fix(backport): keep submodule pointers pinned to the target line

### DIFF
--- a/.github/bin/backport-gitlink.test.sh
+++ b/.github/bin/backport-gitlink.test.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKPORT_SH="${BACKPORT_SH:-${ROOT}/.github/bin/backport.sh}"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/backport-gitlink-test.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+export MERGE_SHA="test-merge-sha"
+export RUN_URL="https://example.invalid/backport-run"
+NORMALIZE_OUTPUT=""
+NORMALIZE_STATUS=0
+TEST_DIR=""
+SUB_A=""
+SUB_B=""
+
+comment_original() {
+    :
+}
+
+load_backport_function() {
+    local name="$1" body
+    body="$(sed -n "/^${name}()/,/^}/p" "$BACKPORT_SH")"
+    if [ -z "$body" ]; then
+        echo "Could not load ${name} from ${BACKPORT_SH}" >&2
+        exit 1
+    fi
+    eval "$body"
+}
+
+load_optional_backport_function() {
+    local name="$1" body
+    body="$(sed -n "/^${name}()/,/^}/p" "$BACKPORT_SH")"
+    [ -z "$body" ] || eval "$body"
+}
+
+load_optional_backport_function gitlink_at
+load_backport_function normalize_gitlinks_to_target
+
+new_repo() {
+    local name="$1" empty_tree
+    TEST_DIR="${TMP_ROOT}/${name}"
+    mkdir -p "$TEST_DIR"
+    cd "$TEST_DIR"
+    git init -q
+    git config user.email "backport-test@example.invalid"
+    git config user.name "Backport Test"
+
+    empty_tree="4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+    SUB_A="$(git commit-tree "$empty_tree" -m "submodule-a")"
+    SUB_B="$(git commit-tree "$empty_tree" -p "$SUB_A" -m "submodule-b")"
+}
+
+write_gitmodules() {
+    cat >.gitmodules <<'EOF'
+[submodule "composableai"]
+	path = composableai
+	url = https://example.invalid/composableai
+EOF
+}
+
+add_gitlink() {
+    git update-index --add --cacheinfo "160000,$1,composableai"
+}
+
+set_gitlink() {
+    git update-index --cacheinfo "160000,$1,composableai"
+}
+
+tree_mode() {
+    git ls-tree "$1" -- "$2" | awk '{print $1}'
+}
+
+tree_oid() {
+    git ls-tree "$1" -- "$2" | awk '{print $3}'
+}
+
+create_target_with_submodule() {
+    write_gitmodules
+    printf 'base\n' >file.txt
+    git add .gitmodules file.txt
+    add_gitlink "$SUB_A"
+    git commit -q -m "base"
+    git branch target
+    git update-ref refs/remotes/origin/target target
+    git checkout -q -b source
+}
+
+create_target_without_submodule() {
+    printf 'base\n' >file.txt
+    git add file.txt
+    git commit -q -m "base"
+    git branch target
+    git update-ref refs/remotes/origin/target target
+    git checkout -q -b source
+}
+
+cherry_pick_source_onto_target() {
+    local source_sha
+    source_sha="$(git rev-parse HEAD)"
+    git checkout -q -B work refs/remotes/origin/target
+    git cherry-pick "$source_sha" >/dev/null
+}
+
+run_normalize_like_backport_one() {
+    local output_file="${TEST_DIR}/normalize.out"
+    # backport_one calls this helper as an if-condition, which is important:
+    # bash suppresses errexit in that call path. Keep the same shape here.
+    if normalize_gitlinks_to_target target >"$output_file" 2>&1; then
+        NORMALIZE_STATUS=0
+    else
+        NORMALIZE_STATUS=$?
+    fi
+    NORMALIZE_OUTPUT="$(cat "$output_file")"
+}
+
+assert_eq() {
+    local expected="$1" actual="$2" message="$3"
+    if [ "$expected" != "$actual" ]; then
+        printf '  %s\n  expected: %s\n  actual:   %s\n' "$message" "$expected" "$actual" >&2
+        return 1
+    fi
+}
+
+assert_diff_quiet() {
+    local left="$1" right="$2" message="$3"
+    if ! git diff --quiet "$left" "$right"; then
+        printf '  %s\n' "$message" >&2
+        git diff --name-status "$left" "$right" >&2
+        return 1
+    fi
+}
+
+assert_normalize_status() {
+    local expected="$1" message="$2"
+    if [ "$expected" != "$NORMALIZE_STATUS" ]; then
+        printf '  %s\n  expected status: %s\n  actual status:   %s\n' \
+            "$message" "$expected" "$NORMALIZE_STATUS" >&2
+        if [ -n "$NORMALIZE_OUTPUT" ]; then
+            printf '  normalizer output:\n%s\n' "$NORMALIZE_OUTPUT" >&2
+        fi
+        return 1
+    fi
+}
+
+test_clean_gitlink_bump_resets_to_target() {
+    new_repo "clean-bump"
+    create_target_with_submodule
+    printf 'source\n' >file.txt
+    git add file.txt
+    set_gitlink "$SUB_B"
+    git commit -q -m "source file plus submodule bump"
+
+    cherry_pick_source_onto_target
+    run_normalize_like_backport_one
+
+    assert_normalize_status "0" "normalizer should succeed"
+    assert_eq "$SUB_A" "$(tree_oid HEAD composableai)" "gitlink should be reset to target pointer"
+    assert_eq "source" "$(cat file.txt)" "real file change should remain"
+    assert_eq $'M\tfile.txt' "$(git diff --name-status refs/remotes/origin/target HEAD)" \
+        "only the real file should differ from target"
+}
+
+test_submodule_only_bump_becomes_noop() {
+    new_repo "submodule-only"
+    create_target_with_submodule
+    set_gitlink "$SUB_B"
+    git commit -q -m "submodule only bump"
+
+    cherry_pick_source_onto_target
+    run_normalize_like_backport_one
+
+    assert_normalize_status "0" "normalizer should succeed"
+    assert_eq "$SUB_A" "$(tree_oid HEAD composableai)" "gitlink should be reset to target pointer"
+    assert_diff_quiet refs/remotes/origin/target HEAD "submodule-only backport should normalize to no diff"
+}
+
+test_submodule_add_fails_closed() {
+    new_repo "submodule-add"
+    create_target_without_submodule
+    write_gitmodules
+    git add .gitmodules
+    add_gitlink "$SUB_B"
+    git commit -q -m "add submodule"
+
+    cherry_pick_source_onto_target
+    run_normalize_like_backport_one
+
+    assert_normalize_status "1" "normalizer should fail closed on submodule add"
+}
+
+test_submodule_remove_fails_closed() {
+    new_repo "submodule-remove"
+    create_target_with_submodule
+    git rm -q .gitmodules composableai
+    git commit -q -m "remove submodule"
+
+    cherry_pick_source_onto_target
+    run_normalize_like_backport_one
+
+    assert_normalize_status "1" "normalizer should fail closed on submodule removal"
+}
+
+test_submodule_replaced_by_directory_fails_closed() {
+    new_repo "submodule-replaced-by-directory"
+    create_target_with_submodule
+    git rm -q --cached composableai
+    mkdir composableai
+    printf 'replacement\n' >composableai/file.txt
+    git add composableai/file.txt
+    git commit -q -m "replace submodule with directory"
+
+    cherry_pick_source_onto_target
+    run_normalize_like_backport_one
+
+    assert_normalize_status "1" "normalizer should fail closed when a submodule becomes a directory"
+    assert_eq "160000" "$(tree_mode refs/remotes/origin/target composableai)" \
+        "target fixture should still be a gitlink"
+}
+
+run_test() {
+    local name="$1" status
+    shift
+    set +e
+    ( set -euo pipefail; "$@" )
+    status=$?
+    set -e
+    if [ "$status" -eq 0 ]; then
+        echo "ok - ${name}"
+    else
+        echo "not ok - ${name}"
+        failures=$((failures + 1))
+    fi
+}
+
+failures=0
+run_test "clean gitlink bump resets to target" test_clean_gitlink_bump_resets_to_target
+run_test "submodule-only bump becomes no-op" test_submodule_only_bump_becomes_noop
+run_test "submodule add fails closed" test_submodule_add_fails_closed
+run_test "submodule removal fails closed" test_submodule_remove_fails_closed
+run_test "submodule replaced by directory fails closed" test_submodule_replaced_by_directory_fails_closed
+
+if [ "$failures" -ne 0 ]; then
+    echo "${failures} backport gitlink test(s) failed." >&2
+    exit 1
+fi
+
+echo "All backport gitlink tests passed."

--- a/.github/bin/backport.sh
+++ b/.github/bin/backport.sh
@@ -7,9 +7,12 @@
 # `main` (label `backport/main`). Also supports `main -> release/X.Y` and
 # `release/X.Y -> release/X.Z`.
 #
-#   Clean cherry-pick  -> a ready-to-merge PR into <target>.
-#   Conflicting pick   -> conflict markers are committed and a DRAFT PR is opened,
-#                         with resolution steps posted back on the original PR.
+#   Clean cherry-pick     -> a ready-to-merge PR into <target>.
+#   Gitlink-only conflict -> the submodule pointer is pinned to the target's OWN
+#                            commit (ours), never the source's, and a normal
+#                            (auto-merging) PR is opened.
+#   Real file conflict    -> conflict markers are committed and a DRAFT PR is opened,
+#                            with resolution steps posted back on the original PR.
 #
 # Required env:
 #   GH_TOKEN         App token with contents:write + pull-requests:write on REPO
@@ -83,9 +86,10 @@ Backport of #${PR_NUMBER} to \`${target}\`. :warning: **The cherry-pick had conf
 
 What was committed so the branch exists for you to fix:
 - **Regular-file conflicts** kept their \`<<<<<<<\` markers — resolve them.
-- **Submodule (gitlink) conflicts** were set to the submodule's \`${target}\` HEAD
-  (e.g. composableai \`main\`) — verify the pointer is the one you want (this
-  assumes the matching submodule change was already backported there).
+- **Submodule (gitlink) conflicts** were pinned to this branch's own \`${target}\`
+  pointer (ours); the source branch's submodule commit is intentionally discarded
+  so it can't leak in. If this backport actually needs a newer submodule commit,
+  backport that submodule change on its own line first.
 - **Structural conflicts** (renames/deletes) were auto-resolved to the incoming
   side — review the full diff, not just the markers.
 
@@ -203,32 +207,102 @@ finalize_pr() {
     return 0
 }
 
-# Resolve unmerged submodule gitlinks (mode 160000) at the index level — the
-# submodule isn't checked out, so they can't be `git add`ed. Point each at the
-# submodule's HEAD on the SAME branch as the backport target (e.g. composableai
-# `main` for a backport to main), so the pointer matches this branch's line rather
-# than carrying the source line's commit. Assumes the matching submodule change
-# was already backported there; the draft PR flags it for verification.
+# Resolve unmerged submodule gitlinks (mode 160000) by pinning each to OURS — the
+# pointer already recorded on the backport target branch. This is the guarantee
+# that a source-branch submodule commit can NEVER leak onto the backport branch:
+# main and release/X.Y legitimately track different composableai/llumiverse
+# commits, so a forward-port must not downgrade the target's pointer and a
+# back-port must not pull an unreleased one. The submodule isn't checked out, so
+# this is done at the index level (an unchecked-out submodule can't be `git add`ed);
+# stage 2 of the unmerged entry is "ours" (== HEAD:<gl>, since HEAD is still the
+# target tip mid-cherry-pick). If this backport genuinely needs a newer submodule
+# commit, that submodule change must be backported on its own line first.
+#
+# A gitlink with no "ours" pointer (a structural add/delete on the submodule path)
+# is left unmerged on purpose — the caller treats it as a manual conflict rather
+# than ever taking the source (theirs) pointer.
 resolve_gitlink_conflicts() {
-    local target="$1" gl name url sha
+    local target="$1" gl ours
     while IFS= read -r gl; do
         [ -n "$gl" ] || continue
-        name="$(git config -f .gitmodules --get-regexp '^submodule\..*\.path$' 2>/dev/null \
-            | awk -v p="$gl" '$2==p{print $1}' | sed -E 's/^submodule\.(.+)\.path$/\1/' | head -1)"
-        url=""
-        [ -n "$name" ] && url="$(git config -f .gitmodules --get "submodule.${name}.url" 2>/dev/null)"
-        if [ -z "$url" ]; then
-            echo "::warning::No .gitmodules URL for gitlink '${gl}'; leaving it unmerged."
+        ours="$(git ls-files --unmerged -- "$gl" | awk '$3=="2"{print $2; exit}')"
+        [ -n "$ours" ] || ours="$(git rev-parse --verify --quiet "HEAD:${gl}" 2>/dev/null || true)"
+        if [ -z "$ours" ]; then
+            echo "::warning::Gitlink '${gl}' has no 'ours' pointer on ${target} (structural submodule conflict); leaving it unmerged."
             continue
         fi
-        sha="$(git ls-remote "$url" "refs/heads/${target}" 2>/dev/null | awk 'NR==1{print $1}')"
-        if [ -z "$sha" ]; then
-            echo "::warning::Could not read '${gl}' ${target} HEAD from ${url}; leaving it unmerged."
-            continue
-        fi
-        git update-index --cacheinfo "160000,${sha},${gl}"
-        echo "Set gitlink '${gl}' to its ${target} HEAD ${sha:0:12} (${url})."
+        git update-index --cacheinfo "160000,${ours},${gl}"
+        echo "Pinned gitlink '${gl}' to the ${target} pointer ${ours:0:12} (ours; source pointer discarded)."
     done < <(git ls-files --unmerged | awk '$1=="160000"{print $4}' | sort -u)
+}
+
+# Echo the commit recorded at <path> in <ref> IFF that path is a submodule there
+# (tree mode 160000); empty otherwise — a blob, a plain directory (tree), or absent.
+# Deliberately mode-aware, NOT `rev-parse <ref>:<path>`: rev-parse returns a SHA for
+# a directory or file too, which would hide a submodule replaced by a plain
+# directory (the gitlink is gone, but rev-parse still yields the directory's tree
+# SHA and the caller would think the submodule is still present).
+gitlink_at() {
+    git ls-tree "$1" -- "$2" 2>/dev/null | awk '$1=="160000"{print $3; exit}'
+}
+
+# Enforce the submodule invariant across the WHOLE tree, on EVERY cherry-pick path:
+# the backport's submodule set (which submodules exist, and the commit each points
+# at) MUST end up identical to the target branch's. A submodule change rides its own
+# line, never a file backport. This is needed because a gitlink can move with NO
+# conflict — when the target pointer equals the source commit's parent pointer, git
+# applies the source bump cleanly and `resolve_gitlink_conflicts` never sees it.
+#
+#   * repointed (a 160000 gitlink on BOTH sides, different sha) -> reset to ours.
+#   * added / removed / replaced (a 160000 gitlink on only ONE side — the other is
+#     absent, a file, or a plain directory) -> fail closed; a structural submodule
+#     change must be cherry-picked by hand, never auto-merged.
+#
+# Enumerates gitlinks from the tree of BOTH origin/<target> and HEAD (their union),
+# not from .gitmodules — a deletion/replacement drops the .gitmodules stanza too, so
+# a .gitmodules-only walk would miss it. Presence is decided mode-aware via
+# gitlink_at (see above). Amends HEAD when it resets a pointer (--allow-empty: a
+# source commit that only bumped a submodule normalizes to a no-op, then dropped by
+# the "no net change" check below). Every mutating git call is checked explicitly:
+# this runs under `if ! normalize_gitlinks_to_target`, which disables errexit inside
+# the whole function body, so a silent failure would otherwise slip through.
+normalize_gitlinks_to_target() {
+    local target="$1" gl ours cur corrected=0
+    while IFS= read -r gl; do
+        [ -n "$gl" ] || continue
+        cur="$(gitlink_at HEAD "$gl")"
+        ours="$(gitlink_at "origin/${target}" "$gl")"
+        [ "$cur" != "$ours" ] || continue               # same submodule pointer (or neither a gitlink here): fine
+        if [ -z "$ours" ] || [ -z "$cur" ]; then
+            # One side is not a 160000 gitlink at this path: the backport adds,
+            # removes, or REPLACES the submodule (e.g. with a plain directory).
+            # Never let a structural submodule change ride an auto-merge — hand off.
+            echo "::error::Backport to ${target} adds, removes, or replaces submodule '${gl}' (not a 160000 gitlink on both sides); refusing to auto-resolve a structural submodule change." >&2
+            comment_original ":x: Backport to \`${target}\` would add, remove, or replace submodule \`${gl}\`. Cherry-pick \`${MERGE_SHA}\` by hand. See ${RUN_URL}"
+            return 1
+        fi
+        if ! git update-index --cacheinfo "160000,${ours},${gl}"; then
+            echo "::error::Could not reset submodule '${gl}' to the ${target} pointer ${ours:0:12}." >&2
+            comment_original ":x: Backport to \`${target}\` could not reset submodule \`${gl}\` to the \`${target}\` pointer. Cherry-pick \`${MERGE_SHA}\` by hand. See ${RUN_URL}"
+            return 1
+        fi
+        corrected=1
+        echo "Reset gitlink '${gl}' to the ${target} pointer ${ours:0:12} (ours; source pointer discarded)."
+    done < <( { git ls-tree -r "origin/${target}"; git ls-tree -r HEAD; } 2>/dev/null \
+                | awk '$1=="160000"{print $4}' | sort -u )
+
+    if [ "$corrected" -eq 1 ]; then
+        # --allow-empty: if the source commit ONLY bumped the submodule, resetting
+        # it to ours leaves nothing — that's a no-op backport, not an error. The
+        # empty commit is then dropped by the "no net change vs target" check below
+        # (a submodule pointer moves on its own line, never as a backport side effect).
+        if ! git commit --amend --no-edit --quiet --allow-empty; then
+            echo "::error::Could not amend ${target} after resetting submodule pointer(s)." >&2
+            comment_original ":x: Backport to \`${target}\` could not re-commit after correcting a submodule pointer. See ${RUN_URL}"
+            return 1
+        fi
+    fi
+    return 0
 }
 
 # --- backport one target --------------------------------------------------
@@ -298,19 +372,43 @@ backport_one() {
             return 0
         fi
         if git diff --name-only --diff-filter=U | grep -q .; then
-            echo "Conflicts cherry-picking onto ${target}; preparing a draft PR."
+            # Partition the conflicts up front. A submodule (gitlink) conflict is
+            # EXPECTED and benign: main and release/X.Y legitimately track different
+            # composableai/llumiverse commits, so any source commit that also bumped
+            # the gitlink conflicts here even when every real file merged cleanly.
+            # Only a NON-gitlink conflict makes this a backport a human must inspect
+            # (a draft). Capture that set before we start resolving anything.
+            local nongitlink_conflicts
+            nongitlink_conflicts="$(git ls-files --unmerged | awk '$1!="160000"{print $4}' | sort -u)"
+            if [ -n "$nongitlink_conflicts" ]; then
+                echo "Real (non-gitlink) conflicts cherry-picking onto ${target}; preparing a draft PR."
+            else
+                echo "Only submodule gitlink conflicts onto ${target}; pinning to ours and opening a normal PR."
+            fi
+
             # Stage conflicted regular files (they keep their markers for manual
-            # resolution); resolve submodule gitlinks at the index level since an
+            # resolution); pin submodule gitlinks to OURS at the index level since an
             # unchecked-out submodule can't be `git add`ed. Avoid `git add -A`,
             # which chokes on the empty submodule directory.
-            git ls-files --unmerged | awk '$1!="160000"{print $4}' | sort -u | while IFS= read -r f; do
+            printf '%s\n' "$nongitlink_conflicts" | while IFS= read -r f; do
                 [ -n "$f" ] && git add -- "$f" 2>/dev/null || true
             done
             resolve_gitlink_conflicts "$target"
-            # Force-resolve anything still unmerged (modify/delete, rename, add/add)
-            # to the incoming side, so ANY conflict becomes a draft for a human to
-            # validate rather than hard-failing the backport.
-            git ls-files --unmerged | awk '{print $4}' | sort -u | while IFS= read -r p; do
+
+            # A gitlink left unmerged (structural submodule add/delete) is the one
+            # thing we must NEVER force to theirs — that would leak the source
+            # submodule pointer onto the backport branch. Bail for a hand cherry-pick.
+            if git ls-files --unmerged | awk '$1=="160000"{print $4}' | grep -q .; then
+                echo "::error::Unresolved submodule gitlink conflict onto ${target}; refusing to take the source pointer. Cherry-pick by hand." >&2
+                comment_original ":x: Backport to \`${target}\` has a submodule conflict that can't be safely auto-resolved without leaking the source pointer. Cherry-pick \`${MERGE_SHA}\` by hand. See ${RUN_URL}"
+                git cherry-pick --abort 2>/dev/null || true
+                return 1
+            fi
+            # Force-resolve any remaining NON-gitlink conflict (modify/delete, rename,
+            # add/add) to the incoming side, so those become a draft for a human to
+            # validate rather than hard-failing the backport. Gitlinks are settled
+            # above and are deliberately excluded here.
+            git ls-files --unmerged | awk '$1!="160000"{print $4}' | sort -u | while IFS= read -r p; do
                 [ -n "$p" ] || continue
                 git checkout --theirs -- "$p" 2>/dev/null && git add -- "$p" 2>/dev/null \
                     || git rm -q -- "$p" 2>/dev/null \
@@ -336,13 +434,28 @@ backport_one() {
                 git cherry-pick --abort 2>/dev/null || true
                 return 1
             fi
-            conflicted=1
+            # A gitlink-only conflict was pinned to ours (no net submodule change) and
+            # auto-merges like any clean backport; only a real file/structural conflict
+            # opens as a draft.
+            if [ -n "$nongitlink_conflicts" ]; then
+                conflicted=1
+            fi
         else
             git cherry-pick --abort 2>/dev/null || true
             echo "::error::Unexpected cherry-pick failure onto ${target}." >&2
             comment_original ":x: Backport to \`${target}\` failed unexpectedly: ${RUN_URL}"
             return 1
         fi
+    fi
+
+    # HARD INVARIANT: no source-branch submodule pointer may reach the backport.
+    # Run on EVERY path (clean pick included) since a gitlink can move with no
+    # conflict when the target pointer equals the source commit's parent. This
+    # comes before the empty-diff check so a clean, submodule-only bump normalizes
+    # to the target pointer and is then correctly skipped as "no net change".
+    if ! normalize_gitlinks_to_target "$target"; then
+        git cherry-pick --abort 2>/dev/null || true
+        return 1
     fi
 
     # Don't open an empty PR: if the result is identical to the target there is


### PR DESCRIPTION
## Summary

The `release/X.Y → main` backport automation mishandled any merged PR that also moved the submodule (llumiverse) pointer:

- **False drafts** — `main` and `release/X.Y` legitimately track different llumiverse commits, so a source commit that also bumped the gitlink raised a submodule conflict, and *every* such backport was opened as an alarming draft even when all real files merged cleanly.
- **Pointer leak** — a gitlink that applied *cleanly* (when the target's pointer equals the source commit's parent pointer) silently carried the source branch's llumiverse commit onto the backport branch, so a forward-port could downgrade the target's submodule pointer.

## Changes (`.github/bin/backport.sh`)

- `resolve_gitlink_conflicts` now pins a conflicted gitlink to **ours** — the target branch's own recorded pointer, read from the index — so `cherry-pick --continue` proceeds without leaking the source pointer. Gitlinks are excluded from the `--theirs` force-resolve sweep.
- New `normalize_gitlinks_to_target` runs after **every** cherry-pick path (clean picks included, where a gitlink can move with no conflict at all) and before push. It resets any repointed submodule to the target's own pointer and **fails closed** on a structural add / remove / replace. Presence is decided mode-aware (a `160000` gitlink via `git ls-tree`), so a submodule swapped for a plain directory is caught too; every mutating `git` call is checked explicitly, because the function runs under `if !` which disables `errexit`.
- Only real file/structural conflicts open a **draft**; gitlink-only conflicts and clean gitlink bumps open a normal auto-merging PR, or are skipped as no-ops when nothing but the submodule moved.

Net effect: the backport's submodule state always ends identical to the target branch's — a submodule change rides its own line, never as a side effect of a file backport.

## Test Plan

- [x] `bash -n .github/bin/backport.sh` — syntax OK
- [x] `shellcheck -S warning .github/bin/backport.sh` — clean
- [x] `bash .github/bin/backport-gitlink.test.sh` — **5/5 pass**: clean gitlink bump resets to the target pointer; submodule-only bump becomes a no-op; submodule add / removal / directory-replacement each fail closed.

> Verification note: `backport.sh` is a CI shell script under `.github/bin/`, outside the pnpm/turbo workspaces, so package build/lint/test (turbo build, vitest, biome) do not apply. Verification is `bash -n` + `shellcheck` + the committed regression test above.
