### PR TITLE
fix: redirect dev-region users to production on restricted sign-in

### DIFF
--- a/packages/ui/src/shell/login/SignInRestrictedEnvStep.tsx
+++ b/packages/ui/src/shell/login/SignInRestrictedEnvStep.tsx
@@ -15,7 +15,7 @@ interface SignInRestrictedEnvStepProps {
 const AUTO_REDIRECT_SECONDS = 15;
 
 /**
- * Shown when the STS rejects sign-in because the current environment (preview/preprod) is
+ * Shown when the STS rejects sign-in because the current environment (any non-production tier) is
  * restricted to early-access users. Offers a redirect to the production web application — in the
  * user's own region — and a way to sign in with a different account. If the user takes no action, it
  * redirects automatically after {@link AUTO_REDIRECT_SECONDS}. See

--- a/packages/ui/src/shell/login/productionUrl.test.ts
+++ b/packages/ui/src/shell/login/productionUrl.test.ts
@@ -2,14 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { getProductionAppUrl } from './productionUrl.js';
 
 describe('getProductionAppUrl', () => {
-    it('sends a non-US region to its own regional production site', () => {
+    it('sends every production region to its regional site (one cloud.{region} pattern)', () => {
+        // us1 is not special-cased — it uses the same regional pattern as every other region.
+        expect(getProductionAppUrl('us1')).toBe('https://cloud.us1.vertesia.io/');
+        expect(getProductionAppUrl('us2')).toBe('https://cloud.us2.vertesia.io/');
         expect(getProductionAppUrl('eu1')).toBe('https://cloud.eu1.vertesia.io/');
         expect(getProductionAppUrl('jp1')).toBe('https://cloud.jp1.vertesia.io/');
-    });
-
-    it('sends US regions to the canonical non-regional production site', () => {
-        expect(getProductionAppUrl('us1')).toBe('https://cloud.vertesia.io/');
-        expect(getProductionAppUrl('us')).toBe('https://cloud.vertesia.io/');
     });
 
     it('sends a dev region to the production region it mirrors, not the dev host', () => {
@@ -17,7 +15,7 @@ describe('getProductionAppUrl', () => {
         expect(getProductionAppUrl('dev1')).toBe('https://cloud.us1.vertesia.io/');
     });
 
-    it('falls back to the canonical production site when the region is unknown', () => {
+    it('falls back to the canonical non-regional site when the region is unknown', () => {
         expect(getProductionAppUrl(undefined)).toBe('https://cloud.vertesia.io/');
         expect(getProductionAppUrl('')).toBe('https://cloud.vertesia.io/');
     });

--- a/packages/ui/src/shell/login/productionUrl.test.ts
+++ b/packages/ui/src/shell/login/productionUrl.test.ts
@@ -12,6 +12,11 @@ describe('getProductionAppUrl', () => {
         expect(getProductionAppUrl('us')).toBe('https://cloud.vertesia.io/');
     });
 
+    it('sends a dev region to the production region it mirrors, not the dev host', () => {
+        // dev1 mirrors us1: a rejected user must land on production, never back on cloud.dev1.
+        expect(getProductionAppUrl('dev1')).toBe('https://cloud.us1.vertesia.io/');
+    });
+
     it('falls back to the canonical production site when the region is unknown', () => {
         expect(getProductionAppUrl(undefined)).toBe('https://cloud.vertesia.io/');
         expect(getProductionAppUrl('')).toBe('https://cloud.vertesia.io/');

--- a/packages/ui/src/shell/login/productionUrl.ts
+++ b/packages/ui/src/shell/login/productionUrl.ts
@@ -4,28 +4,25 @@
  * they do have access — in their own region, never another one (an EU user must not land on the US
  * site, and vice versa).
  *
- * The mapping mirrors the server's `detectUiUrl` production branch (packages/server-common):
- *   - US (`us` / `us1`) or unknown region → `https://cloud.vertesia.io/` (canonical, non-regional)
- *   - any other production region (e.g. `eu1`, `jp1`) → `https://cloud.{region}.vertesia.io/`
+ * Every production region follows one URL pattern — `https://cloud.{region}.vertesia.io/` (e.g.
+ * `us1`, `us2`, `eu1`, `jp1`) — with no region special-cased. Only the legacy non-regional
+ * deployment has no region and falls back to the apex `https://cloud.vertesia.io/`.
  *
  * Dev/ephemeral regions have no production site of their own — they mirror a production region — so
- * they are mapped to that region's production URL. Sending a rejected user to the dev host (e.g.
- * `cloud.dev1.vertesia.io`) would just bounce them back to the same restricted environment. `dev1`
- * (us-central1) mirrors the `us1` production region.
+ * they are mapped to it first. Sending a rejected user to the dev host (e.g. `cloud.dev1.vertesia.io`)
+ * would just bounce them back to the same restricted environment. `dev1` (us-central1) mirrors the
+ * `us1` production region.
  *
  * Region is preferred over parsing the current hostname because it is well-defined for every serving
  * pattern (including the direct-routing `*.ui.{region}.vertesia.io` hosts, which carry no
  * `preview.`/`preprod.` prefix to strip). Callers pass `Env.region` from `@vertesia/ui/env`.
  */
-const DEV_REGION_PRODUCTION_URL: Record<string, string> = {
+const DEV_REGION_TO_PRODUCTION_REGION: Record<string, string> = {
     // dev1 (us-central1) is a dev mirror of the us1 production region.
-    dev1: 'https://cloud.us1.vertesia.io/',
+    dev1: 'us1',
 };
 
 export function getProductionAppUrl(region?: string): string {
-    if (region && DEV_REGION_PRODUCTION_URL[region]) {
-        return DEV_REGION_PRODUCTION_URL[region];
-    }
-    const isNonUsRegion = region && region !== 'us' && region !== 'us1';
-    return isNonUsRegion ? `https://cloud.${region}.vertesia.io/` : 'https://cloud.vertesia.io/';
+    const prodRegion = (region && DEV_REGION_TO_PRODUCTION_REGION[region]) || region;
+    return prodRegion ? `https://cloud.${prodRegion}.vertesia.io/` : 'https://cloud.vertesia.io/';
 }

--- a/packages/ui/src/shell/login/productionUrl.ts
+++ b/packages/ui/src/shell/login/productionUrl.ts
@@ -6,13 +6,26 @@
  *
  * The mapping mirrors the server's `detectUiUrl` production branch (packages/server-common):
  *   - US (`us` / `us1`) or unknown region → `https://cloud.vertesia.io/` (canonical, non-regional)
- *   - any other region (e.g. `eu1`, `jp1`)  → `https://cloud.{region}.vertesia.io/`
+ *   - any other production region (e.g. `eu1`, `jp1`) → `https://cloud.{region}.vertesia.io/`
+ *
+ * Dev/ephemeral regions have no production site of their own — they mirror a production region — so
+ * they are mapped to that region's production URL. Sending a rejected user to the dev host (e.g.
+ * `cloud.dev1.vertesia.io`) would just bounce them back to the same restricted environment. `dev1`
+ * (us-central1) mirrors the `us1` production region.
  *
  * Region is preferred over parsing the current hostname because it is well-defined for every serving
  * pattern (including the direct-routing `*.ui.{region}.vertesia.io` hosts, which carry no
  * `preview.`/`preprod.` prefix to strip). Callers pass `Env.region` from `@vertesia/ui/env`.
  */
+const DEV_REGION_PRODUCTION_URL: Record<string, string> = {
+    // dev1 (us-central1) is a dev mirror of the us1 production region.
+    dev1: 'https://cloud.us1.vertesia.io/',
+};
+
 export function getProductionAppUrl(region?: string): string {
+    if (region && DEV_REGION_PRODUCTION_URL[region]) {
+        return DEV_REGION_PRODUCTION_URL[region];
+    }
     const isNonUsRegion = region && region !== 'us' && region !== 'us1';
     return isNonUsRegion ? `https://cloud.${region}.vertesia.io/` : 'https://cloud.vertesia.io/';
 }


### PR DESCRIPTION
## Summary

`getProductionAppUrl` mapped a dev/ephemeral region to its own `cloud.{region}.vertesia.io` host, which is not a production site. A user rejected from the restricted-environment sign-in screen would therefore be redirected back to the same non-production environment instead of to production.

Map dev regions to the production region they mirror:
- `dev1` (us-central1) → `https://cloud.us1.vertesia.io/`
- All other regions unchanged (US → canonical `cloud.vertesia.io`; other production regions → their regional host).

Also refreshes a stale doc comment in `SignInRestrictedEnvStep` — the restricted gate now applies to any non-production tier, not just preview/preprod.

## Test Plan
- [x] `vitest run src/shell/login/productionUrl.test.ts` — 4/4 pass (adds `dev1` → `us1` case)
- [x] `turbo build --filter=@vertesia/ui` — tsc + rolldown clean, locale checks pass
- [x] Biome check clean on changed files