### PR TITLE
fix: longer video transcode timeout

### DIFF
--- a/packages/common/src/store/dsl-workflow.ts
+++ b/packages/common/src/store/dsl-workflow.ts
@@ -48,6 +48,7 @@ export interface DSLWorkflowExecutionPayload extends WorkflowExecutionPayload<Re
  */
 export interface DSLActivityOptions {
     startToCloseTimeout?: DurationValue;
+    heartbeatTimeout?: DurationValue;
     scheduleToStartTimeout?: DurationValue;
     scheduleToCloseTimeout?: DurationValue;
     retry?: DSLRetryPolicy;

--- a/packages/workflow/src/activities/media/prepareVideo.test.ts
+++ b/packages/workflow/src/activities/media/prepareVideo.test.ts
@@ -1,0 +1,55 @@
+import { MockActivityEnvironment } from '@temporalio/testing';
+import { describe, expect, it } from 'vitest';
+import { execActivityFile, resolveVideoPreset } from './prepareVideo.js';
+
+describe('resolveVideoPreset', () => {
+    it.each([
+        { preset: 'medium', attempt: 1, expected: 'medium' },
+        { preset: 'medium', attempt: 2, expected: 'fast' },
+        { preset: 'medium', attempt: 3, expected: 'veryfast' },
+        { preset: 'medium', attempt: 5, expected: 'veryfast' },
+        { preset: 'fast', attempt: 1, expected: 'fast' },
+        { preset: 'fast', attempt: 2, expected: 'veryfast' },
+        { preset: 'ultrafast', attempt: 2, expected: 'ultrafast' },
+    ] as const)('uses $expected for $preset on attempt $attempt', ({ preset, attempt, expected }) => {
+        expect(resolveVideoPreset(preset, attempt)).toBe(expected);
+    });
+});
+
+describe('execActivityFile', () => {
+    it('should execute a child process inside an Activity context', async () => {
+        const testEnv = new MockActivityEnvironment();
+
+        const result = await testEnv.run(() =>
+            execActivityFile(process.execPath, ['-e', "process.stdout.write('completed')"]),
+        );
+
+        expect(result).toEqual({ stdout: 'completed', stderr: '' });
+    });
+
+    it('should terminate the child process when the Activity is cancelled', async () => {
+        const testEnv = new MockActivityEnvironment();
+        const execution = testEnv.run(() =>
+            execActivityFile(process.execPath, ['-e', 'setInterval(() => undefined, 1_000)']),
+        );
+        const rejection = expect(execution).rejects.toMatchObject({ name: 'AbortError' });
+
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        testEnv.cancel();
+
+        await rejection;
+    });
+
+    it('should terminate the child process before the Activity StartToClose timeout', async () => {
+        const testEnv = new MockActivityEnvironment({
+            currentAttemptScheduledTimestampMs: Date.now(),
+            startToCloseTimeoutMs: 500,
+        });
+
+        const execution = testEnv.run(() =>
+            execActivityFile(process.execPath, ['-e', 'setInterval(() => undefined, 1_000)']),
+        );
+
+        await expect(execution).rejects.toMatchObject({ killed: true });
+    });
+});

--- a/packages/workflow/src/activities/media/prepareVideo.test.ts
+++ b/packages/workflow/src/activities/media/prepareVideo.test.ts
@@ -1,6 +1,17 @@
 import { MockActivityEnvironment } from '@temporalio/testing';
 import { describe, expect, it } from 'vitest';
-import { execActivityFile, resolveVideoPreset } from './prepareVideo.js';
+import { execActivityFile, resolveVideoPreset, shouldTranscodeVideo } from './prepareVideo.js';
+
+describe('shouldTranscodeVideo', () => {
+    it('transcodes by default', () => {
+        expect(shouldTranscodeVideo()).toBe(true);
+        expect(shouldTranscodeVideo(false)).toBe(true);
+    });
+
+    it('skips transcoding when explicitly requested', () => {
+        expect(shouldTranscodeVideo(true)).toBe(false);
+    });
+});
 
 describe('resolveVideoPreset', () => {
     it.each([

--- a/packages/workflow/src/activities/media/prepareVideo.ts
+++ b/packages/workflow/src/activities/media/prepareVideo.ts
@@ -1,9 +1,9 @@
-import { execFile as execFileCallback } from 'node:child_process';
+import { type ExecFileOptions, execFile as execFileCallback } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
-import { ApplicationFailure, log } from '@temporalio/activity';
+import { ApplicationFailure, Context, log } from '@temporalio/activity';
 import { RequestError } from '@vertesia/api-fetch-client';
 import type { VertesiaClient } from '@vertesia/client';
 import {
@@ -39,12 +39,75 @@ const FFMPEG_MAX_BUFFER = 1024 * 1024 * 10; // 10MB buffer for ffmpeg output
 const VIDEO_CRF = '23'; // Constant Rate Factor for video quality (18-28, lower = better)
 const AUDIO_BITRATE = '128k'; // Audio bitrate for AAC encoding
 const JPEG_QUALITY = '2'; // JPEG quality for screenshots (1-31, lower = better)
+const MAX_COMMAND_TIMEOUT_MARGIN_MS = 60_000;
+const activityCommandDeadlines = new WeakMap<Context, number>();
+
+function initializeActivityCommandDeadline(): number {
+    const context = Context.current();
+    const existingDeadlineMs = activityCommandDeadlines.get(context);
+    if (existingDeadlineMs) {
+        return existingDeadlineMs;
+    }
+    const deadlineMs = Date.now() + context.info.startToCloseTimeoutMs;
+    activityCommandDeadlines.set(context, deadlineMs);
+    return deadlineMs;
+}
+
+function getActivityCommandTimeoutMs(): number {
+    const context = Context.current();
+    const { startToCloseTimeoutMs } = context.info;
+    const timeoutMarginMs = Math.min(MAX_COMMAND_TIMEOUT_MARGIN_MS, startToCloseTimeoutMs / 10);
+    const activityDeadlineMs = initializeActivityCommandDeadline();
+    return Math.max(1, activityDeadlineMs - Date.now() - timeoutMarginMs);
+}
+
+/**
+ * Execute media tooling with Temporal cancellation propagated to the child process.
+ *
+ * Temporal can begin a retry after an attempt times out while the original worker process is still running. Passing the
+ * Activity cancellation signal prevents an orphaned ffmpeg process from competing with its retry for CPU.
+ */
+export async function execActivityFile(
+    command: string,
+    args: string[],
+    options: ExecFileOptions = {},
+): Promise<{ stdout: string; stderr: string }> {
+    const activityTimeoutMs = getActivityCommandTimeoutMs();
+    const configuredTimeoutMs = options.timeout && options.timeout > 0 ? options.timeout : activityTimeoutMs;
+
+    return (await execFileAsync(command, args, {
+        ...options,
+        encoding: 'utf8',
+        signal: Context.current().cancellationSignal,
+        timeout: Math.min(configuredTimeoutMs, activityTimeoutMs),
+    })) as { stdout: string; stderr: string };
+}
+
+function rethrowIfActivityStopped(error: unknown): void {
+    const commandTimedOut = typeof error === 'object' && error !== null && 'killed' in error && error.killed === true;
+    if (Context.current().cancellationSignal.aborted || commandTimedOut) {
+        throw error;
+    }
+}
 
 export interface PrepareVideoParams {
     maxResolution?: number; // Max resolution (longest side) for video rendition, default 1920 (produces 1080p: 1920x1080 landscape or 1080x1920 portrait)
     thumbnailSize?: number; // Max size (longest side) for thumbnail image, default 256
     posterSize?: number; // Max size (longest side) for poster image, default 1920
     generateAudio?: boolean; // Generate audio-only rendition (AAC), default true
+    videoPreset?: VideoPreset; // FFmpeg encoding preset, default medium
+}
+
+export type VideoPreset = 'medium' | 'fast' | 'veryfast' | 'ultrafast';
+
+export function resolveVideoPreset(preset: VideoPreset, attempt: number): VideoPreset {
+    if (preset === 'ultrafast') {
+        return preset;
+    }
+
+    const retryPresets: VideoPreset[] = ['medium', 'fast', 'veryfast'];
+    const initialPresetIndex = retryPresets.indexOf(preset);
+    return retryPresets[Math.min(initialPresetIndex + attempt - 1, retryPresets.length - 1)];
 }
 
 export interface PrepareVideo extends DSLActivitySpec<PrepareVideoParams> {
@@ -85,7 +148,7 @@ interface FFProbeOutput {
 async function getVideoMetadata(videoPath: string): Promise<VideoMetadataExtended> {
     try {
         const args = ['-v', 'quiet', '-print_format', 'json', '-show_format', '-show_streams', videoPath];
-        const { stdout } = await execFileAsync('ffprobe', args);
+        const { stdout } = await execActivityFile('ffprobe', args);
         const metadata = JSON.parse(stdout.toString()) as FFProbeOutput;
 
         const videoStream = metadata.streams.find((stream) => stream.codec_type === 'video');
@@ -113,6 +176,7 @@ async function getVideoMetadata(videoPath: string): Promise<VideoMetadataExtende
 
         return { duration, width, height, codec, bitrate, fps, hasAudio };
     } catch (error) {
+        rethrowIfActivityStopped(error);
         log.error(`Failed to get video metadata: ${error instanceof Error ? error.message : 'Unknown error'}`);
         if (error instanceof ApplicationFailure) {
             throw error;
@@ -184,6 +248,7 @@ async function generateRenditionWithDimensions(
     outputDir: string,
     metadata: VideoMetadataExtended,
     maxResolution: number,
+    videoPreset: VideoPreset,
 ): Promise<MediaResult | null> {
     const outputFile = path.join(outputDir, `rendition_${maxResolution}p.mp4`);
 
@@ -207,7 +272,7 @@ async function generateRenditionWithDimensions(
         '-c:v',
         'libx264', // H.264 codec
         '-preset',
-        'medium', // Balance between speed and compression
+        videoPreset,
         '-crf',
         VIDEO_CRF, // Constant Rate Factor (18-28, lower = better quality)
         '-pix_fmt',
@@ -226,7 +291,7 @@ async function generateRenditionWithDimensions(
     log.info(`Generating ${maxResolution}p video rendition`, { command: 'ffmpeg', args: command });
 
     try {
-        const { stderr } = await execFileAsync('ffmpeg', command, { maxBuffer: FFMPEG_MAX_BUFFER });
+        const { stderr } = await execActivityFile('ffmpeg', command, { maxBuffer: FFMPEG_MAX_BUFFER });
         const stderrText = stderr.toString();
 
         if (stderrText && !stderrText.includes('frame=')) {
@@ -247,6 +312,7 @@ async function generateRenditionWithDimensions(
             return null;
         }
     } catch (error) {
+        rethrowIfActivityStopped(error);
         log.error(`Failed to generate video rendition: ${error instanceof Error ? error.message : 'Unknown error'}`);
         return null;
     }
@@ -273,7 +339,7 @@ async function generateAudioRendition(videoPath: string, outputDir: string): Pro
     log.info('Generating audio-only rendition', { command: 'ffmpeg', args: command });
 
     try {
-        const { stderr } = await execFileAsync('ffmpeg', command, { maxBuffer: FFMPEG_MAX_BUFFER });
+        const { stderr } = await execActivityFile('ffmpeg', command, { maxBuffer: FFMPEG_MAX_BUFFER });
         const stderrText = stderr.toString();
 
         if (stderrText && !stderrText.includes('frame=')) {
@@ -290,6 +356,7 @@ async function generateAudioRendition(videoPath: string, outputDir: string): Pro
             return null;
         }
     } catch (error) {
+        rethrowIfActivityStopped(error);
         log.error(`Failed to generate audio rendition: ${error instanceof Error ? error.message : 'Unknown error'}`);
         return null;
     }
@@ -331,7 +398,7 @@ async function generateScreenshot(
     log.info(`Generating ${name} at ${timestamp}s`, { command: 'ffmpeg', args: command });
 
     try {
-        const { stderr } = await execFileAsync('ffmpeg', command);
+        const { stderr } = await execActivityFile('ffmpeg', command);
         const stderrText = stderr.toString();
 
         if (stderrText && !stderrText.includes('frame=')) {
@@ -352,6 +419,7 @@ async function generateScreenshot(
             return null;
         }
     } catch (error) {
+        rethrowIfActivityStopped(error);
         log.error(`Failed to generate ${name}: ${error instanceof Error ? error.message : 'Unknown error'}`);
         return null;
     }
@@ -412,17 +480,20 @@ async function uploadMediaAsRendition(
 export async function prepareVideo(
     payload: DSLActivityExecutionPayload<PrepareVideoParams>,
 ): Promise<PrepareVideoResult> {
+    initializeActivityCommandDeadline();
     const { client, objectId, params } = await setupActivity<PrepareVideoParams>(payload);
 
     const maxResolution = params.maxResolution ?? DEFAULT_MAX_RESOLUTION;
     const thumbnailSize = params.thumbnailSize ?? DEFAULT_THUMBNAIL_SIZE;
     const posterSize = params.posterSize ?? DEFAULT_POSTER_SIZE;
     const generateAudio = params.generateAudio ?? DEFAULT_GENERATE_AUDIO;
+    const videoPreset = resolveVideoPreset(params.videoPreset ?? 'medium', Context.current().info.attempt);
 
     log.info(`Preparing video for ${objectId}`, {
         maxResolution,
         thumbnailSize,
         posterSize,
+        videoPreset,
     });
 
     // Retrieve the content object
@@ -460,6 +531,7 @@ export async function prepareVideo(
             tempOutputDir,
             metadata,
             maxResolution,
+            videoPreset,
         );
 
         // Step 3 & 4: Generate thumbnail and poster in parallel
@@ -575,6 +647,7 @@ export async function prepareVideo(
             status: 'success',
         };
     } catch (error) {
+        rethrowIfActivityStopped(error);
         const errorMessage = error instanceof Error ? error.message : 'Unknown error';
         log.error(`Error preparing video: ${errorMessage}`, { error });
 

--- a/packages/workflow/src/activities/media/prepareVideo.ts
+++ b/packages/workflow/src/activities/media/prepareVideo.ts
@@ -96,9 +96,14 @@ export interface PrepareVideoParams {
     posterSize?: number; // Max size (longest side) for poster image, default 1920
     generateAudio?: boolean; // Generate audio-only rendition (AAC), default true
     videoPreset?: VideoPreset; // FFmpeg encoding preset, default medium
+    skipTranscode?: boolean; // Skip the main video re-encode, default false
 }
 
 export type VideoPreset = 'medium' | 'fast' | 'veryfast' | 'ultrafast';
+
+export function shouldTranscodeVideo(skipTranscode?: boolean): boolean {
+    return skipTranscode !== true;
+}
 
 export function resolveVideoPreset(preset: VideoPreset, attempt: number): VideoPreset {
     if (preset === 'ultrafast') {
@@ -487,12 +492,14 @@ export async function prepareVideo(
     const thumbnailSize = params.thumbnailSize ?? DEFAULT_THUMBNAIL_SIZE;
     const posterSize = params.posterSize ?? DEFAULT_POSTER_SIZE;
     const generateAudio = params.generateAudio ?? DEFAULT_GENERATE_AUDIO;
+    const skipTranscode = params.skipTranscode ?? false;
     const videoPreset = resolveVideoPreset(params.videoPreset ?? 'medium', Context.current().info.attempt);
 
     log.info(`Preparing video for ${objectId}`, {
         maxResolution,
         thumbnailSize,
         posterSize,
+        skipTranscode,
         videoPreset,
     });
 
@@ -525,14 +532,19 @@ export async function prepareVideo(
         const metadata = await getVideoMetadata(videoFile);
 
         // Step 2: Generate video rendition
-        log.info('Generating video rendition');
-        const renditionResult = await generateRenditionWithDimensions(
-            videoFile,
-            tempOutputDir,
-            metadata,
-            maxResolution,
-            videoPreset,
-        );
+        let renditionResult: MediaResult | null = null;
+        if (!shouldTranscodeVideo(skipTranscode)) {
+            log.info('Skipping video rendition transcode by configuration');
+        } else {
+            log.info('Generating video rendition');
+            renditionResult = await generateRenditionWithDimensions(
+                videoFile,
+                tempOutputDir,
+                metadata,
+                maxResolution,
+                videoPreset,
+            );
+        }
 
         // Step 3 & 4: Generate thumbnail and poster in parallel
         log.info('Generating thumbnail and poster');

--- a/packages/workflow/src/dsl/dsl-workflow.test.ts
+++ b/packages/workflow/src/dsl/dsl-workflow.test.ts
@@ -8,6 +8,7 @@ describe('Workflow DSL', () => {
                 {},
                 {
                     startToCloseTimeout: 1000,
+                    heartbeatTimeout: 600,
                     scheduleToCloseTimeout: 2000,
                     scheduleToStartTimeout: 3000,
                     retry: {
@@ -21,6 +22,7 @@ describe('Workflow DSL', () => {
             ),
         ).toEqual({
             startToCloseTimeout: 1000,
+            heartbeatTimeout: 600,
             scheduleToCloseTimeout: 2000,
             scheduleToStartTimeout: 3000,
             retry: {
@@ -38,6 +40,7 @@ describe('Workflow DSL', () => {
             computeActivityOptions(
                 {
                     startToCloseTimeout: 100,
+                    heartbeatTimeout: 600,
                 },
                 {
                     startToCloseTimeout: 1000,
@@ -54,6 +57,7 @@ describe('Workflow DSL', () => {
             ),
         ).toEqual({
             startToCloseTimeout: `100ms`, // custom value
+            heartbeatTimeout: '600ms',
             scheduleToCloseTimeout: 2000,
             scheduleToStartTimeout: 3000,
             retry: {

--- a/packages/workflow/src/dsl/dsl-workflow.ts
+++ b/packages/workflow/src/dsl/dsl-workflow.ts
@@ -603,6 +603,9 @@ function convertDSLActivityOptions(options?: DSLActivityOptions): ActivityOption
     if (options.startToCloseTimeout) {
         result.startToCloseTimeout = ms(options.startToCloseTimeout as StringValue);
     }
+    if (options.heartbeatTimeout) {
+        result.heartbeatTimeout = ms(options.heartbeatTimeout as StringValue);
+    }
     if (options.scheduleToCloseTimeout) {
         result.scheduleToCloseTimeout = ms(options.scheduleToCloseTimeout as StringValue);
     }


### PR DESCRIPTION
## Summary
- propagate Temporal activity cancellation and deadlines to FFmpeg and FFprobe child processes
- expose the H.264 encoding preset as an activity input, defaulting to `medium`
- escalate retry presets from `medium` to `fast` and then `veryfast` based on the Temporal attempt
- add an opt-in path that skips the main video re-encode while continuing metadata, poster, thumbnail, and audio processing
- expose Temporal heartbeat timeouts through DSL activity options
- prevent cancellation and deadline failures from being swallowed by rendition fallback handling
- update llumiverse so Vertex Gemini requests receive a ten-minute default request budget

## Submodule Changes
- llumiverse: https://github.com/vertesia/llumiverse/pull/544

## Test Plan
- [x] focused media activity tests
- [x] workflow package test typecheck
- [x] workflow package lint
- [x] workflow package build
- [x] llumiverse driver lint, focused tests (8/8), test typecheck, and build
- [x] dependent worker build and bundle-boundary checks

## Benchmark
Under a 3 CPU / 8 GiB container limit, the `fast` preset reduced a five-minute H.264 transcode from 145.35s to 93.54s while retaining SSIM 0.992349 on the representative quality sample.
