### PR TITLE
fix: reject unauthorized token scope

### DIFF
--- a/packages/ui/src/session/UserSessionProvider.tsx
+++ b/packages/ui/src/session/UserSessionProvider.tsx
@@ -1,11 +1,18 @@
 import { Env } from '@vertesia/ui/env';
 import { onAuthStateChanged } from 'firebase/auth';
 import { type ReactNode, useEffect, useRef, useState } from 'react';
-import { getComposableToken, RestrictedEnvironmentError, STSError, UserNotFoundError } from './auth/composable';
+import {
+    getComposableToken,
+    RestrictedEnvironmentError,
+    resolveAuthSelection,
+    STSError,
+    TokenAuthorizationError,
+    UserNotFoundError,
+} from './auth/composable';
 import { authReturnUrl, shouldRedirectToCentralAuth } from './auth/domainRouting';
 import { getFirebaseAuth } from './auth/firebase';
 import { useAuthState } from './auth/useAuthState';
-import { LastSelectedAccountId_KEY, LastSelectedProjectId_KEY, UserSession, UserSessionContext } from './UserSession';
+import { UserSession, UserSessionContext } from './UserSession';
 
 const CENTRAL_AUTH_REDIRECT = 'https://internal-auth.vertesia.app/';
 
@@ -28,6 +35,18 @@ export function UserSessionProvider({ children, loadOnboardingStatus = true }: U
     const hasInitiatedAuthRef = useRef(false);
     const authFlowRef = useRef<(() => undefined | (() => void)) | undefined>(undefined);
 
+    const clearRejectedUrlScope = (error: TokenAuthorizationError, clearHash = false) => {
+        const url = new URL(window.location.href);
+        if (error.projectId && url.searchParams.get('p') === error.projectId) {
+            url.searchParams.delete('p');
+        } else if (error.accountId && url.searchParams.get('a') === error.accountId) {
+            url.searchParams.delete('a');
+            url.searchParams.delete('p');
+        }
+        if (clearHash) url.hash = '';
+        window.history.replaceState(window.history.state, '', url);
+    };
+
     const redirectToCentralAuth = (projectId?: string, accountId?: string) => {
         const url = new URL(`${CENTRAL_AUTH_REDIRECT}?sts=${Env.endpoints.sts ?? 'https://sts.vertesia.io'}`);
         const currentUrl = authReturnUrl();
@@ -49,12 +68,7 @@ export function UserSessionProvider({ children, loadOnboardingStatus = true }: U
         console.log('Auth: starting auth flow');
         Env.logger.info('Starting auth flow');
         const currentUrl = new URL(window.location.href);
-        const selectedAccount =
-            currentUrl.searchParams.get('a') ?? localStorage.getItem(LastSelectedAccountId_KEY) ?? undefined;
-        const selectedProject =
-            currentUrl.searchParams.get('p') ??
-            localStorage.getItem(`${LastSelectedProjectId_KEY}-${selectedAccount}`) ??
-            undefined;
+        const { accountId: selectedAccount, projectId: selectedProject } = resolveAuthSelection(currentUrl);
         console.log('Auth: selected account', selectedAccount);
         console.log('Auth: selected project', selectedProject);
         Env.logger.info('Selected account and project', {
@@ -125,6 +139,14 @@ export function UserSessionProvider({ children, loadOnboardingStatus = true }: U
                         session.isLoading = false;
                         session.authError = err;
                         setSession(session.clone());
+                        return;
+                    }
+
+                    if (err instanceof TokenAuthorizationError) {
+                        session.isLoading = false;
+                        session.authError = err;
+                        setSession(session.clone());
+                        clearRejectedUrlScope(err, true);
                         return;
                     }
 
@@ -232,8 +254,15 @@ export function UserSessionProvider({ children, loadOnboardingStatus = true }: U
                             // Keep the Firebase session for UserNotFoundError (signup flow) and
                             // RestrictedEnvironmentError (identity is valid; the environment is gated).
                             // Logging out would retrigger onAuthStateChanged and clear the authError.
-                            if (!(err instanceof UserNotFoundError) && !(err instanceof RestrictedEnvironmentError)) {
+                            if (
+                                !(err instanceof UserNotFoundError) &&
+                                !(err instanceof RestrictedEnvironmentError) &&
+                                !(err instanceof TokenAuthorizationError)
+                            ) {
                                 session.logout();
+                            }
+                            if (err instanceof TokenAuthorizationError) {
+                                clearRejectedUrlScope(err);
                             }
                             session.isLoading = false;
                             session.authError = err;

--- a/packages/ui/src/session/auth/composable.test.ts
+++ b/packages/ui/src/session/auth/composable.test.ts
@@ -30,6 +30,7 @@ describe('getComposableToken', () => {
 
     afterEach(() => {
         vi.unstubAllGlobals();
+        vi.clearAllMocks();
     });
 
     it('uses an authorization-bearing STS-issued Vertesia token directly instead of exchanging it', async () => {
@@ -107,5 +108,118 @@ describe('getComposableToken', () => {
         expect(result.rawToken).toBe(exchangedToken);
         expect(fetchMock).toHaveBeenCalledOnce();
         expect(fetchMock.mock.calls[0]?.[0]?.toString()).toBe('https://sts.dev1.vertesia.io/token/issue');
+    });
+
+    it('does not relax a rejected account and project scope', async () => {
+        localStorage.setItem('composableai.lastSelectedAccountId', 'account-a');
+        localStorage.setItem('composableai.lastSelectedProjectId-account-a', 'project-a');
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response('Project does not belong to account', {
+                status: 403,
+            }),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        const { fetchComposableToken } = await importComposableAuth();
+        const getIdToken = vi.fn(async () => 'identity-token');
+        await expect(fetchComposableToken(getIdToken, 'account-a', 'project-a')).rejects.toMatchObject({
+            name: 'TokenAuthorizationError',
+            accountId: 'account-a',
+            projectId: 'project-a',
+            responseMessage: 'Project does not belong to account',
+        });
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(localStorage.getItem('composableai.lastSelectedAccountId')).toBe('account-a');
+        expect(localStorage.getItem('composableai.lastSelectedProjectId-account-a')).toBe('project-a');
+    });
+
+    it('clears a rejected persisted project without retrying or losing its account', async () => {
+        localStorage.setItem('composableai.lastSelectedAccountId', 'account-a');
+        localStorage.setItem('composableai.lastSelectedProjectId-account-a', 'project-a');
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValue(new Response('Project does not belong to account', { status: 403 }));
+        vi.stubGlobal('fetch', fetchMock);
+
+        const { getComposableToken } = await importComposableAuth();
+        await expect(getComposableToken('account-a', 'project-a', 'identity-token', true, true)).rejects.toBeInstanceOf(
+            Error,
+        );
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(localStorage.getItem('composableai.lastSelectedAccountId')).toBe('account-a');
+        expect(localStorage.getItem('composableai.lastSelectedProjectId-account-a')).toBeNull();
+    });
+
+    it('clears a rejected persisted account-only scope without retrying', async () => {
+        localStorage.setItem('composableai.lastSelectedAccountId', 'account-a');
+        const fetchMock = vi.fn().mockResolvedValue(new Response('Account access denied', { status: 403 }));
+        vi.stubGlobal('fetch', fetchMock);
+
+        const { getComposableToken } = await importComposableAuth();
+        await expect(getComposableToken('account-a', undefined, 'identity-token', true, true)).rejects.toBeInstanceOf(
+            Error,
+        );
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(localStorage.getItem('composableai.lastSelectedAccountId')).toBeNull();
+    });
+
+    it('does not clear an unrelated persisted selection', async () => {
+        localStorage.setItem('composableai.lastSelectedAccountId', 'account-b');
+        localStorage.setItem('composableai.lastSelectedProjectId-account-b', 'project-b');
+        const fetchMock = vi.fn().mockResolvedValue(new Response('Project access denied', { status: 403 }));
+        vi.stubGlobal('fetch', fetchMock);
+
+        const { getComposableToken } = await importComposableAuth();
+        await expect(getComposableToken('account-a', 'project-a', 'identity-token', true, true)).rejects.toBeInstanceOf(
+            Error,
+        );
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(localStorage.getItem('composableai.lastSelectedAccountId')).toBe('account-b');
+        expect(localStorage.getItem('composableai.lastSelectedProjectId-account-b')).toBe('project-b');
+    });
+});
+
+describe('resolveAuthSelection', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        localStorage.setItem('composableai.lastSelectedAccountId', 'stored-account');
+        localStorage.setItem('composableai.lastSelectedProjectId-stored-account', 'stored-project');
+        localStorage.setItem('composableai.lastSelectedProjectId-url-account', 'account-project');
+    });
+
+    it('does not combine a URL project with a stored account', async () => {
+        const { resolveAuthSelection } = await importComposableAuth();
+        expect(resolveAuthSelection(new URL('https://app.example.test/?p=url-project'))).toEqual({
+            accountId: undefined,
+            projectId: 'url-project',
+        });
+    });
+
+    it('uses an account and project supplied together by the URL', async () => {
+        const { resolveAuthSelection } = await importComposableAuth();
+        expect(resolveAuthSelection(new URL('https://app.example.test/?a=url-account&p=url-project'))).toEqual({
+            accountId: 'url-account',
+            projectId: 'url-project',
+        });
+    });
+
+    it('preserves cached project restoration for an account-only URL', async () => {
+        const { resolveAuthSelection } = await importComposableAuth();
+        expect(resolveAuthSelection(new URL('https://app.example.test/?a=url-account'))).toEqual({
+            accountId: 'url-account',
+            projectId: 'account-project',
+        });
+    });
+
+    it('restores the complete persisted selection when the URL has no scope', async () => {
+        const { resolveAuthSelection } = await importComposableAuth();
+        expect(resolveAuthSelection(new URL('https://app.example.test/'))).toEqual({
+            accountId: 'stored-account',
+            projectId: 'stored-project',
+        });
     });
 });

--- a/packages/ui/src/session/auth/composable.ts
+++ b/packages/ui/src/session/auth/composable.ts
@@ -10,11 +10,39 @@ import { getFirebaseAuth, getFirebaseAuthToken } from './firebase';
 let AUTH_TOKEN_RAW: string | undefined;
 let AUTH_TOKEN: AuthTokenPayload | undefined;
 
+function clearRejectedPersistedScope(accountId?: string, projectId?: string) {
+    if (!accountId) return;
+
+    const projectKey = `${LastSelectedProjectId_KEY}-${accountId}`;
+    if (projectId) {
+        if (localStorage.getItem(projectKey) === projectId) {
+            localStorage.removeItem(projectKey);
+        }
+        return;
+    }
+
+    if (localStorage.getItem(LastSelectedAccountId_KEY) === accountId) {
+        localStorage.removeItem(LastSelectedAccountId_KEY);
+        localStorage.removeItem(projectKey);
+    }
+}
+
 interface ComposableTokenResponse {
     rawToken: string;
     token: AuthTokenPayload;
     error: boolean;
     message?: string;
+}
+
+export function resolveAuthSelection(currentUrl: URL): { accountId?: string; projectId?: string } {
+    const urlAccount = currentUrl.searchParams.get('a') ?? undefined;
+    const urlProject = currentUrl.searchParams.get('p') ?? undefined;
+    const accountId =
+        urlAccount ??
+        (urlProject === undefined ? (localStorage.getItem(LastSelectedAccountId_KEY) ?? undefined) : undefined);
+    const projectId = urlProject ?? localStorage.getItem(`${LastSelectedProjectId_KEY}-${accountId}`) ?? undefined;
+
+    return { accountId, projectId };
 }
 
 function normalizeIssuer(value: string | undefined): string | undefined {
@@ -232,44 +260,16 @@ export async function fetchComposableToken(
                 );
             }
 
-            // User doesn't have access to the requested account/project, or has no accounts
-            // This can happen with:
-            // 1. Stale localStorage from previous user
-            // 2. User invited to a new account (doesn't have access yet)
-            // 3. User exists but has no accounts at all
-
-            if (retryCount > 0) {
-                // Already retried without account scope - this is a real authorization failure
-                console.error('403: Access denied even without account scope - user may have no accounts');
-                Env.logger.error('403: Access denied after retry - authorization failure', {
-                    vertesia: {
-                        account_id: accountId,
-                        project_id: projectId,
-                        status: stsRes.status,
-                        retry_count: retryCount,
-                    },
-                });
-                throw new Error('Access denied - user may not have access to any accounts');
-            }
-
-            console.log('403: Access denied - clearing cached account and retrying without account scope');
-            Env.logger.warn('403: Access denied - clearing cached account and retrying', {
+            const responseMessage = await stsRes.text();
+            Env.logger.warn('STS rejected the requested account or project', {
                 vertesia: {
                     account_id: accountId,
                     project_id: projectId,
                     status: stsRes.status,
-                    retry_count: retryCount,
+                    error: responseMessage,
                 },
             });
-
-            // Clear any stale account/project from localStorage
-            localStorage.removeItem(LastSelectedAccountId_KEY);
-            if (accountId) {
-                localStorage.removeItem(`${LastSelectedProjectId_KEY}-${accountId}`);
-            }
-
-            // Retry without account/project scope - let user log in to their default account
-            return fetchComposableToken(getIdToken, undefined, undefined, ttl, retryCount + 1);
+            throw new TokenAuthorizationError(stsEndpoint, accountId, projectId, responseMessage);
         }
 
         if (!stsRes.ok) {
@@ -378,19 +378,28 @@ export async function getComposableToken(
         return { rawToken: AUTH_TOKEN_RAW, token: AUTH_TOKEN, error: false };
     }
 
-    //token is close to expire, refresh it
-    if (!devAuthToken && !useInternalAuth && getFirebaseAuth().currentUser) {
-        //we have a firebase user, get the token from there
-        AUTH_TOKEN_RAW = await fetchComposableTokenFromFirebaseToken(selectedAccount, selectedProject);
-    } else if (!devAuthToken && (initToken || AUTH_TOKEN_RAW)) {
-        // we have a token already and no firebase user, refresh it
-        AUTH_TOKEN_RAW = await fetchComposableToken(
-            () => Promise.resolve(initToken ?? AUTH_TOKEN_RAW),
-            selectedAccount,
-            selectedProject,
-        );
-    } else if (devAuthToken) {
-        AUTH_TOKEN_RAW = devAuthToken;
+    try {
+        //token is close to expire, refresh it
+        if (!devAuthToken && !useInternalAuth && getFirebaseAuth().currentUser) {
+            //we have a firebase user, get the token from there
+            AUTH_TOKEN_RAW = await fetchComposableTokenFromFirebaseToken(selectedAccount, selectedProject);
+        } else if (!devAuthToken && (initToken || AUTH_TOKEN_RAW)) {
+            // we have a token already and no firebase user, refresh it
+            AUTH_TOKEN_RAW = await fetchComposableToken(
+                () => Promise.resolve(initToken ?? AUTH_TOKEN_RAW),
+                selectedAccount,
+                selectedProject,
+            );
+        } else if (devAuthToken) {
+            AUTH_TOKEN_RAW = devAuthToken;
+        }
+    } catch (error: unknown) {
+        if (error instanceof TokenAuthorizationError) {
+            AUTH_TOKEN_RAW = undefined;
+            AUTH_TOKEN = undefined;
+            clearRejectedPersistedScope(selectedAccount, selectedProject);
+        }
+        throw error;
     }
 
     if (!AUTH_TOKEN_RAW) {
@@ -434,6 +443,18 @@ export class STSError extends Error {
         super(message);
         this.name = 'STSError';
         this.stsURL = stsURL;
+    }
+}
+
+export class TokenAuthorizationError extends STSError {
+    constructor(
+        stsURL: string,
+        public readonly accountId?: string,
+        public readonly projectId?: string,
+        public readonly responseMessage?: string,
+    ) {
+        super('Access denied for the selected account or project', stsURL);
+        this.name = 'TokenAuthorizationError';
     }
 }
 


### PR DESCRIPTION
## Summary
- treat an STS 403 as a scoped authorization failure instead of silently retrying without account or project scope
- resolve a project-only URL independently instead of combining it with a persisted account
- preserve existing account-only URL and complete localStorage restoration behavior
- invalidate only the rejected persisted selection: remove a rejected project while preserving its account, or remove a rejected account-only selection
- clear the failed in-memory token and matching URL scope so a later user-initiated attempt can recover
- preserve unrelated persisted selections, Firebase hash routes, restricted-environment handling, and direct-token flows
- surface the authorization failure through the existing sign-in error UI without an automatic retry

## Why
Account and project values can come from URL parameters or persisted browser selection. Combining a project supplied by the URL with an account supplied only by localStorage can create an invalid cross-account scope. Project-only URLs now remain project-only, allowing STS to resolve the authorized owning account without inheriting unrelated browser state.

When STS rejects an inconsistent or inaccessible scope, token acquisition remains strict: the rejected request is attempted once and remains visible to the user. The shared session package removes only the rejected browser state so a reload or other explicit retry can recover without clearing all site data or silently entering a personal/default organization.

For a rejected account/project pair, the account is retained and only the project is removed. For a rejected account-only request, the account and its associated project entry are removed.

## Test Plan
- [x] `pnpm lint` from `packages/ui`
- [x] `pnpm typecheck:test` from `packages/ui`
- [x] `pnpm test` from `packages/ui` (76 files, 722 tests)
- [x] `pnpm build` from `packages/ui`
- [x] `pnpm --filter @dglabs/composable-ui build` in the dependent parent checkout