### PR TITLE
fix(workflow): ffmpeg progress-stall watchdog for media activities

### DIFF
--- a/packages/workflow/src/activities/media/exec.test.ts
+++ b/packages/workflow/src/activities/media/exec.test.ts
@@ -168,4 +168,27 @@ describe('execActivityFileWithProgress', () => {
         },
         TIMING_TEST_TIMEOUT_MS,
     );
+
+    it(
+        'terminates a still-progressing child at the Activity start-to-close deadline',
+        async () => {
+            // The child keeps reporting advancing progress, so the stall watchdog never fires; the Activity deadline
+            // must still terminate it. This exercises a different path than execActivityFile — the spawn timeout, not
+            // execFile's timeout.
+            const deadlineEnv = new MockActivityEnvironment({
+                currentAttemptScheduledTimestampMs: Date.now(),
+                startToCloseTimeoutMs: 600,
+            });
+            const execution = deadlineEnv.run(() =>
+                execActivityFileWithProgress(
+                    process.execPath,
+                    ['-e', 'setInterval(() => process.stderr.write(`frame=${Date.now()}\\n`), 50)'],
+                    { stallTimeoutMs: 60_000 },
+                ),
+            );
+
+            await expect(execution).rejects.toMatchObject({ killed: true });
+        },
+        TIMING_TEST_TIMEOUT_MS,
+    );
 });

--- a/packages/workflow/src/activities/media/exec.test.ts
+++ b/packages/workflow/src/activities/media/exec.test.ts
@@ -1,0 +1,171 @@
+import { MockActivityEnvironment } from '@temporalio/testing';
+import { describe, expect, it } from 'vitest';
+import { createFfmpegProgressTracker, execActivityFile, execActivityFileWithProgress } from './exec.js';
+
+describe('execActivityFile', () => {
+    it('should execute a child process inside an Activity context', async () => {
+        const testEnv = new MockActivityEnvironment();
+
+        const result = await testEnv.run(() =>
+            execActivityFile(process.execPath, ['-e', "process.stdout.write('completed')"]),
+        );
+
+        expect(result).toEqual({ stdout: 'completed', stderr: '' });
+    });
+
+    it('should terminate the child process when the Activity is cancelled', async () => {
+        const testEnv = new MockActivityEnvironment();
+        const execution = testEnv.run(() =>
+            execActivityFile(process.execPath, ['-e', 'setInterval(() => undefined, 1_000)']),
+        );
+        const rejection = expect(execution).rejects.toMatchObject({ name: 'AbortError' });
+
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        testEnv.cancel();
+
+        await rejection;
+    });
+
+    it('should terminate the child process before the Activity StartToClose timeout', async () => {
+        const testEnv = new MockActivityEnvironment({
+            currentAttemptScheduledTimestampMs: Date.now(),
+            startToCloseTimeoutMs: 500,
+        });
+
+        const execution = testEnv.run(() =>
+            execActivityFile(process.execPath, ['-e', 'setInterval(() => undefined, 1_000)']),
+        );
+
+        await expect(execution).rejects.toMatchObject({ killed: true });
+    });
+});
+
+describe('createFfmpegProgressTracker', () => {
+    it('reports advancement only when a monotonic field increases', () => {
+        const tracker = createFfmpegProgressTracker();
+        expect(tracker.observe('frame=1 time=00:00:00.10\n')).toBe(true);
+        expect(tracker.observe('frame=2 time=00:00:00.20\n')).toBe(true);
+        // A wedged encoder re-emitting an identical status line must not be mistaken for progress (P1).
+        expect(tracker.observe('frame=2 time=00:00:00.20\n')).toBe(false);
+        expect(tracker.observe('frame=2 time=00:00:00.20\n')).toBe(false);
+    });
+
+    it('advances on time= for audio-only output with no frame= field', () => {
+        const tracker = createFfmpegProgressTracker();
+        expect(tracker.observe('size=1024kB time=00:00:01.00 bitrate=209.7kbits/s\n')).toBe(true);
+        expect(tracker.observe('size=1024kB time=00:00:01.00 bitrate=209.7kbits/s\n')).toBe(false);
+        expect(tracker.observe('size=2048kB time=00:00:02.00 bitrate=209.7kbits/s\n')).toBe(true);
+    });
+
+    it('recognizes a marker split across stream chunks (P2)', () => {
+        const tracker = createFfmpegProgressTracker();
+        // No delimiter yet: the partial record is buffered rather than parsed.
+        expect(tracker.observe('fra')).toBe(false);
+        // Reassembled to `frame=7` once the record completes.
+        expect(tracker.observe('me=7\n')).toBe(true);
+    });
+
+    it('treats carriage-return-delimited snapshots as complete records', () => {
+        const tracker = createFfmpegProgressTracker();
+        expect(tracker.observe('frame=1\rframe=2\r')).toBe(true);
+        expect(tracker.observe('frame=2\r')).toBe(false);
+    });
+});
+
+describe('execActivityFileWithProgress', () => {
+    const activityEnv = () =>
+        new MockActivityEnvironment({
+            currentAttemptScheduledTimestampMs: Date.now(),
+            startToCloseTimeoutMs: 60_000,
+        });
+
+    // Timing-based cases run with generous timeouts so shared-CI CPU contention cannot flake them. The stall window is
+    // kept far larger than the progress cadence so a delayed-but-alive child is never mistaken for a wedged one.
+    const TIMING_TEST_TIMEOUT_MS = 20_000;
+
+    it(
+        'captures output and resolves when the command completes',
+        async () => {
+            const result = (await activityEnv().run(() =>
+                execActivityFileWithProgress(process.execPath, [
+                    '-e',
+                    "process.stderr.write('frame=1\\n'); process.stdout.write('ok')",
+                ]),
+            )) as { stdout: string; stderr: string };
+
+            expect(result.stdout).toBe('ok');
+            expect(result.stderr).toContain('frame=1');
+        },
+        TIMING_TEST_TIMEOUT_MS,
+    );
+
+    it(
+        'terminates a child that reports progress and then stops',
+        async () => {
+            const execution = activityEnv().run(() =>
+                execActivityFileWithProgress(
+                    process.execPath,
+                    ['-e', "process.stderr.write('frame=1\\n'); setInterval(() => undefined, 1_000)"],
+                    { stallTimeoutMs: 300 },
+                ),
+            );
+
+            await expect(execution).rejects.toMatchObject({ stalled: true, killed: true });
+        },
+        TIMING_TEST_TIMEOUT_MS,
+    );
+
+    it(
+        'terminates a child that keeps repeating the same progress line',
+        async () => {
+            // A wedged encoder that keeps flushing an identical status line must still be detected as stalled (P1).
+            const execution = activityEnv().run(() =>
+                execActivityFileWithProgress(
+                    process.execPath,
+                    ['-e', "setInterval(() => process.stderr.write('frame=1 time=00:00:01.00\\n'), 40)"],
+                    { stallTimeoutMs: 300 },
+                ),
+            );
+
+            await expect(execution).rejects.toMatchObject({ stalled: true, killed: true });
+        },
+        TIMING_TEST_TIMEOUT_MS,
+    );
+
+    it(
+        'keeps running while the child continues to report progress',
+        async () => {
+            // Emit progress every 100ms for ~500ms against a 2s stall window: a healthy child must never trip it, even
+            // if CI scheduling delays some ticks.
+            const script = [
+                'let n = 0;',
+                'const timer = setInterval(() => {',
+                '    process.stderr.write(`frame=${++n}\\n`);',
+                '    if (n >= 5) {',
+                '        clearInterval(timer);',
+                '        process.exit(0);',
+                '    }',
+                '}, 100);',
+            ].join('\n');
+
+            const result = (await activityEnv().run(() =>
+                execActivityFileWithProgress(process.execPath, ['-e', script], { stallTimeoutMs: 2_000 }),
+            )) as { stdout: string; stderr: string };
+
+            expect(result.stderr).toContain('frame=5');
+        },
+        TIMING_TEST_TIMEOUT_MS,
+    );
+
+    it(
+        'rejects with the exit code when the command fails',
+        async () => {
+            const execution = activityEnv().run(() =>
+                execActivityFileWithProgress(process.execPath, ['-e', 'process.exit(3)']),
+            );
+
+            await expect(execution).rejects.toMatchObject({ code: 3, killed: false });
+        },
+        TIMING_TEST_TIMEOUT_MS,
+    );
+});

--- a/packages/workflow/src/activities/media/exec.ts
+++ b/packages/workflow/src/activities/media/exec.ts
@@ -69,6 +69,11 @@ export async function execActivityFile(
 }
 
 export interface ProgressAwareOptions {
+    /**
+     * Coarse upper bound on retained stdout/stderr, counted in UTF-16 code units (not UTF-8 bytes). ffmpeg output is
+     * ASCII-dominant so this closely tracks bytes; it only exists to keep captured output from growing without bound
+     * (older output is dropped — tail retained — rather than failing the command). Not a strict byte cap.
+     */
     maxBuffer?: number;
     stallTimeoutMs?: number;
 }

--- a/packages/workflow/src/activities/media/exec.ts
+++ b/packages/workflow/src/activities/media/exec.ts
@@ -1,0 +1,260 @@
+import { type ExecFileOptions, execFile as execFileCallback, spawn } from 'node:child_process';
+import { promisify } from 'node:util';
+import { Context } from '@temporalio/activity';
+
+const execFileAsync = promisify(execFileCallback);
+
+/** 10MB buffer for ffmpeg output. */
+export const FFMPEG_MAX_BUFFER = 1024 * 1024 * 10;
+
+const MAX_COMMAND_TIMEOUT_MARGIN_MS = 60_000;
+
+/** Terminate an ffmpeg child that makes no encoding progress for this long, so Temporal can retry it promptly. */
+const FFMPEG_STALL_TIMEOUT_MS = 120_000;
+
+// ffmpeg streams encoding progress as `frame=`/`time=` stats. We track the *advance* of these monotonic fields (rather
+// than mere presence) so a wedged encoder that keeps re-emitting an identical status line is still detected as stalled.
+const FFMPEG_TIME_PATTERN = /time=\s*(\d+):([0-5]?\d):([0-5]?\d(?:\.\d+)?)/;
+const FFMPEG_FRAME_PATTERN = /frame=\s*(\d+)/;
+// ffmpeg delimits stats snapshots with a carriage return, so the carry buffer normally stays tiny. These bounds are a
+// defensive guard against an unterminated stream, retaining enough of a tail to reunite a marker split at the boundary.
+const PROGRESS_CARRY_LIMIT = 64 * 1024;
+const PROGRESS_CARRY_TAIL = 512;
+
+const activityCommandDeadlines = new WeakMap<Context, number>();
+
+/**
+ * Anchor the child-process deadline at the moment the Activity starts, so every later command derives its timeout from a
+ * stable point regardless of how long input download took.
+ */
+export function initializeActivityCommandDeadline(): number {
+    const context = Context.current();
+    const existingDeadlineMs = activityCommandDeadlines.get(context);
+    if (existingDeadlineMs) {
+        return existingDeadlineMs;
+    }
+    const deadlineMs = Date.now() + context.info.startToCloseTimeoutMs;
+    activityCommandDeadlines.set(context, deadlineMs);
+    return deadlineMs;
+}
+
+function getActivityCommandTimeoutMs(): number {
+    const context = Context.current();
+    const { startToCloseTimeoutMs } = context.info;
+    const timeoutMarginMs = Math.min(MAX_COMMAND_TIMEOUT_MARGIN_MS, startToCloseTimeoutMs / 10);
+    const activityDeadlineMs = initializeActivityCommandDeadline();
+    return Math.max(1, activityDeadlineMs - Date.now() - timeoutMarginMs);
+}
+
+/**
+ * Execute media tooling with Temporal cancellation propagated to the child process.
+ *
+ * Temporal can begin a retry after an attempt times out while the original worker process is still running. Passing the
+ * Activity cancellation signal prevents an orphaned ffmpeg process from competing with its retry for CPU.
+ */
+export async function execActivityFile(
+    command: string,
+    args: string[],
+    options: ExecFileOptions = {},
+): Promise<{ stdout: string; stderr: string }> {
+    const activityTimeoutMs = getActivityCommandTimeoutMs();
+    const configuredTimeoutMs = options.timeout && options.timeout > 0 ? options.timeout : activityTimeoutMs;
+
+    return (await execFileAsync(command, args, {
+        ...options,
+        encoding: 'utf8',
+        signal: Context.current().cancellationSignal,
+        timeout: Math.min(configuredTimeoutMs, activityTimeoutMs),
+    })) as { stdout: string; stderr: string };
+}
+
+export interface ProgressAwareOptions {
+    maxBuffer?: number;
+    stallTimeoutMs?: number;
+}
+
+function parseFfmpegTimeCentis(text: string): number | undefined {
+    const match = FFMPEG_TIME_PATTERN.exec(text);
+    if (!match) {
+        return undefined;
+    }
+    const totalSeconds = Number(match[1]) * 3600 + Number(match[2]) * 60 + Number(match[3]);
+    return Number.isFinite(totalSeconds) ? Math.round(totalSeconds * 100) : undefined;
+}
+
+function parseFfmpegFrame(text: string): number | undefined {
+    const match = FFMPEG_FRAME_PATTERN.exec(text);
+    return match ? Number(match[1]) : undefined;
+}
+
+export interface ProgressTracker {
+    /** Feed a raw output chunk; returns true when a monotonic progress field advanced past its previous maximum. */
+    observe(chunk: string): boolean;
+}
+
+/**
+ * Track ffmpeg forward progress across arbitrarily-chunked output.
+ *
+ * Node delivers stream data in arbitrary slices, so a marker such as `frame=42` can arrive split across two chunks. The
+ * tracker buffers partial records until a `\r`/`\n` delimiter completes them, then reports advancement only when the
+ * parsed frame count or media timestamp exceeds the previous maximum — repeated identical stats from a wedged encoder do
+ * not count as progress.
+ */
+export function createFfmpegProgressTracker(): ProgressTracker {
+    let carry = '';
+    let maxTimeCentis = -1;
+    let maxFrame = -1;
+
+    const noteSegment = (segment: string): boolean => {
+        let advanced = false;
+        const timeCentis = parseFfmpegTimeCentis(segment);
+        if (timeCentis !== undefined && timeCentis > maxTimeCentis) {
+            maxTimeCentis = timeCentis;
+            advanced = true;
+        }
+        const frame = parseFfmpegFrame(segment);
+        if (frame !== undefined && frame > maxFrame) {
+            maxFrame = frame;
+            advanced = true;
+        }
+        return advanced;
+    };
+
+    return {
+        observe(chunk: string): boolean {
+            carry += chunk;
+            const segments = carry.split(/[\r\n]+/);
+            carry = segments.pop() ?? '';
+            let advanced = false;
+            for (const segment of segments) {
+                advanced = noteSegment(segment) || advanced;
+            }
+            if (carry.length > PROGRESS_CARRY_LIMIT) {
+                advanced = noteSegment(carry) || advanced;
+                carry = carry.slice(carry.length - PROGRESS_CARRY_TAIL);
+            }
+            return advanced;
+        },
+    };
+}
+
+/**
+ * Execute a long-running media command while enforcing a progress-stall watchdog on top of the Activity deadline and
+ * cancellation.
+ *
+ * The worker heartbeats every Activity on a fixed interval, so a wedged ffmpeg child that stops emitting progress would
+ * otherwise keep the Activity alive until its multi-hour Start-to-Close timeout. Watching ffmpeg's progress markers lets
+ * us terminate a stalled encode within `stallTimeoutMs` so Temporal retries it promptly (escalating to a faster preset
+ * on the next attempt). A stall is surfaced as a `killed` error so it propagates as an Activity failure via
+ * {@link rethrowIfActivityStopped} instead of being swallowed into a missing rendition.
+ */
+export async function execActivityFileWithProgress(
+    command: string,
+    args: string[],
+    { maxBuffer = FFMPEG_MAX_BUFFER, stallTimeoutMs = FFMPEG_STALL_TIMEOUT_MS }: ProgressAwareOptions = {},
+): Promise<{ stdout: string; stderr: string }> {
+    const activityTimeoutMs = getActivityCommandTimeoutMs();
+    const stallWindowMs = Math.max(1, Math.min(stallTimeoutMs, activityTimeoutMs));
+
+    return await new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+        const child = spawn(command, args, {
+            signal: Context.current().cancellationSignal,
+            timeout: activityTimeoutMs,
+            killSignal: 'SIGKILL',
+        });
+
+        let stdout = '';
+        let stderr = '';
+        let settled = false;
+        let stalled = false;
+        let stallTimer: NodeJS.Timeout | undefined;
+
+        const armStallTimer = () => {
+            if (stallTimer) {
+                clearTimeout(stallTimer);
+            }
+            stallTimer = setTimeout(() => {
+                stalled = true;
+                child.kill('SIGKILL');
+            }, stallWindowMs);
+            // Never keep the event loop alive solely for the watchdog timer.
+            stallTimer.unref?.();
+        };
+
+        const append = (current: string, chunk: string): string => {
+            const combined = current + chunk;
+            return combined.length > maxBuffer ? combined.slice(combined.length - maxBuffer) : combined;
+        };
+
+        // ffmpeg writes progress to stderr by default, but track both streams so the watchdog works regardless of where
+        // a given command reports it. Each stream keeps its own line buffer.
+        const stdoutProgress = createFfmpegProgressTracker();
+        const stderrProgress = createFfmpegProgressTracker();
+
+        child.stdout?.setEncoding('utf8');
+        child.stderr?.setEncoding('utf8');
+        child.stdout?.on('data', (chunk: string) => {
+            stdout = append(stdout, chunk);
+            if (stdoutProgress.observe(chunk)) {
+                armStallTimer();
+            }
+        });
+        child.stderr?.on('data', (chunk: string) => {
+            stderr = append(stderr, chunk);
+            if (stderrProgress.observe(chunk)) {
+                armStallTimer();
+            }
+        });
+
+        armStallTimer();
+
+        const settle = (finish: () => void) => {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            if (stallTimer) {
+                clearTimeout(stallTimer);
+            }
+            finish();
+        };
+
+        child.on('error', (error) => settle(() => reject(error)));
+
+        child.on('close', (code, signal) =>
+            settle(() => {
+                if (stalled) {
+                    const seconds = Math.round(stallWindowMs / 1000);
+                    reject(
+                        Object.assign(new Error(`${command} made no progress for ${seconds}s and was terminated`), {
+                            killed: true,
+                            stalled: true,
+                        }),
+                    );
+                } else if (code === 0) {
+                    resolve({ stdout, stderr });
+                } else {
+                    const detail = signal ? `signal ${signal}` : `code ${code}`;
+                    reject(
+                        Object.assign(new Error(`${command} exited with ${detail}: ${stderr.slice(-2000)}`), {
+                            killed: child.killed || signal != null,
+                            code,
+                            signal,
+                        }),
+                    );
+                }
+            }),
+        );
+    });
+}
+
+/**
+ * Re-throw errors that represent the Activity being stopped (cancellation, Start-to-Close timeout, or a progress-stall
+ * kill) so they are not swallowed by rendition fallback handling. Genuine tool failures still return `null` upstream.
+ */
+export function rethrowIfActivityStopped(error: unknown): void {
+    const commandTimedOut = typeof error === 'object' && error !== null && 'killed' in error && error.killed === true;
+    if (Context.current().cancellationSignal.aborted || commandTimedOut) {
+        throw error;
+    }
+}

--- a/packages/workflow/src/activities/media/prepareAudio.ts
+++ b/packages/workflow/src/activities/media/prepareAudio.ts
@@ -1,8 +1,6 @@
-import { execFile as execFileCallback } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { promisify } from 'node:util';
 import { log } from '@temporalio/activity';
 import { RequestError } from '@vertesia/api-fetch-client';
 import type { VertesiaClient } from '@vertesia/client';
@@ -17,12 +15,15 @@ import {
 import { setupActivity } from '../../dsl/setup/ActivityContext.js';
 import { DocumentNotFoundError, InvalidContentTypeError } from '../../errors.js';
 import { saveBlobToTempFile } from '../../utils/blobs.js';
-
-const execFileAsync = promisify(execFileCallback);
+import {
+    execActivityFile,
+    execActivityFileWithProgress,
+    initializeActivityCommandDeadline,
+    rethrowIfActivityStopped,
+} from './exec.js';
 
 // Default configuration constants
 const DEFAULT_AUDIO_BITRATE = '128k'; // Default audio bitrate for AAC encoding
-const FFMPEG_MAX_BUFFER = 1024 * 1024 * 10; // 10MB buffer for ffmpeg output
 
 export interface PrepareAudioParams {
     audioBitrate?: string; // Audio bitrate for AAC encoding, default '128k'
@@ -79,7 +80,7 @@ export interface PrepareAudioResult {
 async function getAudioMetadata(audioPath: string): Promise<AudioMetadataExtended> {
     try {
         const args = ['-v', 'quiet', '-print_format', 'json', '-show_format', '-show_streams', audioPath];
-        const { stdout } = await execFileAsync('ffprobe', args);
+        const { stdout } = await execActivityFile('ffprobe', args);
         const metadata = JSON.parse(stdout.toString()) as FFProbeOutput;
 
         const audioStream = metadata.streams.find((stream) => stream.codec_type === 'audio');
@@ -96,6 +97,7 @@ async function getAudioMetadata(audioPath: string): Promise<AudioMetadataExtende
 
         return { duration, codec, bitrate, sampleRate, channels };
     } catch (error) {
+        rethrowIfActivityStopped(error);
         log.error(`Failed to get audio metadata: ${error instanceof Error ? error.message : 'Unknown error'}`);
         throw new Error(`Failed to probe audio metadata: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
@@ -128,7 +130,7 @@ async function generateAudioRendition(
     log.info('Generating web audio rendition (AAC M4A)', { command: 'ffmpeg', args: command, audioBitrate });
 
     try {
-        const { stderr } = await execFileAsync('ffmpeg', command, { maxBuffer: FFMPEG_MAX_BUFFER });
+        const { stderr } = await execActivityFileWithProgress('ffmpeg', command);
         const stderrText = stderr.toString();
 
         if (stderrText && !stderrText.includes('frame=')) {
@@ -145,6 +147,7 @@ async function generateAudioRendition(
             return null;
         }
     } catch (error) {
+        rethrowIfActivityStopped(error);
         log.error(`Failed to generate audio rendition: ${error instanceof Error ? error.message : 'Unknown error'}`);
         return null;
     }
@@ -200,6 +203,7 @@ async function uploadAudioAsRendition(
 export async function prepareAudio(
     payload: DSLActivityExecutionPayload<PrepareAudioParams>,
 ): Promise<PrepareAudioResult> {
+    initializeActivityCommandDeadline();
     const { client, objectId, params } = await setupActivity<PrepareAudioParams>(payload);
 
     const audioBitrate = params.audioBitrate ?? DEFAULT_AUDIO_BITRATE;
@@ -291,6 +295,7 @@ export async function prepareAudio(
             status: 'success',
         };
     } catch (error) {
+        rethrowIfActivityStopped(error);
         const errorMessage = error instanceof Error ? error.message : 'Unknown error';
         log.error(`Error preparing audio: ${errorMessage}`, { error });
 

--- a/packages/workflow/src/activities/media/prepareVideo.test.ts
+++ b/packages/workflow/src/activities/media/prepareVideo.test.ts
@@ -1,6 +1,5 @@
-import { MockActivityEnvironment } from '@temporalio/testing';
 import { describe, expect, it } from 'vitest';
-import { execActivityFile, resolveVideoPreset, shouldTranscodeVideo } from './prepareVideo.js';
+import { resolveVideoPreset, shouldTranscodeVideo } from './prepareVideo.js';
 
 describe('shouldTranscodeVideo', () => {
     it('transcodes by default', () => {
@@ -24,43 +23,5 @@ describe('resolveVideoPreset', () => {
         { preset: 'ultrafast', attempt: 2, expected: 'ultrafast' },
     ] as const)('uses $expected for $preset on attempt $attempt', ({ preset, attempt, expected }) => {
         expect(resolveVideoPreset(preset, attempt)).toBe(expected);
-    });
-});
-
-describe('execActivityFile', () => {
-    it('should execute a child process inside an Activity context', async () => {
-        const testEnv = new MockActivityEnvironment();
-
-        const result = await testEnv.run(() =>
-            execActivityFile(process.execPath, ['-e', "process.stdout.write('completed')"]),
-        );
-
-        expect(result).toEqual({ stdout: 'completed', stderr: '' });
-    });
-
-    it('should terminate the child process when the Activity is cancelled', async () => {
-        const testEnv = new MockActivityEnvironment();
-        const execution = testEnv.run(() =>
-            execActivityFile(process.execPath, ['-e', 'setInterval(() => undefined, 1_000)']),
-        );
-        const rejection = expect(execution).rejects.toMatchObject({ name: 'AbortError' });
-
-        await new Promise((resolve) => setTimeout(resolve, 100));
-        testEnv.cancel();
-
-        await rejection;
-    });
-
-    it('should terminate the child process before the Activity StartToClose timeout', async () => {
-        const testEnv = new MockActivityEnvironment({
-            currentAttemptScheduledTimestampMs: Date.now(),
-            startToCloseTimeoutMs: 500,
-        });
-
-        const execution = testEnv.run(() =>
-            execActivityFile(process.execPath, ['-e', 'setInterval(() => undefined, 1_000)']),
-        );
-
-        await expect(execution).rejects.toMatchObject({ killed: true });
     });
 });

--- a/packages/workflow/src/activities/media/prepareVideo.ts
+++ b/packages/workflow/src/activities/media/prepareVideo.ts
@@ -1,8 +1,6 @@
-import { type ExecFileOptions, execFile as execFileCallback } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { promisify } from 'node:util';
 import { ApplicationFailure, Context, log } from '@temporalio/activity';
 import { RequestError } from '@vertesia/api-fetch-client';
 import type { VertesiaClient } from '@vertesia/client';
@@ -19,8 +17,12 @@ import {
 import { setupActivity } from '../../dsl/setup/ActivityContext.js';
 import { DocumentNotFoundError, InvalidContentTypeError } from '../../errors.js';
 import { saveBlobToTempFile } from '../../utils/blobs.js';
-
-const execFileAsync = promisify(execFileCallback);
+import {
+    execActivityFile,
+    execActivityFileWithProgress,
+    initializeActivityCommandDeadline,
+    rethrowIfActivityStopped,
+} from './exec.js';
 
 // Default configuration constants
 const DEFAULT_MAX_RESOLUTION = 1920; // Max resolution for video rendition (produces 1080p)
@@ -35,60 +37,9 @@ const POSTER_TIMESTAMP_MAX = 2; // Maximum poster timestamp in seconds
 const MIN_SCREENSHOT_TIMESTAMP = 1; // Minimum timestamp for screenshots in seconds
 
 // FFmpeg configuration constants
-const FFMPEG_MAX_BUFFER = 1024 * 1024 * 10; // 10MB buffer for ffmpeg output
 const VIDEO_CRF = '23'; // Constant Rate Factor for video quality (18-28, lower = better)
 const AUDIO_BITRATE = '128k'; // Audio bitrate for AAC encoding
 const JPEG_QUALITY = '2'; // JPEG quality for screenshots (1-31, lower = better)
-const MAX_COMMAND_TIMEOUT_MARGIN_MS = 60_000;
-const activityCommandDeadlines = new WeakMap<Context, number>();
-
-function initializeActivityCommandDeadline(): number {
-    const context = Context.current();
-    const existingDeadlineMs = activityCommandDeadlines.get(context);
-    if (existingDeadlineMs) {
-        return existingDeadlineMs;
-    }
-    const deadlineMs = Date.now() + context.info.startToCloseTimeoutMs;
-    activityCommandDeadlines.set(context, deadlineMs);
-    return deadlineMs;
-}
-
-function getActivityCommandTimeoutMs(): number {
-    const context = Context.current();
-    const { startToCloseTimeoutMs } = context.info;
-    const timeoutMarginMs = Math.min(MAX_COMMAND_TIMEOUT_MARGIN_MS, startToCloseTimeoutMs / 10);
-    const activityDeadlineMs = initializeActivityCommandDeadline();
-    return Math.max(1, activityDeadlineMs - Date.now() - timeoutMarginMs);
-}
-
-/**
- * Execute media tooling with Temporal cancellation propagated to the child process.
- *
- * Temporal can begin a retry after an attempt times out while the original worker process is still running. Passing the
- * Activity cancellation signal prevents an orphaned ffmpeg process from competing with its retry for CPU.
- */
-export async function execActivityFile(
-    command: string,
-    args: string[],
-    options: ExecFileOptions = {},
-): Promise<{ stdout: string; stderr: string }> {
-    const activityTimeoutMs = getActivityCommandTimeoutMs();
-    const configuredTimeoutMs = options.timeout && options.timeout > 0 ? options.timeout : activityTimeoutMs;
-
-    return (await execFileAsync(command, args, {
-        ...options,
-        encoding: 'utf8',
-        signal: Context.current().cancellationSignal,
-        timeout: Math.min(configuredTimeoutMs, activityTimeoutMs),
-    })) as { stdout: string; stderr: string };
-}
-
-function rethrowIfActivityStopped(error: unknown): void {
-    const commandTimedOut = typeof error === 'object' && error !== null && 'killed' in error && error.killed === true;
-    if (Context.current().cancellationSignal.aborted || commandTimedOut) {
-        throw error;
-    }
-}
 
 export interface PrepareVideoParams {
     maxResolution?: number; // Max resolution (longest side) for video rendition, default 1920 (produces 1080p: 1920x1080 landscape or 1080x1920 portrait)
@@ -296,7 +247,7 @@ async function generateRenditionWithDimensions(
     log.info(`Generating ${maxResolution}p video rendition`, { command: 'ffmpeg', args: command });
 
     try {
-        const { stderr } = await execActivityFile('ffmpeg', command, { maxBuffer: FFMPEG_MAX_BUFFER });
+        const { stderr } = await execActivityFileWithProgress('ffmpeg', command);
         const stderrText = stderr.toString();
 
         if (stderrText && !stderrText.includes('frame=')) {
@@ -344,7 +295,7 @@ async function generateAudioRendition(videoPath: string, outputDir: string): Pro
     log.info('Generating audio-only rendition', { command: 'ffmpeg', args: command });
 
     try {
-        const { stderr } = await execActivityFile('ffmpeg', command, { maxBuffer: FFMPEG_MAX_BUFFER });
+        const { stderr } = await execActivityFileWithProgress('ffmpeg', command);
         const stderrText = stderr.toString();
 
         if (stderrText && !stderrText.includes('frame=')) {

--- a/packages/workflow/src/activities/media/probeMediaStreams.test.ts
+++ b/packages/workflow/src/activities/media/probeMediaStreams.test.ts
@@ -3,6 +3,7 @@ import type { VertesiaClient } from '@vertesia/client';
 import { ContentEventName, type DSLActivityExecutionPayload } from '@vertesia/common';
 import type { ActivityContext } from '@vertesia/workflow';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { execActivityFile } from './exec.js';
 import { type ProbeMediaStreamsParams, type ProbeMediaStreamsResult, probeMediaStreams } from './probeMediaStreams.js';
 
 vi.mock('../../dsl/setup/ActivityContext.js', async (importOriginal) => {
@@ -10,14 +11,12 @@ vi.mock('../../dsl/setup/ActivityContext.js', async (importOriginal) => {
     return { ...actual, setupActivity: vi.fn() };
 });
 
-// child_process.exec uses util.promisify.custom to return { stdout, stderr }.
-// vi.hoisted ensures these are defined before the vi.mock factory runs.
-const { execMock, execCustom } = vi.hoisted(() => {
-    const custom = vi.fn();
-    const mock = Object.assign(vi.fn(), { [Symbol.for('nodejs.util.promisify.custom')]: custom });
-    return { execMock: mock, execCustom: custom };
+// probeMediaStreams delegates ffprobe to the shared exec helper, so mock that seam and drive the parsed output
+// directly. The helper's cancellation/timeout wrapping is covered by exec.test.ts.
+vi.mock('./exec.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('./exec.js')>();
+    return { ...actual, execActivityFile: vi.fn() };
 });
-vi.mock('child_process', () => ({ exec: execMock }));
 
 let testEnv: MockActivityEnvironment;
 
@@ -44,7 +43,7 @@ const createPayload = (objectId = 'test-object-id'): DSLActivityExecutionPayload
 });
 
 function mockExec(stdout: string) {
-    execCustom.mockResolvedValue({ stdout, stderr: '' });
+    vi.mocked(execActivityFile).mockResolvedValue({ stdout, stderr: '' });
 }
 
 async function setupMockContext(objectId: string, signedUrl: string): Promise<void> {

--- a/packages/workflow/src/activities/media/probeMediaStreams.ts
+++ b/packages/workflow/src/activities/media/probeMediaStreams.ts
@@ -1,12 +1,9 @@
-import { exec } from 'node:child_process';
-import { promisify } from 'node:util';
 import { ApplicationFailure, log } from '@temporalio/activity';
 import { RequestError } from '@vertesia/api-fetch-client';
 import type { DSLActivityExecutionPayload, DSLActivitySpec } from '@vertesia/common';
 import { setupActivity } from '../../dsl/setup/ActivityContext.js';
 import { DocumentNotFoundError } from '../../errors.js';
-
-const execAsync = promisify(exec);
+import { execActivityFile, initializeActivityCommandDeadline, rethrowIfActivityStopped } from './exec.js';
 
 const FFPROBE_MAX_BUFFER = 1024 * 1024; // 1MB is more than enough for stream metadata JSON
 
@@ -32,6 +29,7 @@ interface FFProbeOutput {
 export async function probeMediaStreams(
     payload: DSLActivityExecutionPayload<ProbeMediaStreamsParams>,
 ): Promise<ProbeMediaStreamsResult> {
+    initializeActivityCommandDeadline();
     const { client, objectId } = await setupActivity<ProbeMediaStreamsParams>(payload);
 
     const inputObject = await client.objects.retrieve(objectId).catch((err: unknown) => {
@@ -54,12 +52,18 @@ export async function probeMediaStreams(
 
     // ffprobe reads only the container headers via HTTP range requests.
     // -probesize 32k caps the amount read from the network to ~32 KB.
+    // ffprobe emits no frame=/time= progress, so the stall watchdog does not apply here; the shared exec wrapper still
+    // propagates Activity cancellation and bounds the read by the Activity deadline, and passing the URL as an argv
+    // entry (not a shell string) removes the shell-interpolation surface.
     let stdout: string;
     try {
-        ({ stdout } = await execAsync(`ffprobe -v quiet -probesize 32k -print_format json -show_streams "${url}"`, {
-            maxBuffer: FFPROBE_MAX_BUFFER,
-        }));
+        ({ stdout } = await execActivityFile(
+            'ffprobe',
+            ['-v', 'quiet', '-probesize', '32k', '-print_format', 'json', '-show_streams', url],
+            { maxBuffer: FFPROBE_MAX_BUFFER },
+        ));
     } catch (err: unknown) {
+        rethrowIfActivityStopped(err);
         const message = err instanceof Error ? err.message : String(err);
         log.error(`ffprobe failed for object ${objectId}: ${message}`);
         throw new Error(`Failed to probe media streams for object ${objectId}: ${message}`);

--- a/packages/workflow/src/activities/renditions/generateVideoRendition.ts
+++ b/packages/workflow/src/activities/renditions/generateVideoRendition.ts
@@ -1,16 +1,18 @@
-import { execFile as execFileCallback } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { promisify } from 'node:util';
 import { log } from '@temporalio/activity';
 import type { DSLActivityExecutionPayload, DSLActivitySpec } from '@vertesia/common';
 import { setupActivity } from '../../dsl/setup/ActivityContext.js';
 import { DocumentNotFoundError, WorkflowParamNotFoundError } from '../../errors.js';
 import { saveBlobToTempFile } from '../../utils/blobs.js';
 import { type ImageRenditionParams, uploadRenditionPages } from '../../utils/renditions.js';
-
-const execFileAsync = promisify(execFileCallback);
+import {
+    execActivityFile,
+    execActivityFileWithProgress,
+    initializeActivityCommandDeadline,
+    rethrowIfActivityStopped,
+} from '../media/exec.js';
 
 interface GenerateVideoRenditionParams extends ImageRenditionParams {}
 
@@ -32,7 +34,7 @@ interface VideoMetadata {
 async function getVideoMetadata(videoPath: string): Promise<VideoMetadata> {
     try {
         const args = ['-v', 'quiet', '-print_format', 'json', '-show_format', '-show_streams', videoPath];
-        const { stdout } = await execFileAsync('ffprobe', args);
+        const { stdout } = await execActivityFile('ffprobe', args);
         const metadata = JSON.parse(stdout.toString()) as {
             streams?: Array<{ codec_type?: string; width?: number; height?: number }>;
             format?: { duration?: string };
@@ -45,6 +47,7 @@ async function getVideoMetadata(videoPath: string): Promise<VideoMetadata> {
 
         return { duration, width, height };
     } catch (error) {
+        rethrowIfActivityStopped(error);
         log.error(`Failed to get video metadata: ${error instanceof Error ? error.message : 'Unknown error'}`);
         throw new Error(`Failed to probe video metadata: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
@@ -79,7 +82,7 @@ async function generateThumbnail(
     ];
     log.info(`Generating thumbnail at ${timestamp}s`, { command: 'ffmpeg', args: command });
     try {
-        const { stderr } = await execFileAsync('ffmpeg', command);
+        const { stderr } = await execActivityFileWithProgress('ffmpeg', command);
         const stderrText = stderr.toString();
 
         // Log any warnings from ffmpeg
@@ -96,6 +99,7 @@ async function generateThumbnail(
             return undefined;
         }
     } catch (error) {
+        rethrowIfActivityStopped(error);
         log.error(
             `Failed to generate thumbnail at ${timestamp}s: ${error instanceof Error ? error.message : 'Unknown error'}`,
         );
@@ -104,6 +108,7 @@ async function generateThumbnail(
 }
 
 export async function generateVideoRendition(payload: DSLActivityExecutionPayload<GenerateVideoRenditionParams>) {
+    initializeActivityCommandDeadline();
     const { client, objectId, params: originParams } = await setupActivity<GenerateVideoRenditionParams>(payload);
 
     // Fix: Use maxHeightWidth if max_hw is not provided
@@ -209,6 +214,7 @@ export async function generateVideoRendition(payload: DSLActivityExecutionPayloa
             requestedCount: thumbnailCount,
         });
     } catch (error) {
+        rethrowIfActivityStopped(error);
         log.error(`Error generating thumbnails for video: ${error instanceof Error ? error.message : 'Unknown error'}`);
         throw new Error(`Failed to generate thumbnails for video: ${objectId}`);
     } finally {


### PR DESCRIPTION
## Summary
- Add a shared exec helper (`activities/media/exec.ts`) that runs ffmpeg/ffprobe children with the Temporal Activity **cancellation signal** and an **activity-deadline timeout**.
- Add a **progress-stall watchdog** (`execActivityFileWithProgress`) that terminates a wedged ffmpeg child when it stops making progress and surfaces it as a killed error so Temporal retries — instead of burning the full start-to-close timeout. The worker heartbeats regardless of ffmpeg progress, so this is the only thing that catches a stuck transcode on a live worker.
- The progress tracker counts **only monotonic advancement** of `frame=`/`time=` (a wedged encoder that keeps re-emitting an identical status line is still detected as stalled) and **reassembles markers split across stream chunks** (a boundary split cannot false-kill a healthy encode).
- `rethrowIfActivityStopped` lets cancellation/timeout/stall propagate instead of being swallowed by rendition fallback handling (genuine tool failures still fall back).
- Wire it into `prepareVideo`, `prepareAudio`, and `generateVideoRendition` (ffmpeg → watchdog; ffprobe → cancellation/timeout wrapper). `probeMediaStreams` runs ffprobe through the wrapper only — ffprobe emits no `frame=`/`time=` progress, so the stall watchdog does not apply — and now passes the URL as an argv entry instead of a shell string, removing the shell-interpolation surface.

## Test Plan
- [x] `pnpm --filter @vertesia/workflow lint`
- [x] `pnpm --filter @vertesia/workflow build`
- [x] `pnpm --filter @vertesia/workflow typecheck:test`
- [x] New `exec.test.ts`: monotonic-advance (repeated stats do not reset), split-marker reassembly, carriage-return records, stall termination (incl. a chatty-but-wedged child), cancellation, and start-to-close termination — stable across repeated runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)