### PR TITLE
fix: type OpenAI-compatible custom headers

### DIFF
--- a/packages/common/src/environment.ts
+++ b/packages/common/src/environment.ts
@@ -91,6 +91,8 @@ export interface TextFallbackOptions {
 export interface ExecutionEnvironmentSettings {
     [key: string]: unknown;
     bucket_access_principal?: string;
+    /** Custom HTTP headers sent by OpenAI-compatible environments. */
+    default_headers?: Record<string, string>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add an explicit default_headers string map to execution environment settings
- document the field as custom HTTP headers for OpenAI-compatible environments

## Verification
- pnpm run lint
- pnpm run build
- pnpm run typecheck:test