### PR TITLE
Feat: tab changes

### DIFF
--- a/packages/ui/src/core/components/shadcn/tabs.test.tsx
+++ b/packages/ui/src/core/components/shadcn/tabs.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Tabs, TabsBar, TabsPanel } from './tabs';
+
+const TABS = [
+    { name: 'first', label: 'First', href: '#first', content: <div>First panel</div> },
+    { name: 'second', label: 'Second', href: '#second', content: <div>Second panel</div> },
+];
+
+function renderTabs(canChangeTab?: (nextTab: string, currentTab?: string) => boolean) {
+    return render(
+        <Tabs tabs={TABS} defaultValue="first" canChangeTab={canChangeTab}>
+            <TabsBar />
+            <TabsPanel />
+        </Tabs>,
+    );
+}
+
+describe('Tabs canChangeTab', () => {
+    beforeEach(() => {
+        window.history.replaceState(null, '', '/');
+    });
+
+    it('cancels the switch and leaves the hash alone when the guard returns false', () => {
+        const canChangeTab = vi.fn().mockReturnValue(false);
+        renderTabs(canChangeTab);
+
+        fireEvent.click(screen.getByRole('tab', { name: 'Second' }));
+
+        expect(canChangeTab).toHaveBeenCalledWith('second', 'first');
+        expect(screen.getByText('First panel')).toBeDefined();
+        expect(screen.queryByText('Second panel')).toBeNull();
+        expect(window.location.hash).toBe('');
+    });
+
+    it('allows the switch when the guard returns true', () => {
+        const canChangeTab = vi.fn().mockReturnValue(true);
+        renderTabs(canChangeTab);
+
+        fireEvent.click(screen.getByRole('tab', { name: 'Second' }));
+
+        expect(screen.getByText('Second panel')).toBeDefined();
+        expect(window.location.hash).toBe('#second');
+    });
+
+    it('does not consult the guard when the active tab is clicked again', () => {
+        const canChangeTab = vi.fn().mockReturnValue(false);
+        renderTabs(canChangeTab);
+
+        fireEvent.click(screen.getByRole('tab', { name: 'First' }));
+
+        expect(canChangeTab).not.toHaveBeenCalled();
+        expect(screen.getByText('First panel')).toBeDefined();
+    });
+
+    it('still switches from a hash change so a cancelled switch can be resumed', () => {
+        const canChangeTab = vi.fn().mockReturnValue(false);
+        renderTabs(canChangeTab);
+
+        window.location.hash = 'second';
+        fireEvent(window, new HashChangeEvent('hashchange'));
+
+        expect(screen.getByText('Second panel')).toBeDefined();
+    });
+});

--- a/packages/ui/src/core/components/shadcn/tabs.tsx
+++ b/packages/ui/src/core/components/shadcn/tabs.tsx
@@ -15,6 +15,17 @@ export interface Tab {
     is_allowed?: boolean;
 }
 
+/**
+ * Guard consulted before switching to another tab. Return `false` to cancel the switch — the active
+ * tab, the URL hash and the browser history are all left untouched, so the guard can hold the user
+ * on a tab that has unsaved changes while a confirmation is shown.
+ *
+ * It is only called when the target tab differs from the active one, but it may be called more than
+ * once for a single attempted switch (a click reaches both the trigger and the Radix root), so any
+ * side effect it performs must be idempotent.
+ */
+export type CanChangeTab = (nextTab: string, currentTab?: string) => boolean;
+
 const TabsContext = React.createContext<{
     size?: number;
     tabs?: Tab[];
@@ -23,6 +34,7 @@ const TabsContext = React.createContext<{
     responsive?: boolean;
     variant?: 'tabs' | 'pills';
     updateHash?: boolean;
+    canChangeTab?: CanChangeTab;
 }>({
     size: undefined,
     tabs: undefined,
@@ -45,6 +57,7 @@ interface TabsProps {
     responsive?: boolean;
     variant?: 'tabs' | 'pills';
     updateHash?: boolean;
+    canChangeTab?: CanChangeTab;
 }
 
 const Tabs = ({
@@ -59,6 +72,7 @@ const Tabs = ({
     responsive = false,
     variant = 'tabs',
     updateHash = true,
+    canChangeTab,
 }: TabsProps) => {
     // Filter tabs based on is_allowed (undefined or true means visible)
     const visibleTabs = React.useMemo(
@@ -121,6 +135,9 @@ const Tabs = ({
 
     const handleValueChange = React.useCallback(
         (newValue: string) => {
+            // Bail before touching the value or the history so a cancelled switch is a no-op.
+            if (newValue !== value && canChangeTab && !canChangeTab(newValue, value)) return;
+
             setValue(newValue);
 
             // Update the URL hash when tab changes (only if updateHash is true and not controlled by parent)
@@ -135,7 +152,7 @@ const Tabs = ({
                 onTabChange(newValue);
             }
         },
-        [current, onTabChange, updateHash],
+        [current, onTabChange, updateHash, canChangeTab, value],
     );
 
     const setTab = React.useCallback(
@@ -155,6 +172,7 @@ const Tabs = ({
                 responsive: responsive,
                 variant,
                 updateHash,
+                canChangeTab,
             }}
         >
             <TabsPrimitive.Root
@@ -176,13 +194,17 @@ interface TabsBarProps {
 }
 
 const TabsBar = ({ className, sticky, direction }: TabsBarProps) => {
-    const { tabs, size, current, setTab, responsive, variant, updateHash } = React.useContext(TabsContext);
+    const { tabs, size, current, setTab, responsive, variant, updateHash, canChangeTab } =
+        React.useContext(TabsContext);
 
     const fullWidth = size !== 0;
 
     const handleTabChange = React.useCallback(
         (tabName: string) => {
             if (!tabs || !setTab) return;
+            // Consulted here too: this path pushes the tab href before `setTab` reaches the guard in
+            // `Tabs`, so a cancelled switch would otherwise leave the URL pointing at the other tab.
+            if (tabName !== current && canChangeTab && !canChangeTab(tabName, current)) return;
 
             const tab = tabs.find((t) => t.name === tabName);
 
@@ -194,7 +216,7 @@ const TabsBar = ({ className, sticky, direction }: TabsBarProps) => {
 
             setTab(tabName);
         },
-        [tabs, setTab, updateHash],
+        [tabs, setTab, updateHash, canChangeTab, current],
     );
 
     if (!tabs || !setTab) {


### PR DESCRIPTION
## Description

### Tab
- add `canChangeTab` to prevent the user from switching tabs based on the caller logic