### PR TITLE
chore(deps, security): resolve dependency alerts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,15 +20,20 @@ overrides:
   '@types/koa@<3.0.3': ^3.0.3
   vite: 8.1.4
   '@ungap/structured-clone@<=1.3.0': ^1.3.1
+  '@hono/node-server@<2.0.5': 2.0.10
+  brace-expansion@>=2.0.0 <2.1.2: 2.1.2
+  brace-expansion@>=3.0.0 <5.0.7: 5.0.7
   diff@>=6.0.0 <8.0.3: ^8.0.3
   dompurify@<=3.4.10: ^3.4.11
+  fast-uri@>=3.0.0 <3.1.4: 3.1.4
   '@grpc/grpc-js@<1.9.16': ~1.9.16
   '@grpc/grpc-js@>=1.14.0 <1.14.4': ~1.14.4
   form-data@>=4.0.0 <4.0.6: ^4.0.6
-  js-yaml@>=4.0.0 <4.2.0: ^4.2.0
-  protobufjs@<=7.6.2: ^7.6.3
+  js-yaml@>=4.0.0 <4.3.0: 4.3.0
+  protobufjs@<=7.6.4: 7.6.5
   serialize-javascript@<=7.0.2: ^7.0.3
   serialize-javascript@>=5.0.0 <7.0.5: ^7.0.5
+  shell-quote@<=1.8.4: 1.9.0
 
 importers:
 
@@ -140,7 +145,7 @@ importers:
         version: 4.1.0
       koa-send:
         specifier: ^5.0.1
-        version: 5.0.1
+        version: 5.0.1(supports-color@8.1.1)
       path-to-regexp:
         specifier: ^8.4.2
         version: 8.4.2
@@ -218,7 +223,7 @@ importers:
         version: link:../../tsconfig
       supertest:
         specifier: ^7.2.2
-        version: 7.2.2
+        version: 7.2.2(supports-color@8.1.1)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1840,12 +1845,6 @@ packages:
     resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
     engines: {node: '>=6'}
     hasBin: true
-
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
-    peerDependencies:
-      hono: ^4
 
   '@hono/node-server@2.0.10':
     resolution: {integrity: sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==}
@@ -4161,11 +4160,11 @@ packages:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
     engines: {node: '>=18'}
 
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+  brace-expansion@2.1.2:
+    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   browser-stdout@1.3.1:
@@ -4830,8 +4829,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -5265,8 +5264,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   js-yaml@5.2.1:
@@ -6018,8 +6017,8 @@ packages:
     resolution: {integrity: sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==}
     engines: {node: '>=14.0.0'}
 
-  protobufjs@7.6.4:
-    resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
   punycode@2.3.1:
@@ -6324,8 +6323,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.4:
-    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+  shell-quote@1.9.0:
+    resolution: {integrity: sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.1:
@@ -7904,19 +7903,15 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.6.4
+      protobufjs: 7.6.5
       yargs: 17.7.2
 
   '@grpc/proto-loader@0.8.0':
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.6.4
+      protobufjs: 7.6.5
       yargs: 17.7.2
-
-  '@hono/node-server@1.19.14(hono@4.12.30)':
-    dependencies:
-      hono: 4.12.30
 
   '@hono/node-server@2.0.10(hono@4.12.30)':
     dependencies:
@@ -7924,7 +7919,7 @@ snapshots:
 
   '@hono/vite-dev-server@0.26.1(hono@4.12.30)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.30)
+      '@hono/node-server': 2.0.10(hono@4.12.30)
       hono: 4.12.30
       minimatch: 9.0.9
 
@@ -9358,7 +9353,7 @@ snapshots:
   '@temporalio/proto@1.20.3':
     dependencies:
       long: 5.3.2
-      protobufjs: 7.6.4
+      protobufjs: 7.6.5
 
   '@temporalio/testing@1.20.3(esbuild@0.28.1)(tslib@2.8.1)':
     dependencies:
@@ -9399,7 +9394,7 @@ snapshots:
       heap-js: 2.7.1
       memfs: 4.56.10(tslib@2.8.1)
       nexus-rpc: 0.0.2
-      protobufjs: 7.6.4
+      protobufjs: 7.6.5
       rxjs: 7.8.2
       source-map: 0.7.6
       source-map-loader: 5.0.0(webpack@5.108.4(@swc/core@1.15.41)(esbuild@0.28.1))
@@ -9953,7 +9948,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -10026,11 +10021,11 @@ snapshots:
       widest-line: 5.0.0
       wrap-ansi: 9.0.2
 
-  brace-expansion@2.1.1:
+  brace-expansion@2.1.2:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -10177,7 +10172,7 @@ snapshots:
     dependencies:
       chalk: 5.6.2
       rxjs: 7.8.2
-      shell-quote: 1.8.4
+      shell-quote: 1.9.0
       supports-color: 10.2.2
       tree-kill: 1.2.2
       yargs: 18.0.0
@@ -10669,7 +10664,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.4: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:
@@ -11225,7 +11220,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -11309,7 +11304,7 @@ snapshots:
 
   koa-compose@4.1.0: {}
 
-  koa-send@5.0.1:
+  koa-send@5.0.1(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       http-errors: 1.8.1
@@ -11961,11 +11956,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 2.1.2
 
   minimist@1.2.8: {}
 
@@ -12000,7 +11995,7 @@ snapshots:
       glob: 10.5.0
       he: 1.2.0
       is-path-inside: 3.0.3
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       log-symbols: 4.1.0
       minimatch: 9.0.9
       ms: 2.1.3
@@ -12211,9 +12206,9 @@ snapshots:
 
   proto3-json-serializer@2.0.2:
     dependencies:
-      protobufjs: 7.6.4
+      protobufjs: 7.6.5
 
-  protobufjs@7.6.4:
+  protobufjs@7.6.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -12655,7 +12650,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.4: {}
+  shell-quote@1.9.0: {}
 
   side-channel-list@1.0.1:
     dependencies:
@@ -12787,7 +12782,7 @@ snapshots:
 
   stylis@4.3.6: {}
 
-  superagent@10.3.0:
+  superagent@10.3.0(supports-color@8.1.1):
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
@@ -12801,11 +12796,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  supertest@7.2.2:
+  supertest@7.2.2(supports-color@8.1.1):
     dependencies:
       cookie-signature: 1.2.2
       methods: 1.1.2
-      superagent: 10.3.0
+      superagent: 10.3.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,7 +20,13 @@ minimumReleaseAgeExclude:
   - "@vertesia/*"
   - "@llumiverse/*"
   # Additional excludes, due to CVEs etc.
-  # Nothing for now
+  # Security updates for Dependabot alerts #215-#224.
+  - brace-expansion@2.1.2
+  - brace-expansion@5.0.7
+  - fast-uri@3.1.4
+  - js-yaml@4.3.0
+  - protobufjs@7.6.5
+  - shell-quote@1.9.0
 catalog:
   react: "19.2.7"
   react-dom: "19.2.7"
@@ -54,13 +60,18 @@ overrides:
   # Standard CVE overrides
   # ============================
   "@ungap/structured-clone@<=1.3.0": ^1.3.1 #CWE-502 and package deprecation, won't show as CVE.
+  "@hono/node-server@<2.0.5": 2.0.10
+  "brace-expansion@>=2.0.0 <2.1.2": 2.1.2
+  "brace-expansion@>=3.0.0 <5.0.7": 5.0.7
   diff@>=6.0.0 <8.0.3: ^8.0.3
   dompurify@<=3.4.10: ^3.4.11
+  "fast-uri@>=3.0.0 <3.1.4": 3.1.4
   # Tilde (not caret) so @firebase/firestore stays on its ~1.9 line and @temporalio/* on 1.14.
   "@grpc/grpc-js@<1.9.16": ~1.9.16
   "@grpc/grpc-js@>=1.14.0 <1.14.4": ~1.14.4
   form-data@>=4.0.0 <4.0.6: ^4.0.6
-  js-yaml@>=4.0.0 <4.2.0: ^4.2.0
-  protobufjs@<=7.6.2: ^7.6.3
+  js-yaml@>=4.0.0 <4.3.0: 4.3.0
+  protobufjs@<=7.6.4: 7.6.5
   serialize-javascript@<=7.0.2: ^7.0.3
   serialize-javascript@>=5.0.0 <7.0.5: ^7.0.5
+  shell-quote@<=1.8.4: 1.9.0

--- a/tools/environment-configuration/pnpm-lock.yaml
+++ b/tools/environment-configuration/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   picomatch@>=4.0.0 <4.0.4: ^4.0.5
   fast-xml-parser@<5.7.0: ^5.10.0
   fast-xml-builder@<=1.1.6: ^1.3.0
-  fast-uri@<=3.1.1: ^4.1.0
+  fast-uri@<4.1.1: 4.1.1
 
 importers:
 
@@ -285,8 +285,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@4.1.0:
-    resolution: {integrity: sha512-ZodJ2cRiLVWGi9IgPb3mbgSqM4CD3LexCHkuv0FfBXHJI1ADfucTD06m6clO2Cy5RZYsw/SiCVl/dyrFI/SYWA==}
+  fast-uri@4.1.1:
+    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
 
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
@@ -614,7 +614,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.0
+      fast-uri: 4.1.1
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -656,7 +656,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@4.1.0: {}
+  fast-uri@4.1.1: {}
 
   fetch-blob@3.2.0:
     dependencies:

--- a/tools/environment-configuration/pnpm-workspace.yaml
+++ b/tools/environment-configuration/pnpm-workspace.yaml
@@ -11,10 +11,10 @@ overrides:
   "picomatch@>=4.0.0 <4.0.4": "^4.0.5"
   "fast-xml-parser@<5.7.0": "^5.10.0"
   "fast-xml-builder@<=1.1.6": "^1.3.0"
-  "fast-uri@<=3.1.1": "^4.1.1"
+  "fast-uri@<4.1.1": "4.1.1"
 minimumReleaseAge: 4320 # 3 days in minutes, minimumReleaseAge protects against supply chain attacks.
 minimumReleaseAgeExclude:
   - '@vertesia/*'
   - '@llumiverse/*'
-  # Renovate security update: fast-uri@<=3.1.1@4.1.1
-  - fast-uri@<=3.1.1@4.1.1
+  # Renovate security update: fast-uri@4.1.1
+  - fast-uri@4.1.1


### PR DESCRIPTION
## Summary

- Pin patched Hono, brace-expansion, fast-uri, js-yaml, protobufjs, and shell-quote versions across the workspace
- Fix the standalone environment-configuration override and lockfile for fast-uri 4.1.1
- Update the llumiverse submodule to include its dependency security fixes

## Submodule Changes

- llumiverse: https://github.com/vertesia/llumiverse/pull/554

## Test Plan

- [x] `pnpm run check`
- [x] `pnpm build`
- [x] `pnpm run ci:test`