### PR TITLE
test(workflow): cover app-contributed type assignment during intake

### DIFF
--- a/packages/workflow/src/activities/generateOrAssignContentType.test.ts
+++ b/packages/workflow/src/activities/generateOrAssignContentType.test.ts
@@ -91,6 +91,7 @@ async function mockSetup(
         }),
     );
     const listTypes = vi.fn(() => Promise.resolve(types));
+    const createType = vi.fn(() => Promise.resolve({ id: 'type-new', name: 'NewType' }));
 
     vi.mocked(setupActivity).mockImplementation((activityPayload) =>
         Promise.resolve({
@@ -103,6 +104,7 @@ async function mockSetup(
                     catalog: {
                         list: listTypes,
                     },
+                    create: createType,
                 },
             } as unknown as VertesiaClient,
             fetchProject: vi.fn(() => Promise.resolve({ configuration: {} })),
@@ -111,10 +113,37 @@ async function mockSetup(
         } as unknown as ActivityContext<GenerateOrAssignContentTypeParams>),
     );
 
-    return { listTypes, update };
+    return { createType, listTypes, update };
 }
 
 describe('generateOrAssignContentType', () => {
+    it('assigns an app-contributed type instead of generating a duplicate', async () => {
+        // An `app:<app>:<type>` entry in the catalog is a real selection candidate: when the model
+        // picks it, the activity must assign it as-is and create nothing. If app-contributed types
+        // are missing from the catalog, selection cannot match one and a duplicate stored type gets
+        // generated for a document the installed app already had a type for.
+        const appType = {
+            id: 'app:invoice-app:Invoice',
+            name: 'Invoice',
+            status: 'active',
+        } as ContentObjectTypeItem;
+        const { createType, update } = await mockSetup([appType, typeItem('GenericDocument', 'active')]);
+        mockSelectionResult('Invoice');
+
+        const result: GenerateOrAssignContentTypeResult = await testEnv.run(
+            generateOrAssignContentType,
+            payload({ allowNewContentTypes: true }),
+        );
+
+        expect(createType).not.toHaveBeenCalled();
+        expect(update).toHaveBeenCalledWith(
+            'object-1',
+            { type: 'app:invoice-app:Invoice' },
+            { suppressWorkflows: true },
+        );
+        expect(result).toEqual({ id: 'app:invoice-app:Invoice', isNew: false, name: 'Invoice' });
+    });
+
     it('excludes draft types from selection and does not assign them if returned by the model', async () => {
         const { update } = await mockSetup([
             typeItem('Invoice', 'active'),


### PR DESCRIPTION
## Summary

- Add a regression test asserting that `generateOrAssignContentType` assigns an app-contributed `app:<app>:<type>` candidate when the model selects it, instead of generating a duplicate stored type.
- Add a `types.create` mock to the shared `mockSetup` helper so the test can assert that nothing is created.

An `app:<app>:<type>` entry in the type catalog is a real selection candidate. If app-contributed types are absent from the catalog, selection cannot match one and the activity generates a duplicate stored type for a document an installed app already has a type for. This test pins the intended behaviour so that path stays covered.

Test-only change — no runtime behaviour is modified.

## Test Plan

- [x] `pnpm lint` in `packages/workflow` — clean
- [x] `pnpm typecheck:test` in `packages/workflow` — clean
- [x] `vitest run` in `packages/workflow` — 26 files, 174 tests passing