### PR TITLE
fix(ui): replayed file_processing snapshots rehydrate composer file chips

### DIFF
--- a/packages/ui/src/features/agent/chat/hooks/useAgentStream.test.tsx
+++ b/packages/ui/src/features/agent/chat/hooks/useAgentStream.test.tsx
@@ -312,6 +312,63 @@ describe('useAgentStream', () => {
         expect(onMessage).toHaveBeenCalledTimes(1);
     });
 
+    it('does not apply replayed file_processing snapshots to server file updates', async () => {
+        let deliver: ((message: AgentMessage) => void) | undefined;
+        const fileSnapshot = (timestamp: number, id: string): AgentMessage =>
+            ({
+                timestamp,
+                workflow_run_id: 'run-1',
+                type: AgentMessageType.SYSTEM,
+                message: '',
+                workstream_id: 'main',
+                details: {
+                    system_type: 'file_processing',
+                    batch_id: 'batch-1',
+                    files: [
+                        {
+                            id,
+                            name: `${id}.pdf`,
+                            content_type: 'application/pdf',
+                            size: 1,
+                            status: FileProcessingStatus.READY,
+                            artifact_path: `files/${id}.pdf`,
+                            reference: `artifact:files/${id}.pdf`,
+                        },
+                    ],
+                    pending_count: 0,
+                    ready_count: 1,
+                    error_count: 0,
+                },
+            }) as AgentMessage;
+        const historical = fileSnapshot(1_000, 'old-upload');
+        const streamMessages = vi.fn<
+            (
+                id: string,
+                onMessage?: (message: AgentMessage, exitFn?: (payload: unknown) => void) => void,
+                since?: number,
+                signal?: AbortSignal,
+                options?: AgentRunStreamMessagesOptions,
+            ) => Promise<unknown>
+        >(async (_id, onMessage, _since, _signal, options) => {
+            deliver = onMessage;
+            options?.onHistoryLoaded?.([historical]);
+            // Completed runs replay archived file_processing snapshots through the
+            // live callback; applying them would rehydrate every historical upload
+            // as a staged composer chip on reopen.
+            onMessage?.(historical);
+            return null;
+        });
+        const client = createClient(streamMessages);
+        const { result } = renderHook(() => useAgentStream(client, 'agent-run-1', vi.fn()));
+
+        await waitFor(() => expect(deliver).toBeDefined());
+        expect(result.current.serverFileUpdates.size).toBe(0);
+
+        act(() => deliver?.(fileSnapshot(1_100, 'new-upload')));
+        expect(result.current.serverFileUpdates.size).toBe(1);
+        expect(result.current.serverFileUpdates.has('new-upload')).toBe(true);
+    });
+
     it('marks initial history as errored when the history fetch fails', async () => {
         const streamMessages = vi.fn<
             (

--- a/packages/ui/src/features/agent/chat/hooks/useAgentStream.test.tsx
+++ b/packages/ui/src/features/agent/chat/hooks/useAgentStream.test.tsx
@@ -314,32 +314,32 @@ describe('useAgentStream', () => {
 
     it('does not apply replayed file_processing snapshots to server file updates', async () => {
         let deliver: ((message: AgentMessage) => void) | undefined;
-        const fileSnapshot = (timestamp: number, id: string): AgentMessage =>
-            ({
-                timestamp,
-                workflow_run_id: 'run-1',
-                type: AgentMessageType.SYSTEM,
-                message: '',
-                workstream_id: 'main',
-                details: {
-                    system_type: 'file_processing',
-                    batch_id: 'batch-1',
-                    files: [
-                        {
-                            id,
-                            name: `${id}.pdf`,
-                            content_type: 'application/pdf',
-                            size: 1,
-                            status: FileProcessingStatus.READY,
-                            artifact_path: `files/${id}.pdf`,
-                            reference: `artifact:files/${id}.pdf`,
-                        },
-                    ],
-                    pending_count: 0,
-                    ready_count: 1,
-                    error_count: 0,
-                },
-            }) as AgentMessage;
+        const fileSnapshot = (timestamp: number, id: string): AgentMessage => ({
+            timestamp,
+            workflow_run_id: 'run-1',
+            type: AgentMessageType.SYSTEM,
+            message: '',
+            workstream_id: 'main',
+            details: {
+                system_type: 'file_processing',
+                batch_id: 'batch-1',
+                files: [
+                    {
+                        id,
+                        name: `${id}.pdf`,
+                        content_type: 'application/pdf',
+                        size: 1,
+                        status: FileProcessingStatus.READY,
+                        artifact_path: `files/${id}.pdf`,
+                        reference: `artifact:files/${id}.pdf`,
+                        started_at: timestamp,
+                    },
+                ],
+                pending_count: 0,
+                ready_count: 1,
+                error_count: 0,
+            },
+        });
         const historical = fileSnapshot(1_000, 'old-upload');
         const streamMessages = vi.fn<
             (

--- a/packages/ui/src/features/agent/chat/hooks/useAgentStream.ts
+++ b/packages/ui/src/features/agent/chat/hooks/useAgentStream.ts
@@ -357,9 +357,12 @@ export function useAgentStream(
                 (message) => {
                     if (abortController.signal.aborted) return;
                     // Completed and idle runs replay their archived history through the live
-                    // stream. Only forward genuinely new deliveries so onMessage consumers
+                    // stream. Track replay status once, before the cursor advances below —
+                    // every replay-sensitive consumer in this callback must use it.
+                    const isReplay = Boolean(message.timestamp && message.timestamp <= lastDeliveredTsRef.current);
+                    // Only forward genuinely new deliveries so onMessage consumers
                     // never treat replayed events as fresh ones.
-                    if (!message.timestamp || message.timestamp > lastDeliveredTsRef.current) {
+                    if (!isReplay) {
                         onMessageRef.current?.(message);
                     }
 
@@ -426,7 +429,13 @@ export function useAgentStream(
                     if (message.type === AgentMessageType.SYSTEM) {
                         const details = message.details as FileProcessingDetails | undefined;
                         if (details?.system_type === 'file_processing' && details.files) {
-                            setServerFileUpdates(new Map(details.files.map((file) => [file.id, file])));
+                            // Replayed snapshots list every file ever uploaded to the run as
+                            // READY; applying them on reconnect would rehydrate historical
+                            // uploads as staged composer chips. Only genuinely new updates
+                            // may touch the file state.
+                            if (!isReplay) {
+                                setServerFileUpdates(new Map(details.files.map((file) => [file.id, file])));
+                            }
                             return;
                         }
                         // Other SYSTEM messages fall through to normal handling


### PR DESCRIPTION
## Summary

- `useAgentStream` gates `onMessage` forwarding on the delivery watermark, but the `file_processing` SYSTEM branch ran **after** the cursor advanced with no replay guard. Completed/idle runs replay archived history through the live stream callback, so reopening a conversation applied the last replayed `file_processing` snapshot — every file ever uploaded to the run, status READY — to `serverFileUpdates`, rehydrating all historical uploads as staged "Ready" chips in the message composer.
- Fix: track replay status once at the top of the live callback (before the cursor advances) and apply `file_processing` updates only for genuinely new deliveries. Composer chips are now only files staged in the current session.

## Test Plan

- [x] New regression test: replayed `file_processing` snapshot leaves `serverFileUpdates` empty; a live snapshot after history still applies (mirrors the existing replay-gating test).
- [x] `packages/ui` full suite passes.
- [x] `pnpm build` in `packages/ui`: clean.
- [x] Biome check on changed files: clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted guard in agent chat streaming with a focused regression test; no auth, API, or data-model changes.
> 
> **Overview**
> Reopening a completed or idle agent run replays archived stream events, including **`file_processing`** SYSTEM snapshots that list every file ever uploaded as READY. **`useAgentStream`** already avoided treating replays as live **`onMessage`** traffic, but the **`file_processing`** branch still wrote those snapshots into **`serverFileUpdates`**, which **`useFileProcessing`** uses to show staged composer chips—so historical uploads looked newly ready.
> 
> The live callback now computes **`isReplay`** once (against **`lastDeliveredTsRef`**, before the delivery cursor advances) and only applies **`file_processing`** updates when **`!isReplay`**. A regression test asserts replayed snapshots leave **`serverFileUpdates`** empty while a later live snapshot still applies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05c0173f4906f430288fa4f5dde1c407a48b8f0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->