### PR TITLE
chore(deps, security): raise brace-expansion floor, add js-yaml 5.x floor

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ overrides:
   vite: 8.1.4
   '@ungap/structured-clone@<=1.3.0': ^1.3.1
   '@hono/node-server@<2.0.5': 2.0.10
-  brace-expansion@>=2.0.0 <2.1.2: 2.1.2
-  brace-expansion@>=3.0.0 <5.0.7: 5.0.7
+  brace-expansion@>=2.0.0 <2.1.4: 2.1.4
+  brace-expansion@>=3.0.0 <5.0.8: 5.0.8
   diff@>=6.0.0 <8.0.3: ^8.0.3
   dompurify@<=3.4.10: ^3.4.11
   fast-uri@>=3.0.0 <3.1.4: 3.1.4
@@ -30,6 +30,7 @@ overrides:
   '@grpc/grpc-js@>=1.14.0 <1.14.4': ~1.14.4
   form-data@>=4.0.0 <4.0.6: ^4.0.6
   js-yaml@>=4.0.0 <4.3.0: 4.3.0
+  js-yaml@>=5.0.0 <5.2.2: 5.2.2
   protobufjs@<=7.6.4: 7.6.5
   serialize-javascript@<=7.0.2: ^7.0.3
   serialize-javascript@>=5.0.0 <7.0.5: ^7.0.5
@@ -306,7 +307,7 @@ importers:
         specifier: ^0.28.1
         version: 0.28.1
       js-yaml:
-        specifier: ^5.2.1
+        specifier: 5.2.2
         version: 5.2.2
       zod:
         specifier: ^4.4.3
@@ -4226,12 +4227,12 @@ packages:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
     engines: {node: '>=18'}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   browser-stdout@1.3.1:
     resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
@@ -10176,11 +10177,11 @@ snapshots:
       widest-line: 5.0.0
       wrap-ansi: 9.0.2
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -12095,11 +12096,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,6 +21,9 @@ minimumReleaseAgeExclude:
   - "@llumiverse/*"
   # Renovate security update: js-yaml@5.2.2
   - js-yaml@5.2.2
+  # GHSA-mh99-v99m-4gvg backport to the 2.x line, published 2026-07-30. Version-scoped exception
+  # so we take the fix now rather than waiting out the 3-day cooldown.
+  - brace-expansion@2.1.4
 catalog:
   react: "19.2.7"
   react-dom: "19.2.7"
@@ -54,8 +57,13 @@ overrides:
   # ============================
   "@ungap/structured-clone@<=1.3.0": ^1.3.1 #CWE-502 and package deprecation, won't show as CVE.
   "@hono/node-server@<2.0.5": 2.0.10
-  "brace-expansion@>=2.0.0 <2.1.2": 2.1.2
-  "brace-expansion@>=3.0.0 <5.0.7": 5.0.7
+  # GHSA-mh99-v99m-4gvg. Each major line is floored on its own backport rather than forced to
+  # 5.0.8, which would be a cross-major jump for its consumers (mocha, @hono/vite-dev-server).
+  # 2.1.4 needs the minimumReleaseAgeExclude entry above. Note the advisory still declares
+  # `>=5.0.8` as its only patched range, so `pnpm audit` may keep reporting the 2.x copy until
+  # GHSA re-scopes it — 2.1.4 does carry the fix (EXPANSION_MAX_LENGTH, CVE-2026-14257).
+  "brace-expansion@>=2.0.0 <2.1.4": 2.1.4
+  "brace-expansion@>=3.0.0 <5.0.8": 5.0.8
   diff@>=6.0.0 <8.0.3: ^8.0.3
   dompurify@<=3.4.10: ^3.4.11
   "fast-uri@>=3.0.0 <3.1.4": 3.1.4
@@ -64,6 +72,11 @@ overrides:
   "@grpc/grpc-js@>=1.14.0 <1.14.4": ~1.14.4
   form-data@>=4.0.0 <4.0.6: ^4.0.6
   js-yaml@>=4.0.0 <4.3.0: 4.3.0
+  # GHSA-pm4m-ph32-ghv5 (5.x line, reached via packages/build-tools). This lockfile already
+  # resolves 5.2.2; the floor pins that in place so a future resolution cannot drop back to a
+  # vulnerable 5.x. Major-scoped on purpose — a bare `js-yaml@<5.2.2` would drag the 4.x
+  # consumers above across a major.
+  "js-yaml@>=5.0.0 <5.2.2": 5.2.2
   protobufjs@<=7.6.4: 7.6.5
   serialize-javascript@<=7.0.2: ^7.0.3
   serialize-javascript@>=5.0.0 <7.0.5: ^7.0.5


### PR DESCRIPTION
## Summary

Addresses the `pnpm audit` findings for this workspace.

- **`brace-expansion`** (GHSA-mh99-v99m-4gvg — DoS via unbounded expansion length causing an out-of-memory crash). Each major line is floored on its own backport rather than forcing everything to `5.0.8`: **2.x -> 2.1.4**, **5.x -> 5.0.8**. Forcing the 2.x consumers (`mocha`, `@hono/vite-dev-server`) onto 5.x would be a cross-major jump for transitive dependents.
- **`js-yaml`** — new **5.x floor of 5.2.2** (GHSA-pm4m-ph32-ghv5, exponential parsing time in flow collections leading to DoS). This lockfile already resolved `5.2.2` via `packages/build-tools`; the floor pins that so a future resolution cannot drop back to a vulnerable 5.x. Deliberately scoped `>=5.0.0 <5.2.2` rather than a bare `<5.2.2`, which would drag the existing 4.x consumers across a major.

### On the brace-expansion 2.x entry

`2.1.4` was published inside our 3-day `minimumReleaseAge` cooldown, so it needs a version-scoped `minimumReleaseAgeExclude` entry — cooldown protection stays in place for every other `brace-expansion` release.

Worth knowing for whoever reads the audit next: the advisory still declares `>=5.0.8` as its **only** patched range, which semver-wise excludes the 1.x/2.x backports. So `pnpm audit` keeps reporting the 2.x copy after this change. That is a reporting artifact, not exposure — `2.1.4` does carry the fix (it ships `EXPANSION_MAX_LENGTH = 4000000` and references CVE-2026-14257). This is noted in a comment next to the override so it is not "fixed" later by forcing a cross-major jump.

## Submodule Changes

- llumiverse: https://github.com/vertesia/llumiverse/pull/560 (brace-expansion + postcss floors). The submodule pointer here targets that PR's branch and will be repointed to the merged commit before this merges.

## Test Plan

- [x] `pnpm audit` — `js-yaml` and the 5.x `brace-expansion` findings cleared; the 2.x report that remains is the advisory-range artifact described above.
- [x] `pnpm install --frozen-lockfile` — passes, lockfile consistent with the workspace config.
- [x] `pnpm build` — 23/23 tasks successful.