### PR TITLE
feat(chat): improve active conversation feedback

### DIFF
--- a/packages/common/src/ask-user.ts
+++ b/packages/common/src/ask-user.ts
@@ -55,7 +55,15 @@ export interface AskUserUxConfig {
 }
 
 /** Message details structure for REQUEST_INPUT messages with UX config */
-export interface AskUserMessageDetails {
+export interface AskUserMessageDetails extends Record<string, unknown> {
+    /** Stable identifier used to correlate this prompt with the user's persisted response. */
+    request_id?: string;
     /** UX configuration for rendering the ask_user widget */
     ux?: AskUserUxConfig;
+}
+
+/** Metadata carried by a user response to a structured REQUEST_INPUT message. */
+export interface RequestInputResponseMetadata {
+    /** Stable identifier copied from the REQUEST_INPUT message. */
+    request_id: string;
 }

--- a/packages/ui/src/features/agent/chat/AgentChatPlaybackControls.test.tsx
+++ b/packages/ui/src/features/agent/chat/AgentChatPlaybackControls.test.tsx
@@ -24,6 +24,8 @@ describe('AgentChatPlaybackControls', () => {
             <AgentChatPlaybackControls cursor="live" messages={messages} onChangeCursor={onChangeCursor} />,
         );
 
+        expect(screen.getByText('Debug')).toBeTruthy();
+
         fireEvent.click(screen.getByRole('button', { name: 'Jump to first message' }));
 
         expect(onChangeCursor).toHaveBeenCalledWith(0);

--- a/packages/ui/src/features/agent/chat/AgentRequestInputOverlay.test.tsx
+++ b/packages/ui/src/features/agent/chat/AgentRequestInputOverlay.test.tsx
@@ -1,22 +1,30 @@
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { AgentMessageType } from '@vertesia/common';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../__tests__/test-utils.js';
 import { AgentRequestInputOverlay } from './AgentRequestInputOverlay';
 import type { RequestInputMessageWithUx } from './ModernAgentOutput/requestInputMessages';
+
+const mocks = vi.hoisted(() => ({
+    getCollectionStatus: vi.fn(),
+}));
 
 vi.mock('@vertesia/ui/session', () => ({
     useUserSession: () => ({
         client: {
             remoteMcpConnections: {
-                getCollectionStatus: vi.fn(),
+                getCollectionStatus: mocks.getCollectionStatus,
             },
         },
     }),
 }));
 
 vi.mock('../../oauth/RemoteMcpConnectionButton.js', () => ({
-    RemoteMcpConnectionButton: () => <button type="button">Connect</button>,
+    RemoteMcpConnectionButton: ({ onAuthChange }: { onAuthChange: () => void }) => (
+        <button type="button" onClick={onAuthChange}>
+            Connect
+        </button>
+    ),
 }));
 
 function createMcpRequestMessage(): RequestInputMessageWithUx {
@@ -27,6 +35,7 @@ function createMcpRequestMessage(): RequestInputMessageWithUx {
         workstream_id: 'main',
         message: 'Connect to Jira to continue.',
         details: {
+            request_id: 'request-mcp-1',
             ux: {
                 mcp_connect: {
                     app_install_id: 'app1',
@@ -46,6 +55,7 @@ function createToolApprovalRequestMessage(): RequestInputMessageWithUx {
         workstream_id: 'main',
         message: 'Approve Write Artifact: quotes.md?',
         details: {
+            request_id: 'write_artifact:name:quotes.md',
             tool_approval: {
                 tool_name: 'write_artifact',
                 tool_title: 'Write Artifact',
@@ -74,6 +84,11 @@ function createToolApprovalRequestMessage(): RequestInputMessageWithUx {
 }
 
 describe('AgentRequestInputOverlay', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.getCollectionStatus.mockResolvedValue({ authenticated: true });
+    });
+
     it('lets the user decline an MCP connection request', () => {
         const onSendMessage = vi.fn();
 
@@ -86,7 +101,29 @@ describe('AgentRequestInputOverlay', () => {
         fireEvent.click(screen.getByRole('button', { name: /decline/i }));
 
         expect(onSendMessage).toHaveBeenCalledTimes(1);
-        expect(onSendMessage).toHaveBeenCalledWith("I don't want to connect to Jira. Continue without it.");
+        expect(onSendMessage).toHaveBeenCalledWith("I don't want to connect to Jira. Continue without it.", {
+            request_input_response: { request_id: 'request-mcp-1' },
+        });
+    });
+
+    it('correlates a successful MCP connection response', async () => {
+        const onMcpConnected = vi.fn();
+
+        renderWithProviders(
+            <AgentRequestInputOverlay
+                message={createMcpRequestMessage()}
+                onSendMessage={vi.fn()}
+                onMcpConnected={onMcpConnected}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Connect' }));
+
+        await waitFor(() => {
+            expect(onMcpConnected).toHaveBeenCalledWith(expect.objectContaining({ collection_id: 'jira' }), {
+                request_input_response: { request_id: 'request-mcp-1' },
+            });
+        });
     });
 
     it('sends a commented tool approval denial with structured metadata', () => {
@@ -107,6 +144,9 @@ describe('AgentRequestInputOverlay', () => {
                 decision: 'deny_with_feedback',
                 approval_key: 'write_artifact:name:quotes.md',
             },
+            request_input_response: {
+                request_id: 'write_artifact:name:quotes.md',
+            },
         });
     });
 
@@ -125,6 +165,9 @@ describe('AgentRequestInputOverlay', () => {
                 decision: 'allow_for_run',
                 approval_key: 'write_artifact:name:quotes.md',
             },
+            request_input_response: {
+                request_id: 'write_artifact:name:quotes.md',
+            },
         });
     });
 
@@ -138,7 +181,9 @@ describe('AgentRequestInputOverlay', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Allow once' }));
 
         expect(onSendMessage).toHaveBeenCalledTimes(1);
-        expect(onSendMessage).toHaveBeenCalledWith('allow_once');
+        expect(onSendMessage).toHaveBeenCalledWith('allow_once', {
+            request_input_response: { request_id: 'write_artifact:name:quotes.md' },
+        });
     });
 
     it('renders legacy field-prefixed tool approval prompts with a friendly target', () => {

--- a/packages/ui/src/features/agent/chat/AgentRequestInputOverlay.tsx
+++ b/packages/ui/src/features/agent/chat/AgentRequestInputOverlay.tsx
@@ -7,15 +7,17 @@ import { RemoteMcpConnectionButton } from '../../oauth/RemoteMcpConnectionButton
 import { AskUserWidget } from './AskUserWidget';
 import {
     getRequestInputDisplayText,
+    getRequestInputResponseMetadata,
     getToolApprovalResponseMetadata,
     type RequestInputMessageWithUx,
+    sendRequestInputResponse,
 } from './ModernAgentOutput/requestInputMessages';
 
 export interface AgentRequestInputOverlayProps {
     message?: RequestInputMessageWithUx;
     onSendMessage?: (message: string, metadata?: Record<string, unknown>) => void;
     /** Called after the user connects the MCP server requested by request_mcp_connection. */
-    onMcpConnected?: (cfg: McpConnectUxConfig) => void;
+    onMcpConnected?: (cfg: McpConnectUxConfig, metadata?: Record<string, unknown>) => void;
     isLoading?: boolean;
     disabled?: boolean;
     className?: string;
@@ -81,11 +83,7 @@ export function AgentRequestInputOverlay({
     const displayText = getRequestInputDisplayText(message);
     const send = (value: string, metadata?: Record<string, unknown>) => {
         if (isDisabled) return;
-        if (metadata) {
-            onSendMessage?.(value, metadata);
-        } else {
-            onSendMessage?.(value);
-        }
+        sendRequestInputResponse(onSendMessage, message, value, metadata);
     };
 
     const wrapperClassName = cn(
@@ -102,7 +100,7 @@ export function AgentRequestInputOverlay({
                     <div className="min-w-0 text-sm leading-6 text-foreground/85">{displayText}</div>
                     <McpRequestInputControls
                         mcpConnect={mcpConnect}
-                        onMcpConnected={onMcpConnected}
+                        onMcpConnected={(cfg) => onMcpConnected?.(cfg, getRequestInputResponseMetadata(message))}
                         onDecline={() => send(t('agent.mcpDeclinedMessage', { name: mcpConnect.name }))}
                         disabled={isDisabled}
                     />

--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.test.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.test.tsx
@@ -2331,7 +2331,7 @@ describe('ModernAgentConversation send handling', () => {
         );
     });
 
-    it('hides the rewind button when the playback toggle is disabled', () => {
+    it('hides the debug button when the playback toggle is disabled', () => {
         mockStreamState({
             messages: [
                 createMessage(AgentMessageType.QUESTION, 'first question'),

--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.test.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.test.tsx
@@ -253,6 +253,7 @@ function latestRightPanelProps() {
 describe('ModernAgentConversation send handling', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        window.sessionStorage.clear();
         mocks.restart.mockResolvedValue({ id: 'agent-run-1' });
         mocks.sendSignal.mockResolvedValue({});
         mocks.getActiveWorkstreams.mockResolvedValue({ running: [] });
@@ -1486,6 +1487,80 @@ describe('ModernAgentConversation send handling', () => {
                 }),
             }),
         );
+    });
+
+    it('does not resurrect an answered request overlay after remounting before the persisted echo arrives', async () => {
+        const requestMessage = {
+            ...createMessage(AgentMessageType.REQUEST_INPUT, 'What is your favorite color?'),
+            details: {
+                request_id: 'ask-user-1',
+                ux: {
+                    options: [
+                        { id: 'red', label: 'Red' },
+                        { id: 'blue', label: 'Blue' },
+                    ],
+                },
+            },
+        };
+        mockStreamState({
+            messages: [requestMessage],
+            isCompleted: false,
+            agentRunStatus: 'RUNNING',
+        });
+
+        const firstView = renderConversation();
+        fireEvent.click(screen.getByRole('button', { name: /Blue/ }));
+
+        await waitFor(() => expect(mocks.sendSignal).toHaveBeenCalledTimes(1));
+        expect(mocks.sendSignal).toHaveBeenCalledWith(
+            'agent-run-1',
+            'UserInput',
+            expect.objectContaining({
+                metadata: expect.objectContaining({
+                    request_input_response: { request_id: 'ask-user-1' },
+                }),
+            }),
+        );
+
+        firstView.unmount();
+        renderConversation();
+
+        expect(screen.queryByText('What is your favorite color?')).toBeNull();
+        expect(screen.queryByRole('button', { name: /Blue/ })).toBeNull();
+    });
+
+    it('restores a request overlay after its response fails to send', async () => {
+        mocks.sendSignal.mockRejectedValueOnce(new Error('offline'));
+        const requestMessage = {
+            ...createMessage(AgentMessageType.REQUEST_INPUT, 'What is your favorite color?'),
+            details: {
+                request_id: 'ask-user-1',
+                ux: {
+                    options: [
+                        { id: 'red', label: 'Red' },
+                        { id: 'blue', label: 'Blue' },
+                    ],
+                },
+            },
+        };
+        mockStreamState({
+            messages: [requestMessage],
+            isCompleted: false,
+            agentRunStatus: 'RUNNING',
+        });
+
+        const firstView = renderConversation();
+        fireEvent.click(screen.getByRole('button', { name: /Blue/ }));
+
+        await waitFor(() => {
+            expect(mocks.updateOptimisticMessageStatus).toHaveBeenCalledWith(expect.any(String), 'failed');
+        });
+
+        firstView.unmount();
+        renderConversation();
+
+        expect(screen.getByText('What is your favorite color?')).not.toBeNull();
+        expect(screen.getByRole('button', { name: /Blue/ })).not.toBeNull();
     });
 
     it('hides a stale request overlay when a terminal run cannot continue', () => {

--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.test.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.test.tsx
@@ -60,6 +60,7 @@ vi.mock('./ModernAgentOutput/MessageInput', () => ({
         onSend: (message: string) => void;
         activeTaskCount?: number;
         activeWorkstreams?: Array<{ workstream_id: string; status: string }>;
+        onSelectWorkstream?: (workstreamId: string) => void;
         isCompleted?: boolean;
         isStreaming?: boolean;
         placeholder?: string;
@@ -90,6 +91,7 @@ vi.mock('./ModernAgentOutput/AllMessagesMixed', async () => {
     return {
         default: ({
             messages,
+            workstreamSourceMessages,
             streamingMessages,
             isCompleted,
             bottomRef,
@@ -101,6 +103,7 @@ vi.mock('./ModernAgentOutput/AllMessagesMixed', async () => {
             onActiveWorkstreamChange,
         }: {
             messages: AgentMessage[];
+            workstreamSourceMessages?: AgentMessage[];
             streamingMessages: Map<string, unknown>;
             isCompleted?: boolean;
             bottomRef: React.RefObject<HTMLDivElement>;
@@ -118,6 +121,7 @@ vi.mock('./ModernAgentOutput/AllMessagesMixed', async () => {
             );
             mocks.allMessagesMixedProps({
                 messages,
+                workstreamSourceMessages,
                 streamingMessages,
                 isCompleted,
                 onSendMessage,
@@ -230,6 +234,7 @@ function latestAllMessagesMixedProps() {
     return calls[calls.length - 1]?.[0] as
         | {
               messages: AgentMessage[];
+              workstreamSourceMessages?: AgentMessage[];
               streamingMessages: Map<string, unknown>;
               isCompleted?: boolean;
               showInitialRequest?: boolean;
@@ -560,6 +565,37 @@ describe('ModernAgentConversation send handling', () => {
                 tool_approval_mode: 'auto_review',
             });
         });
+    });
+
+    it('collapses staged files in the start composer', () => {
+        const { container } = renderWithProviders(
+            <ModernAgentConversation startWorkflow={vi.fn()} hideHeader initialMessage="" />,
+        );
+        const input = container.querySelector('input[type="file"]');
+        const files = ['alpha.txt', 'beta.txt', 'gamma.txt', 'delta.txt', 'epsilon.txt'].map(
+            (name) => new File([name], name, { type: 'text/plain' }),
+        );
+
+        if (!input) {
+            throw new Error('Expected hidden file input to be rendered');
+        }
+
+        fireEvent.change(input, {
+            target: {
+                files,
+            },
+        });
+
+        expect(screen.getByText('alpha.txt')).not.toBeNull();
+        expect(screen.getByText('gamma.txt')).not.toBeNull();
+        expect(screen.queryByText('delta.txt')).toBeNull();
+        expect(screen.getByText('+2')).not.toBeNull();
+
+        fireEvent.click(screen.getByRole('button', { name: /show more/i }));
+
+        expect(screen.getByText('delta.txt')).not.toBeNull();
+        expect(screen.getByText('epsilon.txt')).not.toBeNull();
+        expect(screen.getByRole('button', { name: /show less/i })).not.toBeNull();
     });
 
     it('signals approval mode changes for an active interactive run', async () => {
@@ -1060,6 +1096,7 @@ describe('ModernAgentConversation send handling', () => {
         const latestMessageInputProps = mocks.messageInputProps.mock.lastCall?.[0] as {
             activeTaskCount?: number;
             activeWorkstreams?: Array<{ workstream_id: string; status: string }>;
+            onSelectWorkstream?: (workstreamId: string) => void;
         };
 
         expect(latestRightPanelProps.activeWorkstreams).toEqual([
@@ -1073,6 +1110,12 @@ describe('ModernAgentConversation send handling', () => {
             expect.objectContaining({ workstream_id: 'alpha', status: 'running' }),
             expect.objectContaining({ workstream_id: 'beta', status: 'running' }),
         ]);
+
+        act(() => {
+            latestMessageInputProps.onSelectWorkstream?.('beta');
+        });
+
+        expect(latestAllMessagesMixedProps()?.activeWorkstream).toBe('beta');
     });
 
     it('shows completed workstream lifecycle messages in the panel without counting them as active', async () => {
@@ -2286,6 +2329,78 @@ describe('ModernAgentConversation send handling', () => {
                 isPlaybackEnabled: true,
             }),
         );
+    });
+
+    it('hides the rewind button when the playback toggle is disabled', () => {
+        mockStreamState({
+            messages: [
+                createMessage(AgentMessageType.QUESTION, 'first question'),
+                createMessage(AgentMessageType.ANSWER, 'first answer'),
+            ],
+        });
+
+        renderConversation({ hideHeader: false, showPlaybackToggle: false });
+
+        expect(mocks.headerProps).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                showPlaybackButton: false,
+            }),
+        );
+    });
+
+    it('filters transcript messages as conversation history updates', () => {
+        const question = createMessage(AgentMessageType.QUESTION, 'Summarize the launch plan.');
+        const internalUpdate = createMessage(AgentMessageType.UPDATE, 'Inspecting internal records.');
+        const answer = createMessage(AgentMessageType.ANSWER, 'The launch plan is ready.');
+        const messageFilter = (message: AgentMessage) => message.type !== AgentMessageType.UPDATE;
+
+        mockStreamState({ messages: [question, internalUpdate] });
+        const view = renderConversation({ messageFilter });
+
+        expect(latestAllMessagesMixedProps()?.messages).toEqual([question]);
+        expect(latestAllMessagesMixedProps()?.workstreamSourceMessages).toEqual([question]);
+
+        mockStreamState({ messages: [question, internalUpdate, answer] });
+        view.rerender(
+            <ModernAgentConversation
+                agentRunId="agent-run-1"
+                title="Agent"
+                hideHeader
+                hideMessageInput
+                showRightPanel={false}
+                messageFilter={messageFilter}
+            />,
+        );
+
+        expect(latestAllMessagesMixedProps()?.messages).toEqual([question, answer]);
+        expect(latestAllMessagesMixedProps()?.workstreamSourceMessages).toEqual([question, answer]);
+        expect(document.querySelector('[data-agent-live-message-count="3"]')).not.toBeNull();
+        expect(document.querySelector('[data-agent-rendered-message-count="2"]')).not.toBeNull();
+    });
+
+    it('keeps pending request input actionable when its transcript row is filtered out', () => {
+        const requestMessage = {
+            ...createMessage(AgentMessageType.REQUEST_INPUT, 'Choose a deployment region.'),
+            details: {
+                ux: {
+                    options: [
+                        { id: 'us', label: 'United States' },
+                        { id: 'eu', label: 'Europe' },
+                    ],
+                },
+            },
+        };
+        mockStreamState({
+            messages: [requestMessage],
+            isCompleted: false,
+            agentRunStatus: 'RUNNING',
+        });
+
+        renderConversation({ messageFilter: () => false });
+
+        expect(latestAllMessagesMixedProps()?.messages).toEqual([]);
+        expect(screen.getByText('Choose a deployment region.')).not.toBeNull();
+        expect(screen.getByRole('button', { name: /Europe/ })).not.toBeNull();
     });
 
     it('keeps the replay fixture export action available while messages are empty', () => {

--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
@@ -743,7 +743,7 @@ export interface ModernAgentConversationProps {
     initialToolApprovalMode?: AgentToolApprovalMode;
     /** Force display playback controls on or off. When omitted, local playback can be toggled from the header. */
     enablePlayback?: boolean;
-    /** Show the Rewind button for local playback controls. Defaults to true; set to false to hide it. */
+    /** Show the Debug button for local playback controls. Defaults to true; set to false to hide it. */
     showPlaybackToggle?: boolean;
 }
 

--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
@@ -35,7 +35,7 @@ import {
     AgentResourceResolverProvider,
     isArtifactRefreshEvent,
 } from '@vertesia/ui/widgets';
-import { ArrowUpIcon, Bot, CheckCircle, Cpu, FileTextIcon, UploadIcon, XIcon } from 'lucide-react';
+import { ArrowUpIcon, Bot, CheckCircle, ChevronDown, Cpu, FileTextIcon, UploadIcon, XIcon } from 'lucide-react';
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { McpConnectionsActionMenu } from '../../oauth/McpConnectionsButton.js';
@@ -105,6 +105,9 @@ export interface StartWorkflowOptions {
     tool_approval_mode?: AgentToolApprovalMode;
 }
 
+/** Controls whether a persisted message is included in the rendered conversation transcript. */
+export type AgentMessageFilter = (message: AgentMessage) => boolean;
+
 export type StartWorkflowFn = (
     initialMessage?: string,
     options?: StartWorkflowOptions,
@@ -113,6 +116,7 @@ export type StartWorkflowFn = (
 export type SendAgentMessageFn = (message: string, inputMetadata?: Record<string, unknown>) => void;
 
 const EMPTY_STREAMING_MESSAGES = new Map<string, never>();
+const COLLAPSED_STAGED_FILE_COUNT = 3;
 
 function getTimestampMs(timestamp: number | string | undefined): number {
     if (typeof timestamp === 'number') return timestamp;
@@ -655,6 +659,11 @@ export interface ModernAgentConversationProps {
     hideDocumentPanel?: boolean;
     /** Message types to exclude from the conversation view */
     hiddenMessageTypes?: AgentMessageType[];
+    /**
+     * Optional presentation-only predicate for transcript messages. Returning false hides the message without
+     * changing the underlying conversation stream, workflow state, plans, or pending input.
+     */
+    messageFilter?: AgentMessageFilter;
 
     // Callback to get attached documents when sending messages
     // Returns array of { id, name } to include in message metadata and display
@@ -734,7 +743,7 @@ export interface ModernAgentConversationProps {
     initialToolApprovalMode?: AgentToolApprovalMode;
     /** Force display playback controls on or off. When omitted, local playback can be toggled from the header. */
     enablePlayback?: boolean;
-    /** Show a local toggle for display playback controls in the conversation action rail. */
+    /** Show the Rewind button for local playback controls. Defaults to true; set to false to hide it. */
     showPlaybackToggle?: boolean;
 }
 
@@ -824,6 +833,9 @@ function StartWorkflowView({
 
     // Staged files - stored locally until workflow starts
     const [stagedFiles, setStagedFiles] = useState<File[]>([]);
+    const [areStagedFilesExpanded, setAreStagedFilesExpanded] = useState(false);
+    const visibleStagedFiles = areStagedFilesExpanded ? stagedFiles : stagedFiles.slice(0, COLLAPSED_STAGED_FILE_COUNT);
+    const hiddenStagedFileCount = stagedFiles.length - COLLAPSED_STAGED_FILE_COUNT;
 
     useEffect(() => {
         onAgentWorkingChange?.(isSending);
@@ -920,6 +932,12 @@ function StartWorkflowView({
     const removeStagedFile = useCallback((index: number) => {
         setStagedFiles((prev) => prev.filter((_, i) => i !== index));
     }, []);
+
+    useEffect(() => {
+        if (stagedFiles.length <= COLLAPSED_STAGED_FILE_COUNT) {
+            setAreStagedFilesExpanded(false);
+        }
+    }, [stagedFiles.length]);
 
     useEffect(() => {
         // Focus the input field when component mounts
@@ -1215,7 +1233,7 @@ function StartWorkflowView({
                         {/* Staged files display */}
                         {canStageFiles && stagedFiles.length > 0 && (
                             <div className="flex flex-wrap gap-2">
-                                {stagedFiles.map((file, index) => (
+                                {visibleStagedFiles.map((file, index) => (
                                     <div
                                         key={`${file.name}-${file.size}-${file.lastModified}`}
                                         className="flex items-center gap-1.5 rounded-md bg-attention/10 px-2 py-1 text-sm text-attention"
@@ -1234,6 +1252,26 @@ function StartWorkflowView({
                                         </Button>
                                     </div>
                                 ))}
+                                {stagedFiles.length > COLLAPSED_STAGED_FILE_COUNT && (
+                                    <Button
+                                        type="button"
+                                        variant="ghost"
+                                        size="sm"
+                                        aria-expanded={areStagedFilesExpanded}
+                                        onClick={() => setAreStagedFilesExpanded((expanded) => !expanded)}
+                                        className="h-8 shrink-0 gap-1 rounded-xl px-2.5 text-xs text-muted"
+                                    >
+                                        {!areStagedFilesExpanded && <span>+{hiddenStagedFileCount}</span>}
+                                        {areStagedFilesExpanded ? t('agent.showLess') : t('agent.showMore')}
+                                        <ChevronDown
+                                            className={cn(
+                                                'size-3.5 transition-transform',
+                                                areStagedFilesExpanded && 'rotate-180',
+                                            )}
+                                            aria-hidden="true"
+                                        />
+                                    </Button>
+                                )}
                             </div>
                         )}
 
@@ -1399,6 +1437,7 @@ function ModernAgentConversationInner({
     initialToolApprovalMode,
     enablePlayback,
     showPlaybackToggle = true,
+    messageFilter,
 }: ModernAgentConversationProps & { agentRunId: string }) {
     const { t } = useUITranslation();
     const { client } = useUserSession();
@@ -1628,13 +1667,16 @@ function ModernAgentConversationInner({
 
     const canShowPlaybackToggle = showPlaybackToggle && enablePlayback === undefined && isAgentChatPlaybackAvailable();
     const isPlaybackEnabled = enablePlayback ?? (isAgentChatPlaybackEnabled() || isPlaybackToggleEnabled);
-    const playbackSourceMessages = useMemo(() => {
+    const transcriptSourceMessages = useMemo(() => {
         // Passive artifact autosaves are surfaced by the editor's own save indicator, not the chat.
-        const visibleMessages = messages.filter(
+        return messages.filter(
             (message) => !isPassiveArtifactUpdate(message) && !(hiddenMessageTypes?.includes(message.type) ?? false),
         );
-        return filterMessagesForActiveWorkstream(visibleMessages, activeWorkstream);
-    }, [activeWorkstream, hiddenMessageTypes, messages]);
+    }, [hiddenMessageTypes, messages]);
+    const playbackSourceMessages = useMemo(
+        () => filterMessagesForActiveWorkstream(transcriptSourceMessages, activeWorkstream),
+        [activeWorkstream, transcriptSourceMessages],
+    );
     const playbackState = useMemo(
         () => createPlaybackState(playbackSourceMessages, playbackCursor, isPlaybackEnabled),
         [isPlaybackEnabled, playbackCursor, playbackSourceMessages],
@@ -1644,6 +1686,17 @@ function ModernAgentConversationInner({
     const isPlaybackAtLatest =
         isPlaybackEnabled && !isPlaybackLive && playbackState.cursorIndex === playbackSourceMessages.length - 1;
     const displayedMessages = playbackState.displayedMessages;
+    const renderedMessages = useMemo(
+        () => (messageFilter ? displayedMessages.filter((message) => messageFilter(message)) : displayedMessages),
+        [displayedMessages, messageFilter],
+    );
+    const renderedWorkstreamSourceMessages = useMemo(
+        () =>
+            messageFilter
+                ? transcriptSourceMessages.filter((message) => messageFilter(message))
+                : transcriptSourceMessages,
+        [messageFilter, transcriptSourceMessages],
+    );
     const displayedStreamingMessages = isPlaybackLive ? streamingMessages : EMPTY_STREAMING_MESSAGES;
     const playbackDerivedWorkstreams = useMemo(
         () => deriveWorkstreamsFromMessages(displayedMessages),
@@ -1687,7 +1740,7 @@ function ModernAgentConversationInner({
             agentRunId,
             messageCount: messages.length,
             playbackMessageCount: playbackSourceMessages.length,
-            displayedMessageCount: displayedMessages.length,
+            displayedMessageCount: renderedMessages.length,
             streamingCount: streamingMessages.size,
             displayedStreamingCount: displayedStreamingMessages.size,
             initialHistoryStatus,
@@ -1711,7 +1764,7 @@ function ModernAgentConversationInner({
         agentRunStatus,
         clampedPlaybackCursor,
         displayedIsCompleted,
-        displayedMessages.length,
+        renderedMessages.length,
         displayedStreamingMessages.size,
         effectiveIsCompleted,
         effectiveWorkflowStatus,
@@ -2616,7 +2669,7 @@ function ModernAgentConversationInner({
             data-agent-playback-enabled={isPlaybackEnabled || undefined}
             data-agent-playback-cursor={isPlaybackEnabled ? clampedPlaybackCursor : undefined}
             data-agent-live-message-count={messages.length}
-            data-agent-rendered-message-count={displayedMessages.length}
+            data-agent-rendered-message-count={renderedMessages.length}
             className={cn(
                 'flex flex-col min-h-0 min-w-0 border-0',
                 conversationTab
@@ -2651,8 +2704,8 @@ function ModernAgentConversationInner({
                 <PendingStartConversation message={pendingStartMessage} startedAt={pendingStartTimestamp} />
             ) : (
                 <AllMessagesMixed
-                    messages={displayedMessages}
-                    workstreamSourceMessages={messages}
+                    messages={renderedMessages}
+                    workstreamSourceMessages={renderedWorkstreamSourceMessages}
                     bottomRef={bottomRef as React.RefObject<HTMLDivElement>}
                     isCompleted={displayedIsCompleted}
                     plan={getActivePlan.plan}
@@ -2703,7 +2756,10 @@ function ModernAgentConversationInner({
                 />
             ) : isViewingPlaybackHistory && playbackActiveWorkstreams.length > 0 ? (
                 <div className="flex-shrink-0 pb-safe-area">
-                    <ActiveWorkstreamsSummary activeWorkstreams={playbackActiveWorkstreams} />
+                    <ActiveWorkstreamsSummary
+                        activeWorkstreams={playbackActiveWorkstreams}
+                        onSelectWorkstream={setActiveWorkstream}
+                    />
                 </div>
             ) : (
                 shouldRenderLiveMessageInputArea && (
@@ -2771,6 +2827,7 @@ function ModernAgentConversationInner({
                                         isCompactingContext={isCompactingContext}
                                         activeTaskCount={activeTaskCount}
                                         activeWorkstreams={composerActiveWorkstreams}
+                                        onSelectWorkstream={setActiveWorkstream}
                                         placeholder={composerPlaceholder}
                                         onFilesSelected={canUploadFiles ? handleFileUpload : undefined}
                                         uploadedFiles={uploadedFiles}

--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
@@ -65,7 +65,14 @@ import MessageInput, {
     type UploadedFile,
 } from './ModernAgentOutput/MessageInput';
 import type { MessageItemClassNames } from './ModernAgentOutput/MessageItem';
-import { getPendingRequestInputMessage } from './ModernAgentOutput/requestInputMessages';
+import {
+    clearRequestInputIdAnsweredForSession,
+    getPendingRequestInputMessage,
+    getRequestInputResolutionKey,
+    getRequestInputResponseIdFromMetadata,
+    isRequestInputAnsweredForSession,
+    markRequestInputIdAnsweredForSession,
+} from './ModernAgentOutput/requestInputMessages';
 import type { StreamingMessageClassNames } from './ModernAgentOutput/StreamingMessage';
 import type { ToolCallGroupClassNames } from './ModernAgentOutput/ToolCallGroup';
 import {
@@ -1653,10 +1660,15 @@ function ModernAgentConversationInner({
     useEffect(() => {
         onAgentWorkingChange?.(isAgentWorking);
     }, [isAgentWorking, onAgentWorkingChange]);
-    const pendingRequestInputMessage = useMemo(
-        () => getPendingRequestInputMessage(displayedMessages),
-        [displayedMessages],
-    );
+    const pendingRequestInputMessage = useMemo(() => {
+        const answeredRequestInputKeys = new Set<string>();
+        for (const message of displayedMessages) {
+            if (isRequestInputAnsweredForSession(agentRunId, message)) {
+                answeredRequestInputKeys.add(getRequestInputResolutionKey(message));
+            }
+        }
+        return getPendingRequestInputMessage(displayedMessages, 'main', answeredRequestInputKeys);
+    }, [agentRunId, displayedMessages]);
     // A terminal run silently drops user input unless it can be continued (see the guard in
     // handleSendMessage), so never surface an actionable question overlay in that state —
     // the terminal status box renders instead.
@@ -2078,6 +2090,7 @@ function ModernAgentConversationInner({
                 return;
             }
 
+            const requestInputId = getRequestInputResponseIdFromMetadata(inputMetadata);
             setIsSending(true);
 
             const attachedDocs = getAttachedDocs?.() || [];
@@ -2120,6 +2133,9 @@ function ModernAgentConversationInner({
                     _messageId: messageId,
                     _deliveryStatus: 'sending',
                     ...(inputMetadata?.editing_action ? { editing_action: inputMetadata.editing_action } : {}),
+                    ...(inputMetadata?.request_input_response
+                        ? { request_input_response: inputMetadata.request_input_response }
+                        : {}),
                 },
             };
 
@@ -2151,6 +2167,9 @@ function ModernAgentConversationInner({
             // buffers the signal until the new run is ready to receive it. We reconnect
             // the stream in place (rather than remounting via onRestart) so the existing
             // timeline is preserved and the new exchange appends seamlessly at the bottom.
+            if (requestInputId) {
+                markRequestInputIdAnsweredForSession(agentRunId, requestInputId);
+            }
             const deliver = (async () => {
                 await waitForPendingToolApprovalModeChange();
                 if (isWorkflowTerminalRef.current) {
@@ -2163,6 +2182,9 @@ function ModernAgentConversationInner({
 
             deliver
                 .catch((err) => {
+                    if (requestInputId) {
+                        clearRequestInputIdAnsweredForSession(agentRunId, requestInputId);
+                    }
                     updateOptimisticMessageStatus(messageId, 'failed');
                     toast({
                         status: 'error',
@@ -2202,7 +2224,7 @@ function ModernAgentConversationInner({
     // conversation for tool re-discovery and resume it with a confirmation message so the agent
     // continues automatically with the newly-available tools.
     const handleMcpConnected = useCallback(
-        async (cfg: McpConnectUxConfig) => {
+        async (cfg: McpConnectUxConfig, metadata?: Record<string, unknown>) => {
             // Await the dirty-flag signal BEFORE sending the follow-up message so Temporal records
             // McpConfigChanged ahead of the UserInput. Otherwise the resume turn could run before
             // the flag is set and use the stale tool catalog. An omitted disabled list preserves
@@ -2212,7 +2234,7 @@ function ModernAgentConversationInner({
             } catch (err: unknown) {
                 console.error('Failed to signal MCP config change', err);
             }
-            handleSendMessage(t('agent.mcpConnectedMessage', { name: cfg.name }));
+            handleSendMessage(t('agent.mcpConnectedMessage', { name: cfg.name }), metadata);
         },
         [client, agentRunId, handleSendMessage, t],
     );

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/ActiveWorkstreamsSummary.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/ActiveWorkstreamsSummary.tsx
@@ -1,7 +1,7 @@
-import { cn } from '@vertesia/ui/core';
+import { Button, cn } from '@vertesia/ui/core';
 import { useUITranslation } from '@vertesia/ui/i18n';
-import { Bot } from 'lucide-react';
-import { useMemo } from 'react';
+import { Bot, ChevronDown, ChevronRight } from 'lucide-react';
+import { useEffect, useId, useMemo, useState } from 'react';
 import {
     formatWorkstreamName,
     getWorkstreamDisplayName,
@@ -11,17 +11,35 @@ import {
 
 interface ActiveWorkstreamsSummaryProps {
     activeWorkstreams: WorkstreamInfo[];
+    onSelectWorkstream?: (workstreamId: string) => void;
     className?: string;
 }
 
-export function ActiveWorkstreamsSummary({ activeWorkstreams, className }: ActiveWorkstreamsSummaryProps) {
+const COLLAPSED_WORKSTREAM_COUNT = 3;
+
+export function ActiveWorkstreamsSummary({
+    activeWorkstreams,
+    onSelectWorkstream,
+    className,
+}: ActiveWorkstreamsSummaryProps) {
     const { t } = useUITranslation();
+    const [isExpanded, setIsExpanded] = useState(false);
+    const listId = useId();
     const runningWorkstreams = useMemo(
         () => activeWorkstreams.filter((ws) => ws.status === 'running' || ws.status === 'canceling'),
         [activeWorkstreams],
     );
-    const visibleRunningWorkstreams = runningWorkstreams.slice(0, 3);
+    const visibleRunningWorkstreams = isExpanded
+        ? runningWorkstreams
+        : runningWorkstreams.slice(0, COLLAPSED_WORKSTREAM_COUNT);
     const hiddenRunningWorkstreamCount = Math.max(0, runningWorkstreams.length - visibleRunningWorkstreams.length);
+    const canExpand = runningWorkstreams.length > COLLAPSED_WORKSTREAM_COUNT;
+
+    useEffect(() => {
+        if (!canExpand) {
+            setIsExpanded(false);
+        }
+    }, [canExpand]);
 
     if (runningWorkstreams.length === 0) return null;
 
@@ -31,23 +49,20 @@ export function ActiveWorkstreamsSummary({ activeWorkstreams, className }: Activ
                 className="flex flex-col gap-1.5 rounded-2xl border border-border/70 bg-background/95 p-2 text-xs text-muted shadow-lg shadow-black/5"
                 aria-live="polite"
             >
-                <div className="flex items-center gap-2 px-1 font-medium">
-                    <Bot className="size-3.5 text-muted" aria-hidden="true" />
-                    <span>{t('agent.activeWorkstreams', { count: runningWorkstreams.length })}</span>
+                <div className="flex min-w-0 items-center gap-2 px-1 font-medium">
+                    <Bot className="size-3.5 shrink-0 text-muted" aria-hidden="true" />
+                    <span className="truncate">
+                        {t('agent.activeWorkstreams', { count: runningWorkstreams.length })}
+                    </span>
                 </div>
-                <div className="flex flex-col gap-0.5">
+                <div id={listId} className="flex flex-col gap-0.5">
                     {visibleRunningWorkstreams.map((workstream) => {
                         const workstreamName = getWorkstreamDisplayName(
                             workstream.workstream_id,
                             workstream.interaction,
                         );
-
-                        return (
-                            <span
-                                key={workstream.launch_id || workstream.workstream_id}
-                                className="flex min-w-0 items-center gap-2 rounded-lg px-1 py-1 text-sm text-foreground/80"
-                                title={workstreamName}
-                            >
+                        const content = (
+                            <>
                                 <span
                                     className={cn(
                                         'size-1.5 shrink-0 rounded-full',
@@ -61,13 +76,53 @@ export function ActiveWorkstreamsSummary({ activeWorkstreams, className }: Activ
                                         {formatWorkstreamName(workstream.phase)}
                                     </span>
                                 )}
-                            </span>
+                            </>
+                        );
+
+                        return onSelectWorkstream ? (
+                            <Button
+                                key={workstream.launch_id || workstream.workstream_id}
+                                type="button"
+                                variant="ghost"
+                                className="h-auto min-w-0 justify-start gap-2 rounded-lg px-1 py-1 text-sm text-foreground/80"
+                                title={workstreamName}
+                                onClick={() => {
+                                    setIsExpanded(false);
+                                    onSelectWorkstream(workstream.workstream_id);
+                                }}
+                            >
+                                {content}
+                                <ChevronRight className="ms-auto size-3.5 shrink-0 rtl:rotate-180" aria-hidden="true" />
+                            </Button>
+                        ) : (
+                            <div
+                                key={workstream.launch_id || workstream.workstream_id}
+                                className="flex min-w-0 items-center gap-2 rounded-lg px-1 py-1 text-sm text-foreground/80"
+                                title={workstreamName}
+                            >
+                                {content}
+                            </div>
                         );
                     })}
-                    {hiddenRunningWorkstreamCount > 0 && (
-                        <span className="px-1 py-1 text-xs text-muted">+{hiddenRunningWorkstreamCount}</span>
-                    )}
                 </div>
+                {canExpand && (
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 w-fit shrink-0 gap-1 rounded-xl px-2.5 text-xs text-muted"
+                        aria-expanded={isExpanded}
+                        aria-controls={listId}
+                        onClick={() => setIsExpanded((expanded) => !expanded)}
+                    >
+                        {!isExpanded && <span>+{hiddenRunningWorkstreamCount}</span>}
+                        {isExpanded ? t('agent.showLess') : t('agent.showMore')}
+                        <ChevronDown
+                            className={cn('size-3.5 transition-transform', isExpanded && 'rotate-180')}
+                            aria-hidden="true"
+                        />
+                    </Button>
+                )}
             </output>
         </div>
     );

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/AllMessagesMixed.test.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/AllMessagesMixed.test.tsx
@@ -464,6 +464,7 @@ describe('AllMessagesMixed summary view', () => {
                     type: AgentMessageType.REQUEST_INPUT,
                     message: 'Approve Create Document: name News Headlines Today?',
                     details: {
+                        request_id: 'create_document:name:News Headlines Today',
                         tool_approval: {
                             approval_key: 'create_document:name:News Headlines Today',
                             tool_name: 'create_document',
@@ -498,6 +499,9 @@ describe('AllMessagesMixed summary view', () => {
             tool_approval_response: {
                 decision: 'allow_once',
                 approval_key: 'create_document:name:News Headlines Today',
+            },
+            request_input_response: {
+                request_id: 'create_document:name:News Headlines Today',
             },
         });
     });

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/AllMessagesMixed.test.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/AllMessagesMixed.test.tsx
@@ -318,6 +318,54 @@ describe('AllMessagesMixed summary view', () => {
         expect(screen.getByTestId('post-tool-thinking-indicator').textContent).toBe('Thinking...');
     });
 
+    it('keeps showing thinking when the current display-role marker follows a completed tool', () => {
+        renderSummary(
+            [
+                makeMessage({
+                    timestamp: 1_000,
+                    type: AgentMessageType.QUESTION,
+                    message: 'Find Japan news.',
+                }),
+                makeMessage({
+                    timestamp: 2_000,
+                    message: 'Searching for Japan news',
+                    details: {
+                        event_class: 'activity',
+                        tool: 'web_search_serper',
+                        tool_status: 'running',
+                        tool_run_id: 'tool-1',
+                        activity_group_id: 'activity-1',
+                    },
+                }),
+                makeMessage({
+                    timestamp: 3_000,
+                    message: 'Found Japan news',
+                    details: {
+                        event_class: 'activity',
+                        tool: 'web_search_serper',
+                        tool_status: 'completed',
+                        tool_run_id: 'tool-1',
+                        activity_group_id: 'activity-1',
+                    },
+                }),
+                makeMessage({
+                    timestamp: 4_000,
+                    message: 'Thinking...',
+                    details: {
+                        event_class: 'activity',
+                        display_role: 'thinking',
+                        activity_id: '17',
+                        activity_group_id: 'activity-1',
+                    },
+                }),
+            ],
+            false,
+        );
+
+        expect(screen.getAllByRole('button', { name: /Working.*for/ })).toHaveLength(1);
+        expect(screen.getByTestId('post-tool-thinking-indicator').textContent).toBe('Thinking...');
+    });
+
     it('replaces a completed tool’s progress title with an immediately visible resource deep link', () => {
         renderSummary(
             [

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/AllMessagesMixed.test.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/AllMessagesMixed.test.tsx
@@ -258,6 +258,66 @@ describe('AllMessagesMixed summary view', () => {
         expect(screen.getByText('Found 5 results')).not.toBeNull();
     });
 
+    it('does not show post-tool thinking while the latest tool is still running', () => {
+        renderSummary(
+            [
+                makeMessage({
+                    timestamp: 1_000,
+                    type: AgentMessageType.QUESTION,
+                    message: 'Find Japan news.',
+                }),
+                makeMessage({
+                    timestamp: 2_000,
+                    message: 'Searching for Japan news',
+                    details: {
+                        tool: 'web_search_serper',
+                        tool_status: 'running',
+                        tool_run_id: 'tool-1',
+                    },
+                }),
+            ],
+            false,
+        );
+
+        expect(screen.getAllByRole('button', { name: /Working.*for/ })).toHaveLength(1);
+        expect(screen.queryByTestId('post-tool-thinking-indicator')).toBeNull();
+    });
+
+    it('shows thinking below the active work group after its latest tool completes', () => {
+        renderSummary(
+            [
+                makeMessage({
+                    timestamp: 1_000,
+                    type: AgentMessageType.QUESTION,
+                    message: 'Find Japan news.',
+                }),
+                makeMessage({
+                    timestamp: 2_000,
+                    message: 'Searching for Japan news',
+                    details: {
+                        tool: 'web_search_serper',
+                        tool_status: 'running',
+                        tool_run_id: 'tool-1',
+                    },
+                }),
+                makeMessage({
+                    timestamp: 3_000,
+                    message: 'Found Japan news',
+                    details: {
+                        tool: 'web_search_serper',
+                        tool_status: 'completed',
+                        tool_run_id: 'tool-1',
+                    },
+                }),
+            ],
+            false,
+        );
+
+        expect(screen.queryByRole('button', { name: /Worked\s*for/ })).toBeNull();
+        expect(screen.getAllByRole('button', { name: /Working.*for/ })).toHaveLength(1);
+        expect(screen.getByTestId('post-tool-thinking-indicator').textContent).toBe('Thinking...');
+    });
+
     it('replaces a completed tool’s progress title with an immediately visible resource deep link', () => {
         renderSummary(
             [

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/AllMessagesMixed.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/AllMessagesMixed.tsx
@@ -93,6 +93,7 @@ import {
     getWorkstreamId,
     groupMessagesWithStreaming,
     isInProgress,
+    isToolActivityMessage,
     isToolPreambleMessage,
     isUserStoppedMessage,
     mergeConsecutiveToolGroups,
@@ -2686,18 +2687,23 @@ function AllMessagesMixedComponent({
         });
     }, []);
 
+    const previousActiveWorkstreamRef = useRef(activeWorkstream);
+    useEffect(() => {
+        if (previousActiveWorkstreamRef.current === activeWorkstream) return;
+        previousActiveWorkstreamRef.current = activeWorkstream;
+        requestAnimationFrame(scrollToTop);
+    }, [activeWorkstream, scrollToTop]);
+
     const handleSelectWorkstream = useCallback(
         (workstreamId: string) => {
             setActiveWorkstream(workstreamId);
-            requestAnimationFrame(scrollToTop);
         },
-        [scrollToTop, setActiveWorkstream],
+        [setActiveWorkstream],
     );
 
     const handleShowMainAgentChat = useCallback(() => {
         setActiveWorkstream('all');
-        requestAnimationFrame(scrollToTop);
-    }, [scrollToTop, setActiveWorkstream]);
+    }, [setActiveWorkstream]);
 
     useEffect(() => {
         if (activeWorkstream !== 'all' && !workstreams.has(activeWorkstream)) {
@@ -2967,6 +2973,20 @@ function AllMessagesMixedComponent({
         // completed until the agent posts its next message.
         return !isDisplayCompleted || hasOpenUserTurn(completionDisplayMessages);
     }, [completionDisplayMessages, isDisplayCompleted]);
+
+    const showPostToolThinking = useMemo(() => {
+        if (!isAgentWorking || incompleteStreaming.length > 0) return false;
+
+        const latestSummaryItem = summaryConversationItems[summaryConversationItems.length - 1];
+        const latestMessage = completionDisplayMessages[completionDisplayMessages.length - 1];
+        return (
+            latestSummaryItem?.type === 'work' &&
+            latestSummaryItem.isActive &&
+            latestMessage !== undefined &&
+            isToolActivityMessage(latestMessage) &&
+            latestMessage.details?.tool_status === 'completed'
+        );
+    }, [completionDisplayMessages, incompleteStreaming.length, isAgentWorking, summaryConversationItems]);
 
     const showActivityFallback = shouldShowSummaryActivityFallback(
         summaryConversationItems,
@@ -3684,6 +3704,17 @@ function AllMessagesMixedComponent({
                                     artifactRunId={artifactRunId}
                                 />
                             ))}
+                            {showPostToolThinking && (
+                                <div
+                                    className={cn(
+                                        'mx-auto w-full max-w-3xl px-1 text-sm text-muted',
+                                        workingIndicatorClassName,
+                                    )}
+                                    data-testid="post-tool-thinking-indicator"
+                                >
+                                    {t('agent.thinking')}
+                                </div>
+                            )}
                             {/* Activity fallback - shown before any tool/thought message has arrived */}
                             {showActivityFallback && !showInitialRequestWaitingCard && (
                                 <SummaryActivityRow

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/AllMessagesMixed.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/AllMessagesMixed.tsx
@@ -2979,13 +2979,11 @@ function AllMessagesMixedComponent({
 
         const latestSummaryItem = summaryConversationItems[summaryConversationItems.length - 1];
         const latestMessage = completionDisplayMessages[completionDisplayMessages.length - 1];
-        return (
-            latestSummaryItem?.type === 'work' &&
-            latestSummaryItem.isActive &&
+        const latestMessageShowsThinking =
             latestMessage !== undefined &&
-            isToolActivityMessage(latestMessage) &&
-            latestMessage.details?.tool_status === 'completed'
-        );
+            (latestMessage.details?.display_role === 'thinking' ||
+                (isToolActivityMessage(latestMessage) && latestMessage.details?.tool_status === 'completed'));
+        return latestSummaryItem?.type === 'work' && latestSummaryItem.isActive && latestMessageShowsThinking;
     }, [completionDisplayMessages, incompleteStreaming.length, isAgentWorking, summaryConversationItems]);
 
     const showActivityFallback = shouldShowSummaryActivityFallback(

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/AllMessagesMixed.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/AllMessagesMixed.tsx
@@ -68,6 +68,7 @@ import {
     isToolApprovalRequestInput,
     isToolApprovalRequestInputHidden,
     type RequestInputMessageWithUx,
+    sendRequestInputResponse,
 } from './requestInputMessages';
 import {
     interleaveTurnSummaries,
@@ -753,13 +754,22 @@ function SummaryMessage({
                     variant={uxConfig.variant}
                     multiSelect={uxConfig.multiSelect}
                     onSelect={(optionId) =>
-                        onSendMessage?.(optionId, getToolApprovalResponseMetadata(message, optionId))
+                        sendRequestInputResponse(
+                            onSendMessage,
+                            message,
+                            optionId,
+                            getToolApprovalResponseMetadata(message, optionId),
+                        )
                     }
-                    onMultiSelect={(optionIds) => onSendMessage?.(optionIds.join(', '))}
+                    onMultiSelect={(optionIds) =>
+                        sendRequestInputResponse(onSendMessage, message, optionIds.join(', '))
+                    }
                     allowFreeResponse={!uxConfig.options?.length || !!uxConfig.free_response}
                     placeholder={uxConfig.free_response?.placeholder}
                     submitLabel={uxConfig.free_response?.submit_label}
-                    onSubmit={(value) => onSendMessage?.(value, uxConfig.free_response?.metadata)}
+                    onSubmit={(value) =>
+                        sendRequestInputResponse(onSendMessage, message, value, uxConfig.free_response?.metadata)
+                    }
                     hideBorder
                     compact
                     answered={requestInputAnswered}
@@ -2273,19 +2283,32 @@ function SummaryActivityRow({
                                                 variant={uxConfig.variant}
                                                 multiSelect={uxConfig.multiSelect}
                                                 onSelect={(optionId) =>
-                                                    onSendMessage?.(
+                                                    sendRequestInputResponse(
+                                                        onSendMessage,
+                                                        message,
                                                         optionId,
                                                         getToolApprovalResponseMetadata(message, optionId),
                                                     )
                                                 }
-                                                onMultiSelect={(optionIds) => onSendMessage?.(optionIds.join(', '))}
+                                                onMultiSelect={(optionIds) =>
+                                                    sendRequestInputResponse(
+                                                        onSendMessage,
+                                                        message,
+                                                        optionIds.join(', '),
+                                                    )
+                                                }
                                                 allowFreeResponse={
                                                     !uxConfig.options?.length || !!uxConfig.free_response
                                                 }
                                                 placeholder={uxConfig.free_response?.placeholder}
                                                 submitLabel={uxConfig.free_response?.submit_label}
                                                 onSubmit={(value) =>
-                                                    onSendMessage?.(value, uxConfig.free_response?.metadata)
+                                                    sendRequestInputResponse(
+                                                        onSendMessage,
+                                                        message,
+                                                        value,
+                                                        uxConfig.free_response?.metadata,
+                                                    )
                                                 }
                                                 hideBorder
                                                 compact

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/AttachmentPreview.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/AttachmentPreview.tsx
@@ -1,9 +1,9 @@
 import { Button, cn } from '@vertesia/ui/core';
 import { useUITranslation } from '@vertesia/ui/i18n';
 import { UserSessionContext } from '@vertesia/ui/session';
-import { FileTextIcon, ImageIcon, XIcon } from 'lucide-react';
+import { ChevronDown, FileTextIcon, ImageIcon, XIcon } from 'lucide-react';
 import type React from 'react';
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useEffect, useId, useState } from 'react';
 import { useImageLightbox } from '../ImageLightbox';
 import { getArtifactCacheKey, useArtifactUrlCache } from '../useArtifactUrlCache';
 
@@ -26,6 +26,7 @@ const TEXT_EXTENSIONS = new Set([
     'yaml',
     'yml',
 ]);
+const DEFAULT_COLLAPSED_ATTACHMENT_COUNT = 3;
 
 export interface AttachmentPreviewItem {
     id: string;
@@ -374,11 +375,24 @@ export function AttachmentPreviewList({
     StoreLinkComponent,
     CollectionLinkComponent,
 }: AttachmentPreviewListProps) {
+    const { t } = useUITranslation();
+    const [isExpanded, setIsExpanded] = useState(false);
+    const attachmentListId = useId();
+    const isCollapsible = variant === 'composer' && items.length > DEFAULT_COLLAPSED_ATTACHMENT_COUNT;
+    const visibleItems = isCollapsible && !isExpanded ? items.slice(0, DEFAULT_COLLAPSED_ATTACHMENT_COUNT) : items;
+    const hiddenItemCount = items.length - DEFAULT_COLLAPSED_ATTACHMENT_COUNT;
+
+    useEffect(() => {
+        if (items.length <= DEFAULT_COLLAPSED_ATTACHMENT_COUNT) {
+            setIsExpanded(false);
+        }
+    }, [items.length]);
+
     if (items.length === 0) return null;
 
     return (
-        <div className={cn('flex flex-wrap gap-2', align === 'end' && 'justify-end', className)}>
-            {items.map((item) => (
+        <div id={attachmentListId} className={cn('flex flex-wrap gap-2', align === 'end' && 'justify-end', className)}>
+            {visibleItems.map((item) => (
                 <AttachmentPreview
                     key={item.id}
                     item={item}
@@ -390,6 +404,24 @@ export function AttachmentPreviewList({
                     CollectionLinkComponent={CollectionLinkComponent}
                 />
             ))}
+            {isCollapsible && (
+                <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    aria-controls={attachmentListId}
+                    aria-expanded={isExpanded}
+                    onClick={() => setIsExpanded((expanded) => !expanded)}
+                    className="h-8 shrink-0 gap-1 rounded-xl px-2.5 text-xs text-muted"
+                >
+                    {!isExpanded && <span>+{hiddenItemCount}</span>}
+                    {isExpanded ? t('agent.showLess') : t('agent.showMore')}
+                    <ChevronDown
+                        className={cn('size-3.5 transition-transform', isExpanded && 'rotate-180')}
+                        aria-hidden="true"
+                    />
+                </Button>
+            )}
         </div>
     );
 }

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/Header.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/Header.tsx
@@ -5,6 +5,7 @@ import { useRouterContext } from '@vertesia/ui/router';
 import { useUserSession } from '@vertesia/ui/session';
 import {
     Bot,
+    Bug,
     ClipboardList,
     CopyIcon,
     DownloadCloudIcon,
@@ -13,7 +14,6 @@ import {
     InfoIcon,
     MessageSquareText,
     MoreVertical,
-    Rewind,
     Rows3,
     XIcon,
 } from 'lucide-react';
@@ -185,7 +185,7 @@ export default function Header({
                         variant === 'compact' && 'size-8 rounded-lg',
                     )}
                 >
-                    <Rewind className={cn('size-4', variant === 'full' && 'me-1.5')} />
+                    <Bug className={cn('size-4', variant === 'full' && 'me-1.5')} />
                     {variant === 'full' ? (
                         <span className="font-medium text-xs">{t('agent.rewind.label')}</span>
                     ) : (

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageInput.test.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageInput.test.tsx
@@ -201,6 +201,38 @@ describe('MessageInput', () => {
         expect(screen.getByText('Ready')).not.toBeNull();
     });
 
+    it('collapses large attachment lists while preserving attachment actions', () => {
+        const onRemoveDocument = vi.fn();
+        const selectedDocuments = ['Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon'].map((name, index) => ({
+            id: `doc-${index}`,
+            name,
+        }));
+
+        renderWithProviders(
+            <MessageInput onSend={vi.fn()} selectedDocuments={selectedDocuments} onRemoveDocument={onRemoveDocument} />,
+        );
+
+        expect(screen.getByText('Alpha')).not.toBeNull();
+        expect(screen.getByText('Gamma')).not.toBeNull();
+        expect(screen.queryByText('Delta')).toBeNull();
+        expect(screen.getByText('+2')).not.toBeNull();
+
+        fireEvent.click(screen.getByRole('button', { name: /show more/i }));
+
+        expect(screen.getByText('Delta')).not.toBeNull();
+        expect(screen.getByText('Epsilon')).not.toBeNull();
+        expect(screen.getByRole('button', { name: /show less/i })).not.toBeNull();
+
+        fireEvent.click(screen.getByRole('button', { name: /Remove Epsilon/i }));
+
+        expect(onRemoveDocument).toHaveBeenCalledWith('doc-4');
+
+        fireEvent.click(screen.getByRole('button', { name: /show less/i }));
+
+        expect(screen.queryByText('Delta')).toBeNull();
+        expect(screen.getByText('+2')).not.toBeNull();
+    });
+
     it('renders context usage and triggers manual compaction', async () => {
         const onCompactContext = vi.fn();
 
@@ -268,5 +300,44 @@ describe('MessageInput', () => {
         expect(
             tray.compareDocumentPosition(screen.getByRole('textbox')) & Node.DOCUMENT_POSITION_FOLLOWING,
         ).toBeTruthy();
+    });
+
+    it('collapses large workstream lists and navigates from a selected workstream', () => {
+        const onSelectWorkstream = vi.fn();
+        const activeWorkstreams = ['alpha', 'beta', 'gamma', 'delta', 'epsilon'].map((workstream_id, index) => ({
+            workstream_id,
+            launch_id: `launch-${index}`,
+            elapsed_ms: 0,
+            deadline_ms: 0,
+            remaining_ms: 0,
+            status: 'running' as const,
+        }));
+
+        renderWithProviders(
+            <MessageInput
+                onSend={vi.fn()}
+                isStreaming
+                activeWorkstreams={activeWorkstreams}
+                onSelectWorkstream={onSelectWorkstream}
+            />,
+        );
+
+        expect(screen.getByRole('button', { name: 'Alpha' })).not.toBeNull();
+        expect(screen.getByRole('button', { name: 'Gamma' })).not.toBeNull();
+        expect(screen.queryByRole('button', { name: 'Delta' })).toBeNull();
+        expect(screen.getByText('+2')).not.toBeNull();
+        expect(screen.getByText('Show more')).not.toBeNull();
+
+        fireEvent.click(screen.getByRole('button', { name: /show more/i }));
+
+        expect(screen.getByRole('button', { name: 'Delta' })).not.toBeNull();
+        expect(screen.getByRole('button', { name: 'Epsilon' })).not.toBeNull();
+        expect(screen.getByRole('button', { name: /show less/i })).not.toBeNull();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Delta' }));
+
+        expect(onSelectWorkstream).toHaveBeenCalledWith('delta');
+        expect(screen.queryByRole('button', { name: 'Delta' })).toBeNull();
+        expect(screen.getByRole('button', { name: /show more/i })).not.toBeNull();
     });
 });

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageInput.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageInput.tsx
@@ -66,6 +66,7 @@ interface MessageInputProps {
     isCompactingContext?: boolean;
     activeTaskCount?: number;
     activeWorkstreams?: WorkstreamInfo[];
+    onSelectWorkstream?: (workstreamId: string) => void;
     placeholder?: string;
 
     // File upload props
@@ -133,6 +134,7 @@ export default function MessageInput({
     isCompactingContext = false,
     activeTaskCount = 0,
     activeWorkstreams = [],
+    onSelectWorkstream,
     placeholder,
     // File upload props
     onFilesSelected,
@@ -474,7 +476,7 @@ export default function MessageInput({
                 />
             )}
 
-            <ActiveWorkstreamsSummary activeWorkstreams={activeWorkstreams} />
+            <ActiveWorkstreamsSummary activeWorkstreams={activeWorkstreams} onSelectWorkstream={onSelectWorkstream} />
 
             {/* Input row */}
             <div className="mx-auto flex max-w-3xl flex-col gap-2 rounded-2xl border border-border/70 bg-mixer-muted/15 p-2.5 shadow-lg shadow-black/5">

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageItem.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/MessageItem.tsx
@@ -37,7 +37,7 @@ import { createAgentMarkdownAnchor } from './AgentMarkdownAnchor';
 import { AttachmentPreviewList, parseUserMessageAttachments } from './AttachmentPreview';
 import { MessageDeliveryStatus } from './MessageDeliveryStatus';
 import { processContentForMarkdown } from './processContentForMarkdown';
-import { getToolApprovalResponseMetadata } from './requestInputMessages';
+import { getToolApprovalResponseMetadata, sendRequestInputResponse } from './requestInputMessages';
 import { getWorkstreamId } from './utils';
 
 /** className overrides for MessageItem — single source of truth for all className overrides. */
@@ -625,13 +625,27 @@ function MessageItemComponent({
                             variant={askUserUx.variant}
                             multiSelect={askUserUx.multiSelect}
                             onSelect={(optionId) =>
-                                onSendMessage?.(optionId, getToolApprovalResponseMetadata(message, optionId))
+                                sendRequestInputResponse(
+                                    onSendMessage,
+                                    message,
+                                    optionId,
+                                    getToolApprovalResponseMetadata(message, optionId),
+                                )
                             }
-                            onMultiSelect={(optionIds) => onSendMessage?.(optionIds.join(', '))}
+                            onMultiSelect={(optionIds) =>
+                                sendRequestInputResponse(onSendMessage, message, optionIds.join(', '))
+                            }
                             allowFreeResponse={!askUserUx.options?.length || !!askUserUx.free_response}
                             placeholder={askUserUx.free_response?.placeholder}
                             submitLabel={askUserUx.free_response?.submit_label}
-                            onSubmit={(value) => onSendMessage?.(value, askUserUx.free_response?.metadata)}
+                            onSubmit={(value) =>
+                                sendRequestInputResponse(
+                                    onSendMessage,
+                                    message,
+                                    value,
+                                    askUserUx.free_response?.metadata,
+                                )
+                            }
                             hideBorder
                             compact
                             answered={requestInputAnswered}

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/requestInputMessages.test.ts
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/requestInputMessages.test.ts
@@ -1,8 +1,12 @@
 import { type AgentMessage, AgentMessageType } from '@vertesia/common';
 import { describe, expect, it } from 'vitest';
 import {
+    getAnsweredRequestInputKeys,
     getAnsweredToolApprovalRequestInputKeys,
+    getPendingRequestInputMessage,
     getRequestInputMessageKey,
+    getRequestInputResponseIdFromMetadata,
+    getRequestInputResponseMetadata,
     getToolApprovalResponseMetadata,
 } from './requestInputMessages';
 
@@ -76,5 +80,73 @@ describe('getAnsweredToolApprovalRequestInputKeys', () => {
         const answer = makeUserAnswer('please proceed\n\nUploaded artifacts:\n[a.png](artifact:a)');
         const answered = getAnsweredToolApprovalRequestInputKeys([request, answer]);
         expect(answered.size).toBe(0);
+    });
+});
+
+describe('request input correlation', () => {
+    it('correlates a persisted response to the matching request id', () => {
+        const firstRequest = {
+            ...makeApprovalRequest(),
+            details: { request_id: 'request-1', ux: { options: [{ id: 'red', label: 'Red' }] } },
+        };
+        const secondRequest = {
+            ...makeApprovalRequest(),
+            timestamp: 2,
+            details: { request_id: 'request-2', ux: { options: [{ id: 'blue', label: 'Blue' }] } },
+        };
+        const answer = {
+            ...makeUserAnswer('red'),
+            timestamp: 3,
+            details: { request_input_response: { request_id: 'request-1' } },
+        };
+
+        const answered = getAnsweredRequestInputKeys([firstRequest, secondRequest, answer]);
+
+        expect(answered.has(getRequestInputMessageKey(firstRequest))).toBe(true);
+        expect(answered.has(getRequestInputMessageKey(secondRequest))).toBe(false);
+        expect(getPendingRequestInputMessage([firstRequest, secondRequest, answer])).toBe(secondRequest);
+    });
+
+    it('adds the request id without discarding existing response metadata', () => {
+        const request = {
+            ...makeApprovalRequest(),
+            details: { request_id: 'request-1', ux: { options: [{ id: 'red', label: 'Red' }] } },
+        };
+
+        expect(getRequestInputResponseMetadata(request, { source: 'free-response' })).toEqual({
+            source: 'free-response',
+            request_input_response: { request_id: 'request-1' },
+        });
+    });
+
+    it('does not let an earlier response resolve a later prompt that reused its request id', () => {
+        const firstRequest = {
+            ...makeApprovalRequest(),
+            details: { request_id: 'reused-request', ux: { options: [{ id: 'allow_once' }] } },
+        };
+        const firstAnswer = {
+            ...makeUserAnswer('allow_once'),
+            details: { request_input_response: { request_id: 'reused-request' } },
+        };
+        const secondRequest = {
+            ...makeApprovalRequest(),
+            timestamp: 3,
+            details: { request_id: 'reused-request', ux: { options: [{ id: 'allow_once' }] } },
+        };
+
+        const answered = getAnsweredRequestInputKeys([firstRequest, firstAnswer, secondRequest]);
+
+        expect(answered.has(getRequestInputMessageKey(firstRequest))).toBe(true);
+        expect(answered.has(getRequestInputMessageKey(secondRequest))).toBe(false);
+        expect(getPendingRequestInputMessage([firstRequest, firstAnswer, secondRequest])).toBe(secondRequest);
+    });
+
+    it('reads a request id from response metadata', () => {
+        expect(
+            getRequestInputResponseIdFromMetadata({
+                request_input_response: { request_id: 'request-1' },
+            }),
+        ).toBe('request-1');
+        expect(getRequestInputResponseIdFromMetadata({ request_input_response: {} })).toBeUndefined();
     });
 });

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/requestInputMessages.test.ts
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/requestInputMessages.test.ts
@@ -1,6 +1,7 @@
 import { type AgentMessage, AgentMessageType } from '@vertesia/common';
 import { describe, expect, it } from 'vitest';
 import {
+    clearRequestInputIdAnsweredForSession,
     getAnsweredRequestInputKeys,
     getAnsweredToolApprovalRequestInputKeys,
     getPendingRequestInputMessage,
@@ -8,6 +9,8 @@ import {
     getRequestInputResponseIdFromMetadata,
     getRequestInputResponseMetadata,
     getToolApprovalResponseMetadata,
+    isRequestInputAnsweredForSession,
+    markRequestInputIdAnsweredForSession,
 } from './requestInputMessages';
 
 const APPROVAL_KEY = 'create_interaction:name:JDE AR Payment Processing Agent';
@@ -84,6 +87,26 @@ describe('getAnsweredToolApprovalRequestInputKeys', () => {
 });
 
 describe('request input correlation', () => {
+    it('does not apply session acknowledgement to non-request-input messages with the same id', () => {
+        const agentRunId = 'agent-run-1';
+        const requestId = 'request-1';
+        const request = {
+            ...makeApprovalRequest(),
+            details: { request_id: requestId, ux: { options: [{ id: 'allow_once' }] } },
+        };
+        const unrelatedMessage = {
+            ...makeUserAnswer('Still working'),
+            details: { request_id: requestId },
+        };
+
+        markRequestInputIdAnsweredForSession(agentRunId, requestId);
+
+        expect(isRequestInputAnsweredForSession(agentRunId, request)).toBe(true);
+        expect(isRequestInputAnsweredForSession(agentRunId, unrelatedMessage)).toBe(false);
+
+        clearRequestInputIdAnsweredForSession(agentRunId, requestId);
+    });
+
     it('correlates a persisted response to the matching request id', () => {
         const firstRequest = {
             ...makeApprovalRequest(),

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/requestInputMessages.ts
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/requestInputMessages.ts
@@ -96,6 +96,63 @@ export function getRequestInputMessageKey(message: AgentMessage): string {
         .join('|');
 }
 
+export function getRequestInputId(message: AgentMessage): string | undefined {
+    const details = message.details as Record<string, unknown> | undefined;
+    const requestId = details?.request_id ?? details?.tool_use_id;
+    return typeof requestId === 'string' && requestId ? requestId : undefined;
+}
+
+export function getRequestInputResolutionKey(message: AgentMessage): string {
+    return getRequestInputId(message) ?? getRequestInputMessageKey(message);
+}
+
+const ANSWERED_REQUEST_INPUT_STORAGE_PREFIX = 'vertesia:answered-request-input:';
+
+function getAnsweredRequestInputStorageKey(agentRunId: string, requestId: string): string {
+    return `${ANSWERED_REQUEST_INPUT_STORAGE_PREFIX}${agentRunId}:${requestId}`;
+}
+
+export function markRequestInputIdAnsweredForSession(agentRunId: string, requestId: string): void {
+    if (typeof window === 'undefined') return;
+
+    try {
+        window.sessionStorage.setItem(getAnsweredRequestInputStorageKey(agentRunId, requestId), '1');
+    } catch {
+        // Session storage can be unavailable in privacy-restricted browser contexts.
+    }
+}
+
+export function clearRequestInputIdAnsweredForSession(agentRunId: string, requestId: string): void {
+    if (typeof window === 'undefined') return;
+
+    try {
+        window.sessionStorage.removeItem(getAnsweredRequestInputStorageKey(agentRunId, requestId));
+    } catch {
+        // Session storage can be unavailable in privacy-restricted browser contexts.
+    }
+}
+
+export function isRequestInputAnsweredForSession(agentRunId: string, message: AgentMessage): boolean {
+    const requestId = getRequestInputId(message);
+    if (!requestId || typeof window === 'undefined') return false;
+
+    try {
+        return window.sessionStorage.getItem(getAnsweredRequestInputStorageKey(agentRunId, requestId)) === '1';
+    } catch {
+        return false;
+    }
+}
+
+function getRequestInputResponseId(message: AgentMessage): string | undefined {
+    if (message.type !== AgentMessageType.QUESTION) return undefined;
+
+    const details = getRecord(message.details);
+    const metadata = getRecord(details?.metadata);
+    const response = getRecord(details?.request_input_response) ?? getRecord(metadata?.request_input_response);
+    const requestId = response?.request_id;
+    return typeof requestId === 'string' && requestId ? requestId : undefined;
+}
+
 export function getRequestInputAnswerMessageKey(message: AgentMessage): string {
     const details = message.details as Record<string, unknown> | undefined;
     const keyParts = [
@@ -114,9 +171,21 @@ export function getRequestInputAnswerMessageKey(message: AgentMessage): string {
 
 export function getAnsweredRequestInputKeys(messages: AgentMessage[]): Set<string> {
     const answered = new Set<string>();
+    const latestResponseIndexByRequestId = new Map<string, number>();
+    messages.forEach((message, index) => {
+        const requestId = getRequestInputResponseId(message);
+        if (requestId) latestResponseIndexByRequestId.set(requestId, index);
+    });
 
     messages.forEach((message, index) => {
         if (message.type !== AgentMessageType.REQUEST_INPUT) return;
+
+        const requestId = getRequestInputId(message);
+        const correlatedResponseIndex = requestId ? latestResponseIndexByRequestId.get(requestId) : undefined;
+        if (correlatedResponseIndex !== undefined && correlatedResponseIndex > index) {
+            answered.add(getRequestInputMessageKey(message));
+            return;
+        }
 
         const workstreamId = getWorkstreamId(message);
         for (let nextIndex = index + 1; nextIndex < messages.length; nextIndex += 1) {
@@ -125,13 +194,50 @@ export function getAnsweredRequestInputKeys(messages: AgentMessage[]): Set<strin
 
             if (nextMessage.type === AgentMessageType.REQUEST_INPUT) break;
             if (nextMessage.type === AgentMessageType.QUESTION) {
-                answered.add(getRequestInputMessageKey(message));
+                if (!getRequestInputResponseId(nextMessage)) {
+                    answered.add(getRequestInputMessageKey(message));
+                }
                 break;
             }
         }
     });
 
     return answered;
+}
+
+export function getRequestInputResponseMetadata(
+    message: AgentMessage,
+    metadata?: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+    const requestId = getRequestInputId(message);
+    if (!requestId) return metadata;
+
+    return {
+        ...metadata,
+        request_input_response: { request_id: requestId },
+    };
+}
+
+export function sendRequestInputResponse(
+    onSendMessage: ((message: string, metadata?: Record<string, unknown>) => void) | undefined,
+    requestMessage: AgentMessage,
+    response: string,
+    metadata?: Record<string, unknown>,
+): void {
+    if (!onSendMessage) return;
+
+    const responseMetadata = getRequestInputResponseMetadata(requestMessage, metadata);
+    if (responseMetadata) {
+        onSendMessage(response, responseMetadata);
+    } else {
+        onSendMessage(response);
+    }
+}
+
+export function getRequestInputResponseIdFromMetadata(metadata?: Record<string, unknown>): string | undefined {
+    const response = getRecord(metadata?.request_input_response);
+    const requestId = response?.request_id;
+    return typeof requestId === 'string' && requestId ? requestId : undefined;
 }
 
 export function getResolvedToolApprovalKeys(messages: AgentMessage[]): Set<string> {
@@ -300,6 +406,7 @@ export function isRequestInputAnswered(message: AgentMessage, answeredRequestInp
 export function getPendingRequestInputMessage(
     messages: AgentMessage[],
     workstreamId = 'main',
+    locallyAnsweredRequestInputKeys?: ReadonlySet<string>,
 ): RequestInputMessageWithUx | undefined {
     const answeredRequestInputKeys = getAnsweredRequestInputKeys(messages);
     const resolvedToolApprovalKeys = getResolvedToolApprovalKeys(messages);
@@ -308,6 +415,7 @@ export function getPendingRequestInputMessage(
         const message = messages[index];
         if (!hasRequestInputUx(message)) continue;
         if (getWorkstreamId(message) !== workstreamId) continue;
+        if (locallyAnsweredRequestInputKeys?.has(getRequestInputResolutionKey(message))) continue;
         if (isRequestInputAnswered(message, answeredRequestInputKeys)) continue;
         if (isRequestInputResolvedByToolApprovalEvent(message, resolvedToolApprovalKeys)) continue;
         return message;

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/requestInputMessages.ts
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/requestInputMessages.ts
@@ -133,6 +133,8 @@ export function clearRequestInputIdAnsweredForSession(agentRunId: string, reques
 }
 
 export function isRequestInputAnsweredForSession(agentRunId: string, message: AgentMessage): boolean {
+    if (message.type !== AgentMessageType.REQUEST_INPUT) return false;
+
     const requestId = getRequestInputId(message);
     if (!requestId || typeof window === 'undefined') return false;
 

--- a/packages/ui/src/features/agent/chat/index.ts
+++ b/packages/ui/src/features/agent/chat/index.ts
@@ -39,6 +39,7 @@ export {
 } from './AskUserWidget';
 export * from './JumpingDots';
 export {
+    type AgentMessageFilter,
     ModernAgentConversation,
     type ModernAgentConversationProps,
     type SendAgentMessageFn,

--- a/packages/ui/src/i18n/locales/ar.json
+++ b/packages/ui/src/i18n/locales/ar.json
@@ -164,7 +164,7 @@
   "agent.rewind.jumpToLatest": "الانتقال إلى أحدث رسالة",
   "agent.rewind.jumpToLive": "الانتقال إلى المباشر",
   "agent.rewind.jumpToStart": "الانتقال إلى أول رسالة",
-  "agent.rewind.label": "إعادة التشغيل",
+  "agent.rewind.label": "تصحيح الأخطاء",
   "agent.rewind.nextMessage": "الرسالة التالية",
   "agent.rewind.pause": "إيقاف مؤقت",
   "agent.rewind.positionInput": "موضع التشغيل",

--- a/packages/ui/src/i18n/locales/ar.json
+++ b/packages/ui/src/i18n/locales/ar.json
@@ -200,6 +200,7 @@
   "agent.summary": "ملخص",
   "agent.taskProgress": "تقدم المهام",
   "agent.tasksCompleted": "{{completed}}/{{total}} مكتملة",
+  "agent.thinking": "جارٍ التفكير...",
   "agent.timeout": "انتهت المهلة",
   "agent.toggleRightSidebar": "تبديل الشريط الجانبي الأيمن",
   "agent.typeYourMessage": "اكتب رسالتك...",

--- a/packages/ui/src/i18n/locales/de.json
+++ b/packages/ui/src/i18n/locales/de.json
@@ -192,6 +192,7 @@
   "agent.summary": "Zusammenfassung",
   "agent.taskProgress": "Aufgabenfortschritt",
   "agent.tasksCompleted": "{{completed}}/{{total}} abgeschlossen",
+  "agent.thinking": "Denke nach...",
   "agent.timeout": "Zeitüberschreitung",
   "agent.toggleRightSidebar": "Rechte Seitenleiste umschalten",
   "agent.typeYourMessage": "Geben Sie Ihre Nachricht ein...",

--- a/packages/ui/src/i18n/locales/de.json
+++ b/packages/ui/src/i18n/locales/de.json
@@ -160,7 +160,7 @@
   "agent.rewind.jumpToLatest": "Zur neuesten Nachricht springen",
   "agent.rewind.jumpToLive": "Zur Live-Ansicht springen",
   "agent.rewind.jumpToStart": "Zur ersten Nachricht springen",
-  "agent.rewind.label": "Wiedergabe",
+  "agent.rewind.label": "Debuggen",
   "agent.rewind.nextMessage": "Nächste Nachricht",
   "agent.rewind.pause": "Pausieren",
   "agent.rewind.positionInput": "Wiedergabeposition",

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -265,6 +265,7 @@
     "agent.summary": "Summary",
     "agent.taskProgress": "Task Progress",
     "agent.tasksCompleted": "{{completed}}/{{total}} completed",
+    "agent.thinking": "Thinking...",
     "agent.timeout": "Timed out",
     "agent.toggleRightSidebar": "Toggle right sidebar",
     "agent.typeYourMessage": "Type your message...",

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -224,7 +224,7 @@
     "agent.rewind.jumpToLatest": "Jump to latest message",
     "agent.rewind.jumpToLive": "Jump to live",
     "agent.rewind.jumpToStart": "Jump to first message",
-    "agent.rewind.label": "Rewind",
+    "agent.rewind.label": "Debug",
     "agent.rewind.nextMessage": "Next message",
     "agent.rewind.pause": "Pause",
     "agent.rewind.positionInput": "Playback position",

--- a/packages/ui/src/i18n/locales/es.json
+++ b/packages/ui/src/i18n/locales/es.json
@@ -161,7 +161,7 @@
   "agent.rewind.jumpToLatest": "Ir al mensaje más reciente",
   "agent.rewind.jumpToLive": "Ir a en vivo",
   "agent.rewind.jumpToStart": "Ir al primer mensaje",
-  "agent.rewind.label": "Reproducción",
+  "agent.rewind.label": "Depuración",
   "agent.rewind.nextMessage": "Mensaje siguiente",
   "agent.rewind.pause": "Pausar",
   "agent.rewind.positionInput": "Posición de reproducción",

--- a/packages/ui/src/i18n/locales/es.json
+++ b/packages/ui/src/i18n/locales/es.json
@@ -194,6 +194,7 @@
   "agent.summary": "Resumen",
   "agent.taskProgress": "Progreso de tareas",
   "agent.tasksCompleted": "{{completed}}/{{total}} completadas",
+  "agent.thinking": "Pensando...",
   "agent.timeout": "Tiempo agotado",
   "agent.toggleRightSidebar": "Alternar panel lateral",
   "agent.typeYourMessage": "Escribe tu mensaje...",

--- a/packages/ui/src/i18n/locales/fr.json
+++ b/packages/ui/src/i18n/locales/fr.json
@@ -194,6 +194,7 @@
   "agent.summary": "Résumé",
   "agent.taskProgress": "Progression des tâches",
   "agent.tasksCompleted": "{{completed}}/{{total}} terminées",
+  "agent.thinking": "Réflexion...",
   "agent.timeout": "Délai dépassé",
   "agent.toggleRightSidebar": "Basculer le panneau latéral",
   "agent.typeYourMessage": "Saisissez votre message...",

--- a/packages/ui/src/i18n/locales/fr.json
+++ b/packages/ui/src/i18n/locales/fr.json
@@ -161,7 +161,7 @@
   "agent.rewind.jumpToLatest": "Aller au dernier message",
   "agent.rewind.jumpToLive": "Aller au direct",
   "agent.rewind.jumpToStart": "Aller au premier message",
-  "agent.rewind.label": "Lecture",
+  "agent.rewind.label": "Débogage",
   "agent.rewind.nextMessage": "Message suivant",
   "agent.rewind.pause": "Pause",
   "agent.rewind.positionInput": "Position de lecture",

--- a/packages/ui/src/i18n/locales/it.json
+++ b/packages/ui/src/i18n/locales/it.json
@@ -161,7 +161,7 @@
   "agent.rewind.jumpToLatest": "Vai al messaggio più recente",
   "agent.rewind.jumpToLive": "Vai al live",
   "agent.rewind.jumpToStart": "Vai al primo messaggio",
-  "agent.rewind.label": "Replay",
+  "agent.rewind.label": "Debug",
   "agent.rewind.nextMessage": "Messaggio successivo",
   "agent.rewind.pause": "Pausa",
   "agent.rewind.positionInput": "Posizione di riproduzione",

--- a/packages/ui/src/i18n/locales/it.json
+++ b/packages/ui/src/i18n/locales/it.json
@@ -194,6 +194,7 @@
   "agent.summary": "Riepilogo",
   "agent.taskProgress": "Progresso attività",
   "agent.tasksCompleted": "{{completed}}/{{total}} completate",
+  "agent.thinking": "Sto pensando...",
   "agent.timeout": "Tempo scaduto",
   "agent.toggleRightSidebar": "Alterna pannello laterale",
   "agent.typeYourMessage": "Scrivi il tuo messaggio...",

--- a/packages/ui/src/i18n/locales/ja.json
+++ b/packages/ui/src/i18n/locales/ja.json
@@ -192,6 +192,7 @@
   "agent.summary": "概要",
   "agent.taskProgress": "タスクの進捗",
   "agent.tasksCompleted": "{{completed}}/{{total}} 完了",
+  "agent.thinking": "考え中...",
   "agent.timeout": "タイムアウト",
   "agent.toggleRightSidebar": "右サイドバーの切り替え",
   "agent.typeYourMessage": "メッセージを入力...",

--- a/packages/ui/src/i18n/locales/ja.json
+++ b/packages/ui/src/i18n/locales/ja.json
@@ -160,7 +160,7 @@
   "agent.rewind.jumpToLatest": "最新のメッセージへ移動",
   "agent.rewind.jumpToLive": "ライブへ移動",
   "agent.rewind.jumpToStart": "最初のメッセージへ移動",
-  "agent.rewind.label": "再生",
+  "agent.rewind.label": "デバッグ",
   "agent.rewind.nextMessage": "次のメッセージ",
   "agent.rewind.pause": "一時停止",
   "agent.rewind.positionInput": "再生位置",

--- a/packages/ui/src/i18n/locales/ko.json
+++ b/packages/ui/src/i18n/locales/ko.json
@@ -160,7 +160,7 @@
   "agent.rewind.jumpToLatest": "최신 메시지로 이동",
   "agent.rewind.jumpToLive": "라이브로 이동",
   "agent.rewind.jumpToStart": "첫 메시지로 이동",
-  "agent.rewind.label": "재생",
+  "agent.rewind.label": "디버그",
   "agent.rewind.nextMessage": "다음 메시지",
   "agent.rewind.pause": "일시 중지",
   "agent.rewind.positionInput": "재생 위치",

--- a/packages/ui/src/i18n/locales/ko.json
+++ b/packages/ui/src/i18n/locales/ko.json
@@ -192,6 +192,7 @@
   "agent.summary": "요약",
   "agent.taskProgress": "작업 진행률",
   "agent.tasksCompleted": "{{completed}}/{{total}} 완료",
+  "agent.thinking": "생각 중...",
   "agent.timeout": "시간 초과",
   "agent.toggleRightSidebar": "오른쪽 사이드바 전환",
   "agent.typeYourMessage": "메시지를 입력하세요...",

--- a/packages/ui/src/i18n/locales/pt.json
+++ b/packages/ui/src/i18n/locales/pt.json
@@ -194,6 +194,7 @@
   "agent.summary": "Resumo",
   "agent.taskProgress": "Progresso das tarefas",
   "agent.tasksCompleted": "{{completed}}/{{total}} concluídas",
+  "agent.thinking": "Pensando...",
   "agent.timeout": "Tempo esgotado",
   "agent.toggleRightSidebar": "Alternar painel lateral",
   "agent.typeYourMessage": "Digite sua mensagem...",

--- a/packages/ui/src/i18n/locales/pt.json
+++ b/packages/ui/src/i18n/locales/pt.json
@@ -161,7 +161,7 @@
   "agent.rewind.jumpToLatest": "Ir para a mensagem mais recente",
   "agent.rewind.jumpToLive": "Ir para ao vivo",
   "agent.rewind.jumpToStart": "Ir para a primeira mensagem",
-  "agent.rewind.label": "Reprodução",
+  "agent.rewind.label": "Depuração",
   "agent.rewind.nextMessage": "Próxima mensagem",
   "agent.rewind.pause": "Pausar",
   "agent.rewind.positionInput": "Posição de reprodução",

--- a/packages/ui/src/i18n/locales/ru.json
+++ b/packages/ui/src/i18n/locales/ru.json
@@ -162,7 +162,7 @@
   "agent.rewind.jumpToLatest": "Перейти к последнему сообщению",
   "agent.rewind.jumpToLive": "Перейти к live",
   "agent.rewind.jumpToStart": "Перейти к первому сообщению",
-  "agent.rewind.label": "Повтор",
+  "agent.rewind.label": "Отладка",
   "agent.rewind.nextMessage": "Следующее сообщение",
   "agent.rewind.pause": "Пауза",
   "agent.rewind.positionInput": "Позиция воспроизведения",

--- a/packages/ui/src/i18n/locales/ru.json
+++ b/packages/ui/src/i18n/locales/ru.json
@@ -196,6 +196,7 @@
   "agent.summary": "Сводка",
   "agent.taskProgress": "Прогресс задач",
   "agent.tasksCompleted": "{{completed}}/{{total}} завершено",
+  "agent.thinking": "Размышляю...",
   "agent.timeout": "Время ожидания истекло",
   "agent.toggleRightSidebar": "Переключить правую панель",
   "agent.typeYourMessage": "Введите сообщение...",

--- a/packages/ui/src/i18n/locales/tr.json
+++ b/packages/ui/src/i18n/locales/tr.json
@@ -160,7 +160,7 @@
   "agent.rewind.jumpToLatest": "En yeni mesaja git",
   "agent.rewind.jumpToLive": "Canlıya git",
   "agent.rewind.jumpToStart": "İlk mesaja git",
-  "agent.rewind.label": "Yeniden oynatma",
+  "agent.rewind.label": "Hata ayıklama",
   "agent.rewind.nextMessage": "Sonraki mesaj",
   "agent.rewind.pause": "Duraklat",
   "agent.rewind.positionInput": "Oynatma konumu",

--- a/packages/ui/src/i18n/locales/tr.json
+++ b/packages/ui/src/i18n/locales/tr.json
@@ -192,6 +192,7 @@
   "agent.summary": "Özet",
   "agent.taskProgress": "Görev ilerlemesi",
   "agent.tasksCompleted": "{{completed}}/{{total}} tamamlandı",
+  "agent.thinking": "Düşünüyor...",
   "agent.timeout": "Zaman aşımına uğradı",
   "agent.toggleRightSidebar": "Sağ kenar çubuğunu aç/kapat",
   "agent.typeYourMessage": "Mesajınızı yazın...",

--- a/packages/ui/src/i18n/locales/zh-TW.json
+++ b/packages/ui/src/i18n/locales/zh-TW.json
@@ -192,6 +192,7 @@
   "agent.summary": "摘要",
   "agent.taskProgress": "任務進度",
   "agent.tasksCompleted": "{{completed}}/{{total}} 已完成",
+  "agent.thinking": "思考中...",
   "agent.timeout": "已逾時",
   "agent.toggleRightSidebar": "切換右側邊欄",
   "agent.typeYourMessage": "輸入訊息...",

--- a/packages/ui/src/i18n/locales/zh-TW.json
+++ b/packages/ui/src/i18n/locales/zh-TW.json
@@ -160,7 +160,7 @@
   "agent.rewind.jumpToLatest": "跳到最新訊息",
   "agent.rewind.jumpToLive": "跳到即時",
   "agent.rewind.jumpToStart": "跳到第一則訊息",
-  "agent.rewind.label": "重播",
+  "agent.rewind.label": "偵錯",
   "agent.rewind.nextMessage": "下一則訊息",
   "agent.rewind.pause": "暫停",
   "agent.rewind.positionInput": "播放位置",

--- a/packages/ui/src/i18n/locales/zh.json
+++ b/packages/ui/src/i18n/locales/zh.json
@@ -160,7 +160,7 @@
   "agent.rewind.jumpToLatest": "跳到最新消息",
   "agent.rewind.jumpToLive": "跳到实时",
   "agent.rewind.jumpToStart": "跳到第一条消息",
-  "agent.rewind.label": "回放",
+  "agent.rewind.label": "调试",
   "agent.rewind.nextMessage": "下一条消息",
   "agent.rewind.pause": "暂停",
   "agent.rewind.positionInput": "播放位置",

--- a/packages/ui/src/i18n/locales/zh.json
+++ b/packages/ui/src/i18n/locales/zh.json
@@ -192,6 +192,7 @@
   "agent.summary": "摘要",
   "agent.taskProgress": "任务进度",
   "agent.tasksCompleted": "{{completed}}/{{total}} 已完成",
+  "agent.thinking": "思考中...",
   "agent.timeout": "已超时",
   "agent.toggleRightSidebar": "切换右侧边栏",
   "agent.typeYourMessage": "输入消息...",


### PR DESCRIPTION
## Summary

- correlate request-input prompts and responses so answered widgets do not reappear during replay, including inline replies, approvals, and MCP connection prompts
- keep busy composer content compact with expandable workstream and attachment summaries, plus workstream navigation
- add presentation-only message filtering and show Thinking after a completed tool while the current work group remains active

## Test plan

- [x] pnpm lint
- [x] pnpm typecheck:test
- [x] pnpm test (712 tests)
- [x] pnpm build