### PR TITLE
feat(common,workflow): conversation catalog split and DSL activity vars filter

### DIFF
--- a/packages/common/src/store/conversation-state.ts
+++ b/packages/common/src/store/conversation-state.ts
@@ -43,8 +43,13 @@ export function toolInputRefsArtifactPath(storageId: string): string {
 }
 
 /**
- * Conversation state passed between workflow activities.
- * Contains all context needed to continue a multi-turn agent conversation.
+ * Conversation state passed between workflow activities: the activity-safe,
+ * per-turn dynamic subset of a multi-turn agent conversation. Rides every
+ * conversation activity payload, so it deliberately excludes anything large or
+ * fetchable — the conversation history and tool definitions live in artifact
+ * storage (referenced via `tool_reference` / the conversation storage id), and
+ * catalog/activation data lives in the workflow-memory
+ * {@link ConversationCatalogState} (persisted as catalog.json).
  */
 export interface ConversationState {
     /**
@@ -131,17 +136,8 @@ export interface ConversationState {
     /** Active tools that should not be evicted by bounded active-tool pruning. */
     pinned_tool_names?: string[];
 
-    /**
-     * Activation and usage metadata for tools seen during the conversation.
-     * Used to keep the active tool set bounded without losing recovery context.
-     */
-    tool_activation_metadata?: Record<string, ToolActivationMetadata>;
-
     /** Skills that have been used in this conversation (for auto-syncing scripts and package installation) */
     used_skills?: UsedSkill[];
-
-    /** All available skills from registered tool collections (for upfront hydration in sandbox) */
-    available_skills?: AvailableSkill[];
 
     /** Whether to stream LLM responses to Redis (cached from project config) */
     streaming_enabled?: boolean;
@@ -189,19 +185,13 @@ export interface ConversationState {
     latest_streaming_id?: string;
 
     /**
-     * Mapping of skill names to their related tools.
-     * When a skill is called, its related tools are added to unlocked_tools.
-     */
-    skill_tool_map?: Record<string, string[]>;
-
-    /**
      * Names of skills whose full instructions are already present in the live conversation
      * history (i.e. were delivered by a prior `learn_<skill>` call). Used to make skill
      * re-activation idempotent: a repeat call returns a short "already active" acknowledgement
      * instead of re-dumping the instructions.
      *
-     * Unlike `unlocked_tools`/`skill_tool_map` (which must survive a checkpoint so tools stay
-     * unlocked), this list is reset when a checkpoint compacts the conversation, because the
+     * Unlike `unlocked_tools` (which must survive a checkpoint so tools stay unlocked),
+     * this list is reset when a checkpoint compacts the conversation, because the
      * summary no longer carries the skill instructions and the next call must re-deliver them.
      */
     skill_instructions_delivered?: string[];
@@ -255,6 +245,42 @@ export interface ConversationState {
      */
     app_version?: string;
 }
+
+/**
+ * Tool/skill catalog state for a conversation, split out of {@link ConversationState}
+ * so it never rides Temporal activity payloads:
+ * - `skill_tool_map` and `available_skills` are composed by tool generation and
+ *   persisted next to the tool universe (catalog.json); the workflow holds them in
+ *   memory and the few consuming activities fetch them from artifact storage.
+ * - `tool_activation_metadata` is workflow-side eviction/pin bookkeeping; it survives
+ *   continueAsNew via the continuation payload, never via activity inputs.
+ */
+export interface ConversationCatalogState {
+    /**
+     * Mapping of skill names to their related tools.
+     * When a skill is called, its related tools are added to unlocked_tools.
+     */
+    skill_tool_map?: Record<string, string[]>;
+
+    /** All available skills from registered tool collections (for upfront hydration in sandbox) */
+    available_skills?: AvailableSkill[];
+
+    /**
+     * Activation and usage metadata for tools seen during the conversation.
+     * Used to keep the active tool set bounded without losing recovery context.
+     */
+    tool_activation_metadata?: Record<string, ToolActivationMetadata>;
+}
+
+/**
+ * The subset of {@link ConversationCatalogState} persisted to artifact storage
+ * (catalog.json, next to conversation.json and tools.json). Activation metadata is
+ * runtime bookkeeping and is deliberately not part of the stored catalog.
+ */
+export type StoredConversationCatalog = Pick<ConversationCatalogState, 'skill_tool_map' | 'available_skills'>;
+
+/** Artifact key of the stored conversation catalog, relative to the agent storage root. */
+export const CONVERSATION_CATALOG_ARTIFACT_KEY = 'catalog.json';
 
 /**
  * An MCP server the user can connect to but hasn't yet (active + accessible, no OAuth token).

--- a/packages/workflow/src/dsl/dslProxyActivities.ts
+++ b/packages/workflow/src/dsl/dslProxyActivities.ts
@@ -24,14 +24,35 @@ export function stripWorkflowContinuationFromVars<T>(vars: T): T {
     return rest as T;
 }
 
-export function dslProxyActivities<ActivitiesT extends object>(workflowName: string, options: ActivityOptions = {}) {
+export interface DslProxyOptions {
+    /**
+     * Optional filter applied to `payload.vars` before it is copied into each
+     * activity input. The DSL spreads the whole workflow payload into every
+     * activity scheduling, so for workflows with a large or growing `vars` this
+     * lets the caller keep only the fields its activities actually read —
+     * multiplying the saving by every activity event in the history.
+     *
+     * Runs synchronously inside the Temporal workflow sandbox on every activity
+     * call: it must be deterministic, must not mutate its input (when `vars`
+     * carries no `_continuation` the original workflow object is passed, not a
+     * copy), and must return a new plain object. The synchronous return type
+     * makes an async implementation a compile error.
+     */
+    varsFilter?: (vars: Readonly<Record<string, unknown>>) => Record<string, unknown>;
+}
+
+export function dslProxyActivities<ActivitiesT extends object>(
+    workflowName: string,
+    options: ActivityOptions & DslProxyOptions = {},
+) {
     type DslActivities = {
         [K in keyof ActivitiesT]: ActivitiesT[K] extends DslActivityFunction<infer ParamsT, infer ReturnT>
             ? DslSimplifiedActivityFunction<ParamsT, ReturnT>
             : never;
     };
 
-    const activities = proxyActivities<ActivitiesT>(options) as ActivitiesT;
+    const { varsFilter, ...activityOptions } = options;
+    const activities = proxyActivities<ActivitiesT>(activityOptions) as ActivitiesT;
 
     return new Proxy(
         {},
@@ -42,9 +63,14 @@ export function dslProxyActivities<ActivitiesT extends object>(workflowName: str
                     unknown
                 >;
                 return (payload: WorkflowExecutionPayload, params: Record<string, unknown>) => {
+                    const vars = stripWorkflowContinuationFromVars(payload.vars);
+                    const filteredVars =
+                        varsFilter && vars && typeof vars === 'object' && !Array.isArray(vars)
+                            ? (varsFilter(vars as Record<string, unknown>) as typeof vars)
+                            : vars;
                     return activityFn({
                         ...payload,
-                        vars: stripWorkflowContinuationFromVars(payload.vars),
+                        vars: filteredVars,
                         activity: {
                             name: prop as string,
                         },


### PR DESCRIPTION
## Summary
- `@vertesia/common`: split the tool/skill catalog out of `ConversationState`. The three catalog fields (`skill_tool_map`, `available_skills`, `tool_activation_metadata`) move to a new `ConversationCatalogState` sibling type, with `StoredConversationCatalog` as the subset persisted to artifact storage (`catalog.json`, key exported as `CONVERSATION_CATALOG_ARTIFACT_KEY`). `ConversationState` rides every Temporal activity payload of a conversation workflow, so it now deliberately carries only the per-turn dynamic subset; catalog data is workflow-memory + artifact-storage resident. **Breaking** for consumers that read those optional fields from `ConversationState` — they should consume `ConversationCatalogState` instead.
- `@vertesia/workflow`: `dslProxyActivities` gains an opt-in `varsFilter` option, applied to `payload.vars` before it is copied into each activity input. The DSL spreads the whole workflow payload into every activity scheduling, so workflows with a large or growing `vars` can now bound what rides each activity event. The filter runs synchronously in the workflow sandbox and must be deterministic and non-mutating; the synchronous `Record` return type makes an async implementation a compile error. The option is stripped before reaching Temporal's `proxyActivities`.

## Test Plan
- [x] `pnpm build` (common, workflow — incl. workflow bundle)
- [x] `pnpm lint` (both packages)
- [x] `pnpm test`: common 162 passed, workflow 184 passed
- [x] `pnpm typecheck:test` (both packages)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking type move for catalog fields on `ConversationState` affects all consumers; incorrect `varsFilter` could omit fields activities need and fail runs at runtime.
> 
> **Overview**
> Shrinks what rides every Temporal conversation activity by moving tool/skill catalog data off `ConversationState` and adding an opt-in way to trim workflow `vars` on each DSL activity schedule.
> 
> **`ConversationState`** is documented as the activity-safe per-turn slice only. **`skill_tool_map`**, **`available_skills`**, and **`tool_activation_metadata`** move to new **`ConversationCatalogState`** (workflow memory + artifact fetch; activation metadata via continuation, not activities). Persisted catalog is **`StoredConversationCatalog`** at **`catalog.json`** (`CONVERSATION_CATALOG_ARTIFACT_KEY`). **Breaking:** code reading those fields on `ConversationState` must use `ConversationCatalogState` / stored catalog instead.
> 
> **`dslProxyActivities`** accepts optional **`varsFilter`**: a synchronous, deterministic, non-mutating reducer applied to `payload.vars` (after stripping `_continuation`) before each activity input is built, so large workflow vars are not copied on every history event. `varsFilter` is stripped before Temporal `proxyActivities` options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c48af07e1e64e171f7be8f8f21c17d1a0241736. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->