### PR TITLE
feat(common): agent checkpoint configuration under configuration.agent

### DIFF
--- a/packages/common/src/interaction.ts
+++ b/packages/common/src/interaction.ts
@@ -14,7 +14,7 @@ import type {
 import type { PrincipalType } from './apikey.js';
 import type { MCPToolAnnotations } from './apps.js';
 import type { ExecutionEnvironmentRef } from './environment.js';
-import type { ProjectRef } from './project.js';
+import type { AgentCheckpointConfiguration, ProjectRef } from './project.js';
 import type {
     ExecutablePromptSegmentDef,
     PopulatedPromptSegmentDef,
@@ -700,6 +700,13 @@ export interface AgentRunnerOptions {
      * resolved from the run data.
      */
     request_template?: string;
+
+    /**
+     * Per-agent context checkpoint configuration. Field-wise it overrides the
+     * project's `configuration.agent.checkpoint`; a per-run `checkpoint_tokens`
+     * override still wins over both.
+     */
+    checkpoint?: AgentCheckpointConfiguration;
 }
 
 // ================= User Communication Channels ====================

--- a/packages/common/src/interaction.ts
+++ b/packages/common/src/interaction.ts
@@ -825,9 +825,19 @@ export interface AsyncConversationExecutionPayload extends AsyncExecutionPayload
     /**
      * The token threshold in thousands (K) for creating checkpoints.
      * If total tokens exceed this value, a checkpoint will be created.
-     * If not specified, the default is computed from the selected model context window (75%).
+     * When set it wins over every other checkpoint setting, including the
+     * structured `checkpoint` override below. If not specified, the default
+     * is computed from the selected model context window (80%, capped at 500k).
      */
     checkpoint_tokens?: number;
+
+    /**
+     * Structured per-run checkpoint override. Field-wise it takes precedence
+     * over the interaction's `agent_runner_options.checkpoint` and the
+     * project's `configuration.agent.checkpoint`. The legacy absolute
+     * `checkpoint_tokens` above still wins over everything when set.
+     */
+    checkpoint?: AgentCheckpointConfiguration;
 
     /**
      * Configuration for stripping large data (images, text) from conversation history

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -394,6 +394,15 @@ export interface ProjectConfiguration {
     agent_streaming_enabled?: boolean;
 
     /**
+     * Agent conversation checkpoint threshold in tokens: the context size at
+     * which the conversation is summarized and compacted. Overrides the
+     * model-based default (80% of the model's context window, capped at 500k).
+     * Clamped at runtime to 95% of the model's window so the prompt still fits.
+     * Unset means the model-based default.
+     */
+    agent_checkpoint_tokens?: number;
+
+    /**
      * Indexing configuration for this project.
      * Controls whether indexing and querying are enabled at the project level.
      */

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -368,6 +368,35 @@ export interface ProjectIntakeConfiguration {
     default_content_type?: string;
 }
 
+/**
+ * Agent runtime configuration, scoped under project configuration so agent
+ * settings have one home (`configuration.agent`).
+ */
+export interface AgentProjectConfiguration {
+    /** Conversation checkpoint (context compaction) tuning. */
+    checkpoint?: AgentCheckpointConfiguration;
+}
+
+export interface AgentCheckpointConfiguration {
+    /**
+     * Fraction of the model's context window to use before the conversation is
+     * summarized and compacted (0-1, e.g. 0.95). Model-independent: applies to
+     * whatever model each run uses. Setting it replaces the default hard cap —
+     * a project asking for 0.95 of a 1M-window model checkpoints at 950k.
+     * Clamped at runtime to 0.95 so the prompt still fits.
+     */
+    context_threshold?: number;
+
+    /**
+     * Absolute hard cap in tokens, regardless of the window fraction. Alone it
+     * acts as the threshold; combined with context_threshold the lower of the
+     * two wins. Clamped at runtime to 95% of the model's window. Unset means
+     * the default cap (500k), or no cap beyond the 95% clamp when
+     * context_threshold is set.
+     */
+    max_tokens?: number;
+}
+
 export interface ProjectConfiguration {
     human_context?: string;
 
@@ -394,23 +423,9 @@ export interface ProjectConfiguration {
     agent_streaming_enabled?: boolean;
 
     /**
-     * Agent conversation checkpoint threshold as a fraction of the model's
-     * context window (0–1, e.g. 0.95). Model-independent: applies to whatever
-     * model a run uses. Overrides the default ratio (0.8) AND the default hard
-     * cap — a project setting 0.95 on a 1M model checkpoints at 950k. Clamped
-     * at runtime to 0.95 so the prompt still fits. Combine with
-     * agent_checkpoint_tokens to also bound the absolute size.
+     * Agent runtime configuration for this project.
      */
-    agent_checkpoint_threshold?: number;
-
-    /**
-     * Agent conversation checkpoint hard cap in tokens: the absolute context
-     * size at which the conversation is summarized and compacted, regardless
-     * of the window fraction. Replaces the default 500k cap when set. Clamped
-     * at runtime to 95% of the model's window. Unset means the default cap
-     * (or no cap beyond the 95% clamp when agent_checkpoint_threshold is set).
-     */
-    agent_checkpoint_tokens?: number;
+    agent?: AgentProjectConfiguration;
 
     /**
      * Indexing configuration for this project.

--- a/packages/common/src/project.ts
+++ b/packages/common/src/project.ts
@@ -394,11 +394,21 @@ export interface ProjectConfiguration {
     agent_streaming_enabled?: boolean;
 
     /**
-     * Agent conversation checkpoint threshold in tokens: the context size at
-     * which the conversation is summarized and compacted. Overrides the
-     * model-based default (80% of the model's context window, capped at 500k).
-     * Clamped at runtime to 95% of the model's window so the prompt still fits.
-     * Unset means the model-based default.
+     * Agent conversation checkpoint threshold as a fraction of the model's
+     * context window (0–1, e.g. 0.95). Model-independent: applies to whatever
+     * model a run uses. Overrides the default ratio (0.8) AND the default hard
+     * cap — a project setting 0.95 on a 1M model checkpoints at 950k. Clamped
+     * at runtime to 0.95 so the prompt still fits. Combine with
+     * agent_checkpoint_tokens to also bound the absolute size.
+     */
+    agent_checkpoint_threshold?: number;
+
+    /**
+     * Agent conversation checkpoint hard cap in tokens: the absolute context
+     * size at which the conversation is summarized and compacted, regardless
+     * of the window fraction. Replaces the default 500k cap when set. Clamped
+     * at runtime to 95% of the model's window. Unset means the default cap
+     * (or no cap beyond the 95% clamp when agent_checkpoint_threshold is set).
      */
     agent_checkpoint_tokens?: number;
 

--- a/packages/common/src/store/agent-run.ts
+++ b/packages/common/src/store/agent-run.ts
@@ -22,6 +22,7 @@ import type {
     RunSource,
 } from '../interaction.js';
 import type { EventRef } from '../platform-event.js';
+import type { AgentCheckpointConfiguration } from '../project.js';
 import type { ResourceRef } from '../refs.js';
 import type { AgentEvent } from '../workflow-analytics.js';
 import type { AgentToolApprovalMode } from './agent-approval.js';
@@ -366,8 +367,16 @@ export interface CreateAgentRunPayload<TData = Record<string, unknown>, TPropert
     /** User communication channels (email, interactive) */
     user_channels?: UserChannel[];
 
-    /** Token budget for checkpointing */
+    /** Token budget for checkpointing, in thousands (K). Wins over every other checkpoint setting. */
     checkpoint_tokens?: number;
+
+    /**
+     * Structured checkpoint override for this run. Field-wise it takes
+     * precedence over the interaction's `agent_runner_options.checkpoint`
+     * and the project's `configuration.agent.checkpoint`; the legacy
+     * `checkpoint_tokens` above still wins over everything when set.
+     */
+    checkpoint?: AgentCheckpointConfiguration;
 
     /** Maximum conversation iterations (default: 20) */
     max_iterations?: number;

--- a/packages/common/src/store/conversation-state.ts
+++ b/packages/common/src/store/conversation-state.ts
@@ -143,9 +143,16 @@ export interface ConversationState {
     streaming_enabled?: boolean;
 
     /**
-     * Project-configured checkpoint threshold in tokens (cached from
+     * Project-configured checkpoint threshold as a fraction of the model's
+     * context window (cached from project.configuration.agent_checkpoint_threshold
+     * at conversation start).
+     */
+    checkpoint_threshold?: number;
+
+    /**
+     * Project-configured checkpoint hard cap in tokens (cached from
      * project.configuration.agent_checkpoint_tokens at conversation start).
-     * The workflow resolves the effective threshold from this, the per-run
+     * The workflow resolves the effective threshold from these, the per-run
      * checkpoint_tokens override, and the model-based default.
      */
     checkpoint_tokens?: number;

--- a/packages/common/src/store/conversation-state.ts
+++ b/packages/common/src/store/conversation-state.ts
@@ -143,6 +143,14 @@ export interface ConversationState {
     streaming_enabled?: boolean;
 
     /**
+     * Project-configured checkpoint threshold in tokens (cached from
+     * project.configuration.agent_checkpoint_tokens at conversation start).
+     * The workflow resolves the effective threshold from this, the per-run
+     * checkpoint_tokens override, and the model-based default.
+     */
+    checkpoint_tokens?: number;
+
+    /**
      * Active communication channels with their current state.
      * Channels can be updated as conversation progresses (e.g., email threading info).
      */


### PR DESCRIPTION
## Summary
Adds a proper agent configuration object to project configuration — `configuration.agent` (`AgentProjectConfiguration`) — with conversation checkpoint tuning as its first member:

```jsonc
{ "configuration": { "agent": { "checkpoint": {
    "context_threshold": 0.95,  // fraction of the model's context window (0–1)
    "max_tokens": 600000        // absolute hard cap in tokens
} } } }
```

- `context_threshold`: model-independent fraction of the window to use before the conversation is summarized/compacted. Setting it replaces the default hard cap (0.95 of a 1M-window model → 950k). Clamped at runtime to 0.95.
- `max_tokens`: absolute cap; alone it acts as the threshold, combined with the fraction the lower of the two wins. Clamped at runtime to 95% of the model's window.
- `checkpoint` on `CreateAgentRunPayload` / `AsyncConversationExecutionPayload`: the same structured object per run, top of the field-wise chain; the legacy absolute `checkpoint_tokens` (thousands) still wins over everything when set.
- `AgentRunnerOptions.checkpoint`: the same object on the interaction (agent definition), overriding the project values field-wise; a per-run `checkpoint_tokens` override still wins over both. Precedence: run > interaction > project > model default.
- `ConversationState.checkpoint_threshold` / `checkpoint_tokens`: the resolved values, cached on state at conversation start so the deterministic workflow reads them without I/O.

All additive/optional. `agent_streaming_enabled` deliberately stays flat (already persisted in production documents); future agent settings should go under `configuration.agent`.

## Test Plan
- [x] `pnpm build` (common)
- [x] Exercised by the workflow-side resolver tests in the companion change (precedence, fraction-replaces-cap, both-knobs min, 95% clamping)
