### PR TITLE
fix(ui): context meter uses prompt tokens, matching the checkpoint trigger

### DIFF
--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.test.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.test.tsx
@@ -916,11 +916,13 @@ describe('ModernAgentConversation send handling', () => {
             onCompactContext?: () => void | Promise<void>;
         };
 
+        // Prompt-based, matching the server's checkpoint trigger: `total`
+        // includes reasoning/result tokens that never re-enter context.
         expect(latestMessageInputProps.contextWindowUsage).toEqual({
-            usedTokens: 50_000,
+            usedTokens: 40_000,
             checkpointTokens: 100_000,
-            usedPercent: 50,
-            remainingPercent: 50,
+            usedPercent: 40,
+            remainingPercent: 60,
         });
 
         act(() => {

--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
@@ -137,8 +137,13 @@ function toContextWindowUsage(messages: AgentMessage[]): ContextWindowUsage | un
         const details = messages[index].details;
         if (!details) continue;
 
-        const tokenUsage = details.token_usage as { total?: unknown } | undefined;
-        const usedTokens = getNumberDetail(tokenUsage?.total);
+        const tokenUsage = details.token_usage as { prompt?: unknown; total?: unknown } | undefined;
+        // Mirror the server's checkpoint trigger (getContextPressureTokens):
+        // the last call's prompt size is the actual context; `total` includes
+        // reasoning output that never re-enters context and would overstate
+        // pressure on reasoning models. Fall back to total when no breakdown.
+        const promptTokens = getNumberDetail(tokenUsage?.prompt);
+        const usedTokens = promptTokens && promptTokens > 0 ? promptTokens : getNumberDetail(tokenUsage?.total);
         const checkpointTokens =
             getNumberDetail(details.checkpoint_threshold) ?? getNumberDetail(details.checkpoint_at);
 


### PR DESCRIPTION
## Summary
- The conversation context meter ("N% of context remaining until auto-compact") computed usage as `token_usage.total / checkpoint_threshold`, while the agent runtime triggers compaction on the **last call's prompt size** (`total` includes reasoning/result tokens that never re-enter the model context). On reasoning models the meter overstated pressure — it could show ~0% remaining long before any compaction was due.
- `toContextWindowUsage` now prefers `token_usage.prompt` when reported and positive, falling back to `total` for providers without a prompt breakdown — mirroring the runtime's context-pressure rule.

## Test Plan
- [x] `pnpm test` in `packages/ui` — 697 tests (updated the persisted-messages context-usage test to the prompt-based expectation; total-only fixtures cover the fallback)
- [x] `pnpm build` + `pnpm lint` in `packages/ui`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI calculation change with a clear fallback; no auth, data, or server behavior changes.
> 
> **Overview**
> The agent chat **context window meter** (remaining % until auto-compact) no longer divides `token_usage.total` by the checkpoint threshold. **`toContextWindowUsage`** now uses **`token_usage.prompt`** when the provider reports a positive prompt count, and only falls back to **`total`** when there is no breakdown—matching the runtime’s context-pressure / checkpoint rule.
> 
> On reasoning models, **`total`** includes output/reasoning tokens that do not re-enter context, so the old calculation could show **near-zero remaining context** well before compaction would actually trigger. The persisted-messages test was updated to expect prompt-based percentages (e.g. 40k/100k instead of 50k/100k when prompt and total differ).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d469f5300ba17650de6c1cb7d21324530b2910b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->