### PR TITLE
feat(ui): declare the appgen gateway endpoint on the Env type

### DIFF
--- a/packages/ui/src/env/index.ts
+++ b/packages/ui/src/env/index.ts
@@ -17,6 +17,8 @@ export interface EnvProps {
         sts: string; // Security Token Service endpoint
         git?: string; // Smart HTTP app source git endpoint
         mcp?: string;
+        /** Appgen app-gateway endpoint (serves live development previews and app bundles). */
+        gateway?: string;
     };
     firebase?: {
         apiKey: string;


### PR DESCRIPTION
## Summary
- Adds an optional `gateway` field to `Env.endpoints` (the appgen app-gateway base URL serving live development previews and app bundles) so UI features can construct gateway URLs where the host is known. Purely additive; consumers that don't set it are unaffected.

## Test Plan
- [x] `packages/ui` build
- [x] Exercised by the consuming app's env-derivation and URL-helper tests in the companion change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only, optional field on shared env config with no runtime behavior in this package.
> 
> **Overview**
> Extends **`EnvProps.endpoints`** in `@vertesia/ui` with an optional **`gateway`** string and JSDoc describing it as the appgen app-gateway base URL (live dev previews and app bundles).
> 
> This is **additive only**: hosts that do not populate `gateway` behave as before; consumers can start building gateway URLs when the host supplies the value (aligned with the companion env-derivation / URL-helper work).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9626a41dd02ef500bf983eedfdeaf63b409f2484. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->