### PR TITLE
fix(cli): keep long-running agent streams alive past the auth token TTL

### DIFF
--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -1,6 +1,6 @@
 import { VertesiaClient } from '@vertesia/client';
 import type { Command } from 'commander';
-import { ensureProfileAccessToken } from './profiles/auth.js';
+import { createProfileAuthProvider, ensureProfileAccessToken } from './profiles/auth.js';
 import { config, type Profile } from './profiles/index.js';
 import { isKeyringAvailable } from './profiles/keyring.js';
 
@@ -65,8 +65,8 @@ async function createClient(profile: Profile | undefined): Promise<VertesiaClien
     }
 
     if (!env.apikey && profile) {
-        env.apikey = await ensureProfileAccessToken(profile);
-        if (!env.apikey && !profile.apikey) {
+        const profileToken = await ensureProfileAccessToken(profile);
+        if (!profileToken && !profile.apikey) {
             if (!isKeyringAvailable()) {
                 throw new Error(
                     'No keyring-backed auth token is available for the selected profile on this system. Use VERTESIA_APIKEY or VERTESIA_TOKEN instead.',
@@ -76,6 +76,14 @@ async function createClient(profile: Profile | undefined): Promise<VertesiaClien
                 'No auth token is stored for the selected profile. Run `vertesia auth refresh` to authenticate again.',
             );
         }
+        // A profile configured with a long-lived API key uses it directly.
+        if (!profileToken && profile.apikey) {
+            return new VertesiaClient({ ...env, apikey: profile.apikey });
+        }
+        // A profile access token is short-lived. Resolve it per request through the profile
+        // refresh path instead of pinning the token captured here, so commands that run longer
+        // than the token TTL (`agents stream`, workflow tails) keep working.
+        return new VertesiaClient({ ...env, apikey: undefined }).withAuthCallback(createProfileAuthProvider(profile));
     }
 
     return new VertesiaClient(env);

--- a/packages/cli/src/profiles/auth.ts
+++ b/packages/cli/src/profiles/auth.ts
@@ -18,6 +18,52 @@ export async function ensureProfileAccessToken(
     return result?.token;
 }
 
+/**
+ * Build an authorization callback that resolves the profile access token at call time.
+ *
+ * Long-running commands (streaming an agent run for hours, tailing a workflow) outlive the access
+ * token TTL. Pinning the token captured when the command started makes every later request — and
+ * every stream reconnect — fail with 401/403. This callback goes back through the same profile
+ * refresh path as `vertesia auth token` on each call, and collapses concurrent callers onto a
+ * single refresh.
+ */
+export function createProfileAuthProvider(profile: Profile): () => Promise<string> {
+    let pending: Promise<string | undefined> | undefined;
+
+    return async () => {
+        if (!pending) {
+            pending = resolveProfileToken(profile).finally(() => {
+                pending = undefined;
+            });
+        }
+        const token = await pending;
+        if (!token) {
+            throw new Error(
+                `No auth token is available for profile "${profile.name}". Run \`vertesia auth refresh\` to authenticate again.`,
+            );
+        }
+        return `Bearer ${token}`;
+    };
+}
+
+async function resolveProfileToken(profile: Profile): Promise<string | undefined> {
+    try {
+        const token = await ensureProfileAccessToken(profile);
+        if (token) {
+            return token;
+        }
+    } catch (error) {
+        // A refresh failure is often transient (network, STS hiccup). Report it and fall back to
+        // the stored token so a long-running command can recover on the next request.
+        console.warn(
+            `Failed to refresh the access token for profile "${profile.name}": ${
+                error instanceof Error ? error.message : String(error)
+            }`,
+        );
+    }
+    return readProfileAccessToken(profile);
+}
+
 export async function refreshProfileAccessToken(
     profile: Profile,
     onResult?: OnResultCallback,

--- a/packages/client/src/store/AgentsApi.stream.test.ts
+++ b/packages/client/src/store/AgentsApi.stream.test.ts
@@ -1,0 +1,298 @@
+import { type AgentMessage, AgentMessageType, type CompactMessage } from '@vertesia/common';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { VertesiaClient } from '../client.js';
+
+const AGENT_RUN_ID = 'run-1';
+const STORE_URL = 'https://store.example.test';
+
+class FakeEventSource {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSED = 2;
+
+    static instances: FakeEventSource[] = [];
+    static urls: string[] = [];
+
+    readonly url: string;
+    readonly withCredentials = false;
+    readyState = FakeEventSource.CONNECTING;
+    onopen: ((event: Event) => void) | null = null;
+    onmessage: ((event: MessageEvent) => void) | null = null;
+    onerror: ((event: Event) => void) | null = null;
+
+    constructor(url: string) {
+        this.url = url;
+        FakeEventSource.urls.push(url);
+        FakeEventSource.instances.push(this);
+    }
+
+    close() {
+        this.readyState = FakeEventSource.CLOSED;
+    }
+
+    addEventListener() {}
+    removeEventListener() {}
+    dispatchEvent() {
+        return true;
+    }
+
+    fail() {
+        this.onerror?.(new Event('error'));
+    }
+
+    emit(message: CompactMessage) {
+        this.onmessage?.({ data: JSON.stringify(message) } as MessageEvent);
+    }
+}
+
+interface Harness {
+    client: VertesiaClient;
+    /** `since` query value of every GET /updates call after the initial history fetch. */
+    pollSince: number[];
+    setHistory: (messages: CompactMessage[]) => void;
+    setPollResponse: (handler: (since: number) => CompactMessage[]) => void;
+    setRunStatus: (status: string) => void;
+    issuedTokens: string[];
+}
+
+function createHarness(): Harness {
+    let history: CompactMessage[] = [];
+    let pollResponse: (since: number) => CompactMessage[] = () => [];
+    let runStatus = 'running';
+    let historyServed = false;
+    const pollSince: number[] = [];
+    const issuedTokens: string[] = [];
+
+    const fetchMock = vi.fn(async (input: Request | string) => {
+        const url = new URL(typeof input === 'string' ? input : input.url);
+        if (url.pathname.endsWith('/updates')) {
+            if (!historyServed) {
+                historyServed = true;
+                return Response.json({ messages: history });
+            }
+            const since = Number(url.searchParams.get('since') ?? 0);
+            pollSince.push(since);
+            return Response.json({ messages: pollResponse(since) });
+        }
+        if (url.pathname.endsWith(`/${AGENT_RUN_ID}`)) {
+            return Response.json({ id: AGENT_RUN_ID, status: runStatus });
+        }
+        return Response.json({ error: 'not found' }, { status: 404 });
+    });
+
+    const client = new VertesiaClient({
+        serverUrl: 'https://studio.example.test',
+        storeUrl: STORE_URL,
+        fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    // Mimics a refreshing credential provider: every call hands out a newer token.
+    client.withAuthCallback(async () => {
+        const token = `token-${issuedTokens.length + 1}`;
+        issuedTokens.push(token);
+        return `Bearer ${token}`;
+    });
+
+    return {
+        client,
+        pollSince,
+        issuedTokens,
+        setHistory: (messages) => {
+            history = messages;
+        },
+        setPollResponse: (handler) => {
+            pollResponse = handler;
+        },
+        setRunStatus: (status) => {
+            runStatus = status;
+        },
+    };
+}
+
+/** Advance fake timers and drain the microtask queue so awaited fetches settle. */
+async function settle(ms = 0) {
+    await vi.advanceTimersByTimeAsync(ms);
+    for (let i = 0; i < 20; i++) {
+        await Promise.resolve();
+    }
+}
+
+/** Longer than the capped backoff delay (30s + jitter). */
+const BACKOFF_CEILING_MS = 40000;
+
+async function failCurrentConnection() {
+    FakeEventSource.instances[FakeEventSource.instances.length - 1].fail();
+    await settle(BACKOFF_CEILING_MS);
+}
+
+describe('AgentsApi.streamMessages reconnection', () => {
+    let logs: string[];
+    let warnings: string[];
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        FakeEventSource.instances = [];
+        FakeEventSource.urls = [];
+        logs = [];
+        warnings = [];
+        vi.stubGlobal('EventSource', FakeEventSource);
+        vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+            logs.push(args.map(String).join(' '));
+        });
+        vi.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+            warnings.push(args.map(String).join(' '));
+        });
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    it('resolves a fresh auth token for every reconnection attempt', async () => {
+        const harness = createHarness();
+        const abort = new AbortController();
+        void harness.client.agents.streamMessages(AGENT_RUN_ID, undefined, undefined, abort.signal);
+        await settle();
+
+        expect(FakeEventSource.instances).toHaveLength(1);
+        await failCurrentConnection();
+        await failCurrentConnection();
+        expect(FakeEventSource.instances).toHaveLength(3);
+
+        const tokens = FakeEventSource.urls.map((url) => new URL(url).searchParams.get('access_token'));
+        expect(tokens).toHaveLength(3);
+        expect(new Set(tokens).size).toBe(3);
+        expect(tokens.every((token) => token?.startsWith('token-'))).toBe(true);
+
+        abort.abort();
+        await settle();
+    });
+
+    it('never announces an attempt number above the stated maximum', async () => {
+        const harness = createHarness();
+        const abort = new AbortController();
+        void harness.client.agents.streamMessages(AGENT_RUN_ID, undefined, undefined, abort.signal);
+        await settle();
+
+        // 10 reconnects are allowed; the 11th failure must degrade instead of announcing 11/10.
+        for (let i = 0; i < 11; i++) {
+            await failCurrentConnection();
+        }
+
+        const announced = logs
+            .map((line) => /\(attempt (\d+)\/(\d+)\)/.exec(line))
+            .filter((match): match is RegExpExecArray => match !== null)
+            .map((match) => ({ attempt: Number(match[1]), max: Number(match[2]) }));
+
+        expect(announced).toHaveLength(10);
+        expect(announced.map((entry) => entry.attempt)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        expect(announced.every((entry) => entry.attempt <= entry.max)).toBe(true);
+        expect(FakeEventSource.instances).toHaveLength(11);
+        expect(warnings.some((line) => line.includes('SSE unavailable after 10 attempts'))).toBe(true);
+
+        abort.abort();
+        await settle();
+    });
+
+    it('polls GET /updates from the last received timestamp and emits the messages', async () => {
+        const harness = createHarness();
+        harness.setHistory([{ t: AgentMessageType.UPDATE, m: 'history', ts: 1000 }]);
+        harness.setPollResponse((since) =>
+            since < 2000 ? [{ t: AgentMessageType.UPDATE, m: 'polled', ts: 2000 }] : [],
+        );
+
+        const received: AgentMessage[] = [];
+        const abort = new AbortController();
+        void harness.client.agents.streamMessages(
+            AGENT_RUN_ID,
+            (message) => received.push(message),
+            undefined,
+            abort.signal,
+        );
+        await settle();
+
+        for (let i = 0; i < 11; i++) {
+            await failCurrentConnection();
+        }
+        await settle(6000);
+
+        // The first poll resumes at the history cursor, later polls at the last polled message.
+        expect(harness.pollSince[0]).toBe(1000);
+        expect(harness.pollSince[1]).toBe(2000);
+        expect(received.map((message) => message.message)).toEqual(['history', 'polled']);
+        // Polled messages reach the caller as fully-formed AgentMessages, like the SSE path.
+        expect(received[1]).toMatchObject({
+            type: AgentMessageType.UPDATE,
+            workflow_run_id: AGENT_RUN_ID,
+            workstream_id: 'main',
+            timestamp: 2000,
+        });
+
+        abort.abort();
+        await settle();
+    });
+
+    it('warns on every polling failure instead of failing silently', async () => {
+        const harness = createHarness();
+        harness.setHistory([{ t: AgentMessageType.UPDATE, m: 'history', ts: 1000 }]);
+        harness.setPollResponse(() => {
+            throw new Error('boom');
+        });
+
+        const abort = new AbortController();
+        void harness.client.agents.streamMessages(AGENT_RUN_ID, undefined, undefined, abort.signal);
+        await settle();
+
+        for (let i = 0; i < 11; i++) {
+            await failCurrentConnection();
+        }
+        await settle(6000);
+
+        const pollWarnings = warnings.filter((line) => line.includes('GET /updates failed while polling'));
+        expect(pollWarnings.length).toBeGreaterThanOrEqual(2);
+        expect(pollWarnings[0]).toContain('consecutive failures: 1');
+        expect(pollWarnings[1]).toContain('consecutive failures: 2');
+
+        abort.abort();
+        await settle();
+    });
+
+    it('retries SSE after the polling fallback so an outage is not permanent', async () => {
+        const harness = createHarness();
+        const abort = new AbortController();
+        void harness.client.agents.streamMessages(AGENT_RUN_ID, undefined, undefined, abort.signal);
+        await settle();
+
+        for (let i = 0; i < 11; i++) {
+            await failCurrentConnection();
+        }
+        const connectionsBeforeRetry = FakeEventSource.instances.length;
+        expect(warnings.some((line) => line.includes('SSE retried every 60s'))).toBe(true);
+
+        await settle(61000);
+
+        expect(FakeEventSource.instances.length).toBe(connectionsBeforeRetry + 1);
+        expect(logs.some((line) => line.includes('retrying the SSE connection'))).toBe(true);
+
+        abort.abort();
+        await settle();
+    });
+
+    it('closes the stream when polling observes a terminal run status', async () => {
+        const harness = createHarness();
+        const abort = new AbortController();
+        const done = harness.client.agents.streamMessages(AGENT_RUN_ID, undefined, undefined, abort.signal);
+        await settle();
+
+        for (let i = 0; i < 11; i++) {
+            await failCurrentConnection();
+        }
+        harness.setRunStatus('completed');
+        await settle(6000);
+
+        await expect(done).resolves.toBeNull();
+    });
+});

--- a/packages/client/src/store/AgentsApi.ts
+++ b/packages/client/src/store/AgentsApi.ts
@@ -326,6 +326,10 @@ export class AgentsApi extends ApiTopic {
         let currentSse: EventSource | null = null;
         let interval: ReturnType<typeof setInterval> | null = null;
         let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+        let pollTimer: ReturnType<typeof setTimeout> | null = null;
+        let sseRetryTimer: ReturnType<typeof setTimeout> | null = null;
+        let isPolling = false;
+        let consecutivePollFailures = 0;
         let abortHandler: (() => void) | null = null;
 
         const maxReconnectAttempts = 10;
@@ -338,11 +342,24 @@ export class AgentsApi extends ApiTopic {
             return exponentialDelay + jitter;
         };
 
+        const stopPolling = () => {
+            isPolling = false;
+            if (pollTimer) {
+                clearTimeout(pollTimer);
+                pollTimer = null;
+            }
+            if (sseRetryTimer) {
+                clearTimeout(sseRetryTimer);
+                sseRetryTimer = null;
+            }
+        };
+
         const cleanup = () => {
             if (reconnectTimer) {
                 clearTimeout(reconnectTimer);
                 reconnectTimer = null;
             }
+            stopPolling();
             if (interval) {
                 clearInterval(interval);
                 interval = null;
@@ -372,52 +389,101 @@ export class AgentsApi extends ApiTopic {
         // for any messages we missed and exit cleanly once the run is terminal,
         // even if the terminal message never streamed.
         const POLL_INTERVAL_MS = 5000;
+        // Polling is a degraded mode: retry the real-time channel periodically so a transient
+        // outage (proxy restart, expired credentials that the auth callback later refreshes)
+        // does not permanently downgrade the stream.
+        const SSE_RETRY_INTERVAL_MS = 60000;
         const isTerminalStatus = (status: unknown): boolean =>
             typeof status === 'string' && ['completed', 'failed', 'cancelled'].includes(status);
-        const degradeToPolling = (reason: unknown) => {
-            if (isClosed) return;
-            cleanup();
+
+        // Never swallow a poll failure: while polling, it is the only channel left, so a silent
+        // catch turns a recoverable error (expired token, network blip) into an endless silence.
+        const warnPollFailure = (what: string, error: unknown) => {
+            consecutivePollFailures++;
             console.warn(
-                `Agent stream ${id}: SSE unavailable after ${maxReconnectAttempts} attempts; falling back to /updates polling.`,
-                reason instanceof Error ? reason.message : reason,
+                `Agent stream ${id}: ${what} failed while polling (consecutive failures: ${consecutivePollFailures}); retrying in ${Math.round(POLL_INTERVAL_MS / 1000)}s:`,
+                error instanceof Error ? error.message : error,
             );
-            const tick = async () => {
-                if (isClosed) return;
-                try {
-                    const recent = await this.retrieveMessages(id, lastMessageTimestamp || undefined);
-                    for (const msg of recent) {
-                        if (isClosed) return;
-                        if ((msg.timestamp || 0) <= lastMessageTimestamp) continue;
-                        lastMessageTimestamp = msg.timestamp || lastMessageTimestamp;
-                        if (onMessage) onMessage(msg, exit);
-                        if (isClosed) return;
-                        if (shouldCloseAgentRunStream(msg, id)) {
-                            exit(null);
-                            return;
-                        }
-                    }
-                } catch {
-                    // transient poll error — retry next tick
-                }
-                if (isClosed) return;
-                // Exit even when no terminal message ever streams, by reading the run record.
-                try {
-                    const run = (await this.get(`/${id}`)) as { status?: unknown };
-                    if (isTerminalStatus(run?.status)) {
+        };
+
+        const pollTick = async () => {
+            if (isClosed || !isPolling) return;
+            let polledMessages = false;
+            try {
+                // Resume from the last message we handed to the caller, whether it came from
+                // history, SSE, or an earlier poll. The server returns messages with ts > since.
+                const recent = await this.retrieveMessages(id, lastMessageTimestamp || undefined);
+                polledMessages = true;
+                for (const msg of recent) {
+                    if (isClosed) return;
+                    const timestamp = msg.timestamp || 0;
+                    if (timestamp <= lastMessageTimestamp) continue;
+                    lastMessageTimestamp = timestamp;
+                    if (onMessage) onMessage(msg, exit);
+                    if (isClosed) return;
+                    if (shouldCloseAgentRunStream(msg, id)) {
                         exit(null);
                         return;
                     }
-                } catch {
-                    // ignore — retry next tick
                 }
-                if (!isClosed) {
-                    reconnectTimer = setTimeout(() => {
-                        reconnectTimer = null;
-                        void tick();
-                    }, POLL_INTERVAL_MS);
+            } catch (err) {
+                warnPollFailure('GET /updates', err);
+            }
+            if (isClosed || !isPolling) return;
+            // Exit even when no terminal message ever streams, by reading the run record.
+            try {
+                const run = (await this.get(`/${id}`)) as { status?: unknown };
+                if (isTerminalStatus(run?.status)) {
+                    exit(null);
+                    return;
                 }
-            };
-            void tick();
+                if (polledMessages) consecutivePollFailures = 0;
+            } catch (err) {
+                warnPollFailure('run status check', err);
+            }
+            if (isClosed || !isPolling) return;
+            pollTimer = setTimeout(() => {
+                pollTimer = null;
+                void pollTick();
+            }, POLL_INTERVAL_MS);
+        };
+
+        const retrySseAfterPolling = () => {
+            sseRetryTimer = null;
+            if (isClosed || !isPolling) return;
+            stopPolling();
+            reconnectAttempts = 0;
+            console.log(`Agent stream ${id}: retrying the SSE connection after the polling fallback.`);
+            void setupStream('resume');
+        };
+
+        const degradeToPolling = (reason: unknown) => {
+            if (isClosed || isPolling) return;
+            cleanup();
+            isPolling = true;
+            consecutivePollFailures = 0;
+            console.warn(
+                `Agent stream ${id}: SSE unavailable after ${maxReconnectAttempts} attempts; falling back to GET /updates polling every ${Math.round(POLL_INTERVAL_MS / 1000)}s (SSE retried every ${Math.round(SSE_RETRY_INTERVAL_MS / 1000)}s).`,
+                reason instanceof Error ? reason.message : reason,
+            );
+            sseRetryTimer = setTimeout(retrySseAfterPolling, SSE_RETRY_INTERVAL_MS);
+            void pollTick();
+        };
+
+        // Schedules attempt N of `maxReconnectAttempts`. `reconnectAttempts` holds the number of
+        // the attempt about to run, so the announced counter never exceeds the announced maximum.
+        const scheduleReconnect = (reason: unknown) => {
+            if (isClosed) return;
+            if (reconnectAttempts >= maxReconnectAttempts) {
+                degradeToPolling(reason);
+                return;
+            }
+            const delay = calculateBackoffDelay(reconnectAttempts);
+            reconnectAttempts++;
+            reconnectTimer = setTimeout(() => {
+                reconnectTimer = null;
+                if (!isClosed) void setupStream('reconnect');
+            }, delay);
         };
 
         if (signal) {
@@ -468,7 +534,7 @@ export class AgentsApi extends ApiTopic {
         }
 
         // 2. Connect to SSE for real-time updates
-        const setupStream = async (isReconnect: boolean = false) => {
+        const setupStream = async (mode: 'initial' | 'reconnect' | 'resume' = 'initial') => {
             if (isClosed) return;
             try {
                 const EventSourceImpl = await EventSourceProvider();
@@ -481,6 +547,10 @@ export class AgentsApi extends ApiTopic {
                 }
                 streamUrl.searchParams.set('skipHistory', 'true');
 
+                // Resolve the credential on every attempt (never reuse the one captured when the
+                // stream started): a stream can stay open far longer than the access token TTL,
+                // so a pinned token makes every reconnect fail with 401/403 until the retry
+                // budget is exhausted. The auth callback owns refreshing.
                 const bearerToken = client._auth ? await client._auth() : undefined;
                 if (isClosed) return;
                 if (!bearerToken) {
@@ -493,9 +563,9 @@ export class AgentsApi extends ApiTopic {
                 const token = bearerToken.split(' ')[1];
                 streamUrl.searchParams.set('access_token', token);
 
-                if (isReconnect) {
+                if (mode === 'reconnect') {
                     console.log(
-                        `Reconnecting to agent stream ${id} (attempt ${reconnectAttempts + 1}/${maxReconnectAttempts})`,
+                        `Reconnecting to agent stream ${id} (attempt ${reconnectAttempts}/${maxReconnectAttempts})`,
                     );
                 }
 
@@ -507,7 +577,7 @@ export class AgentsApi extends ApiTopic {
                 let connectionOpenedAt = 0;
 
                 sse.onopen = () => {
-                    if (isReconnect) console.log(`Reconnected to agent stream ${id}`);
+                    if (mode !== 'initial') console.log(`Reconnected to agent stream ${id}`);
                     connectionOpenedAt = Date.now();
                 };
 
@@ -549,35 +619,17 @@ export class AgentsApi extends ApiTopic {
                         reconnectAttempts = 0;
                     }
 
-                    if (reconnectAttempts < maxReconnectAttempts) {
-                        const delay = calculateBackoffDelay(reconnectAttempts);
-                        reconnectAttempts++;
-                        reconnectTimer = setTimeout(() => {
-                            reconnectTimer = null;
-                            if (!isClosed) void setupStream(true);
-                        }, delay);
-                    } else {
-                        degradeToPolling(
-                            new Error(`SSE connection failed after ${maxReconnectAttempts} reconnection attempts`),
-                        );
-                    }
+                    scheduleReconnect(
+                        new Error(`SSE connection failed after ${maxReconnectAttempts} reconnection attempts`),
+                    );
                 };
             } catch (err) {
                 if (isClosed) return;
-                if (reconnectAttempts < maxReconnectAttempts) {
-                    const delay = calculateBackoffDelay(reconnectAttempts);
-                    reconnectAttempts++;
-                    reconnectTimer = setTimeout(() => {
-                        reconnectTimer = null;
-                        if (!isClosed) void setupStream(true);
-                    }, delay);
-                } else {
-                    degradeToPolling(err);
-                }
+                scheduleReconnect(err);
             }
         };
 
-        void setupStream(false);
+        void setupStream('initial');
         return promise;
     }
 


### PR DESCRIPTION
## Summary
`vertesia agents stream` went permanently silent on multi-hour agent runs: after ~1h the SSE connection died, every reconnect failed, the client announced a fallback to `/updates` polling — and then emitted nothing for hours while the run kept posting messages. Four defects, one root cause chain:

- **Pinned auth token (root cause).** Profile-authenticated clients captured the OAuth access token once at process start; `withApiKey` only installs a refresh callback for `pk-`/`sk-` API keys, so the expired JWT was replayed on every reconnect and poll (401/403 forever). Profile clients now install a per-request auth callback through the existing profile refresh path — cached until near expiry, single-flight across concurrent requests, falling back to the stored token on a transient refresh failure. Profiles configured with a long-lived API key now use it directly (previously that path fell through to an unauthenticated client).
- **Silent polling.** The `/updates` fallback wrapped both the poll and the run-status read in bare `catch {}` — a permanently failing poll produced endless silence. Failures now warn per occurrence with a consecutive-failure count.
- **`attempt 11/10`.** The reconnect counter was incremented in two places; the scheduler now owns the budget and the announced counter never exceeds the max.
- **Polling was terminal.** The stream now re-attempts SSE every 60s from the fallback and resets the retry budget on success, so a transient outage no longer degrades the rest of the run.

## Test Plan
- [x] `packages/client`: build, `pnpm test` — 89 tests incl. 6 new stream tests (fresh token per attempt, counter bounds, poll resume cursor + failure warnings, SSE retry after fallback, terminal exit); `pnpm typecheck:test`; biome lint
- [x] `packages/cli`: build + biome lint
- [x] Mutation check: reverting only the stream rework fails 3 of the 6 new tests with the exact field symptoms (`[2..11]` counter, zero poll warnings, no SSE retry)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CLI authentication wiring and agent SSE/polling fallback behavior used by long-running commands; changes are localized and covered by new stream tests, but auth misconfiguration could still break streaming.
> 
> **Overview**
> Fixes **multi-hour `vertesia agents stream` (and similar) sessions** going silent after OAuth access tokens expire.
> 
> **CLI:** Profile OAuth clients no longer pin the token from startup. They use `withAuthCallback(createProfileAuthProvider(...))` so each request (and SSE reconnect) goes through the profile refresh path with single-flight deduplication and a stored-token fallback on transient refresh errors. Profiles that only have a **long-lived API key** now construct the client with that key directly instead of falling through unauthenticated.
> 
> **Client `streamMessages`:** Resolves credentials on **every** SSE connect/reconnect (not once at stream start). Reconnect scheduling is centralized so logged attempts stay within **10/10** (no `11/10`). After SSE exhaustion, **GET /updates** polling warns on each failure (with consecutive failure count), resumes from the last delivered timestamp, exits when the run is terminal, and **retries SSE every 60s** so fallback is not permanent.
> 
> Adds **six** Vitest cases covering fresh tokens per reconnect, reconnect counter bounds, poll cursor/emission, poll failure warnings, SSE retry from fallback, and terminal exit via polling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fedf5e7391990c36ea7965c9dae3aba9393d1450. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->