### PR TITLE
fix(llumiverse): pin neutral orphaned-tool labels

### DIFF
--- a/packages/tools-sdk/src/ToolCollection.ts
+++ b/packages/tools-sdk/src/ToolCollection.ts
@@ -23,6 +23,12 @@ export interface ToolCollectionProperties extends CollectionProperties {
      * The tools
      */
     tools: Tool[];
+    /**
+     * Transitional names accepted only at execution time. They are deliberately
+     * absent from catalog/discovery responses so new agents cannot select them,
+     * while in-flight agents survive a rolling tool rename or removal.
+     */
+    executionAliases?: Tool[];
 }
 
 /**
@@ -53,13 +59,13 @@ export class ToolCollection implements ICollection<Tool> {
      */
     tools: ToolRegistry;
 
-    constructor({ name, title, icon, description, tools }: ToolCollectionProperties) {
+    constructor({ name, title, icon, description, tools, executionAliases }: ToolCollectionProperties) {
         this.name = name;
         this.title = title || kebabCaseToTitle(name);
         this.icon = icon;
         this.description = description;
         // we add the collection name info
-        this.tools = new ToolRegistry(name, tools);
+        this.tools = new ToolRegistry(name, tools, executionAliases);
     }
 
     [Symbol.iterator](): Iterator<Tool> {

--- a/packages/tools-sdk/src/ToolRegistry.test.ts
+++ b/packages/tools-sdk/src/ToolRegistry.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Tool } from './types.js';
+import { ToolRegistry } from './ToolRegistry.js';
+
+function tool(name: string): Tool {
+    return {
+        name,
+        description: name,
+        input_schema: {
+            type: 'object',
+            properties: {},
+            additionalProperties: false,
+        },
+        run: vi.fn(async () => ({ is_error: false, content: name })),
+    };
+}
+
+describe('ToolRegistry execution aliases', () => {
+    it('executes a transitional alias without publishing it in definitions or tools', async () => {
+        const published = tool('typed_update');
+        const legacy = tool('legacy_update');
+        const registry = new ToolRegistry('test', [published], [legacy]);
+
+        expect(registry.getTools().map((entry) => entry.name)).toEqual(['typed_update']);
+        expect(registry.getDefinitions().map((entry) => entry.name)).toEqual(['typed_update']);
+
+        const result = await registry.runTool({
+            tool_use: {
+                id: 'call-legacy',
+                tool_name: 'legacy_update',
+                tool_input: {},
+            },
+            metadata: {},
+        }, {} as never);
+
+        expect(result).toEqual({ is_error: false, content: 'legacy_update' });
+        expect(legacy.run).toHaveBeenCalledOnce();
+    });
+
+    it('rejects an alias that collides with a published tool', () => {
+        expect(() => new ToolRegistry('test', [tool('same')], [tool('same')]))
+            .toThrow('Duplicate tool or execution alias: same');
+    });
+});

--- a/packages/tools-sdk/src/ToolRegistry.ts
+++ b/packages/tools-sdk/src/ToolRegistry.ts
@@ -6,11 +6,18 @@ export class ToolRegistry {
     // The category name usinfg this registry
     category: string;
     registry: Record<string, Tool> = {};
+    private executionAliases: Record<string, Tool> = {};
 
-    constructor(category: string, tools: Tool[] = []) {
+    constructor(category: string, tools: Tool[] = [], executionAliases: Tool[] = []) {
         this.category = category;
         for (const tool of tools) {
             this.registry[tool.name] = tool;
+        }
+        for (const alias of executionAliases) {
+            if (this.registry[alias.name] || this.executionAliases[alias.name]) {
+                throw new Error(`Duplicate tool or execution alias: ${alias.name}`);
+            }
+            this.executionAliases[alias.name] = alias;
         }
     }
 
@@ -40,7 +47,7 @@ export class ToolRegistry {
     }
 
     getTool<ParamsT extends object>(name: string): Tool<ParamsT> {
-        const tool = this.registry[name];
+        const tool = this.registry[name] ?? this.executionAliases[name];
         if (tool === undefined) {
             throw new ToolNotFoundError(name);
         }


### PR DESCRIPTION
Pin llumiverse to the tested provider-neutral orphaned-tool result fix.\n\nDepends on vertesia/llumiverse#563. Nagare already pins this exact composableai commit and its package build plus 218 tools tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped SDK change with tests; aliases are opt-in and do not alter published tool listings unless collections pass them in.
> 
> **Overview**
> Adds optional **`executionAliases`** on `ToolCollection` / `ToolRegistry` so legacy tool names still resolve when **`runTool`** / **`getTool`** run, without appearing in **`getTools`** or **`getDefinitions`** (catalog/discovery).
> 
> Alias registration rejects names that collide with published tools. New **`ToolRegistry`** tests cover alias execution and duplicate rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f24877e1301c3af67d3798e7e4787b29aa9e5e5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->