### PR TITLE
fix(openapi): preserve generated prompt client APIs

### DIFF
--- a/packages/client/src/PromptsApi.ts
+++ b/packages/client/src/PromptsApi.ts
@@ -10,6 +10,7 @@ import type {
     PromptTemplateInteractionsResponse,
     PromptTemplateRef,
     PromptTemplateUpdatePayload,
+    RenderPromptPayload,
     RenderPromptResponse,
 } from '@vertesia/common';
 
@@ -123,7 +124,7 @@ export default class PromptsApi extends ApiTopic {
      * @throws 404 if not found
      * @throws 403 if the prompt is not in the current project
      */
-    render(id: string, payload: object): Promise<RenderPromptResponse> {
+    render(id: string, payload: RenderPromptPayload): Promise<RenderPromptResponse> {
         return this.post(`/${id}/render`, {
             payload,
         });

--- a/packages/common/src/api-schemas/app-runtime.ts
+++ b/packages/common/src/api-schemas/app-runtime.ts
@@ -37,8 +37,6 @@ const JSONSchemaRefSchema: z.ZodType<JSONSchema> = z.any().meta({
     $ref: '#/components/schemas/JSONSchema',
 });
 
-export const RenderPromptPayloadSchema = z.looseObject({}).meta({ id: 'RenderPromptPayload' });
-
 export const ProjectPluginArraySchema = z.array(z.string()).meta({ id: 'ProjectPluginArray' });
 
 export const BinaryFileResponseSchema = z.string().meta({ id: 'BinaryFileResponse', format: 'binary' });

--- a/packages/common/src/api-schemas/interaction.ts
+++ b/packages/common/src/api-schemas/interaction.ts
@@ -421,21 +421,29 @@ export const PromptTemplateSchema = z
     })
     .meta({ id: 'PromptTemplate' });
 
-// The two payloads are `PromptTemplate` minus what the server owns, so they are derived from it here
-// the same way the TypeScript interfaces derived from it with `Omit`. They have to be derived HERE
-// rather than left as interfaces: `PromptTemplate` is now a canonical alias, and an `Omit` over an
-// alias has no properties left to keep — the generator sees the placeholder and publishes an empty
-// object.
+// The two payloads are projections of `PromptTemplate`, so they are derived from its canonical Zod
+// schema here. Leaving them as TypeScript utility types would give the generator only aliases with
+// no runtime properties to publish.
 const SERVER_OWNED_PROMPT_FIELDS = ['id', 'created_at', 'updated_at', 'created_by', 'updated_by', 'project'] as const;
 const SERVER_OWNED_PROMPT_FIELD_KEYS = Object.fromEntries(
     SERVER_OWNED_PROMPT_FIELDS.map((field) => [field, true as const]),
 ) as Record<(typeof SERVER_OWNED_PROMPT_FIELDS)[number], true>;
 
-export const PromptTemplateCreatePayloadSchema = PromptTemplateSchema.omit({
-    ...SERVER_OWNED_PROMPT_FIELD_KEYS,
-    // A create call does not choose these two either: a new prompt is always a draft at version 0.
-    status: true,
-    version: true,
+// Keep the published property order stable. OpenAPI Generator uses it for required Go constructor
+// arguments. Zod's `.pick()` builds the projected shape in mask order, whereas `.omit()` preserves
+// the full response model's order and would change this constructor when that model is reorganized.
+export const PromptTemplateCreatePayloadSchema = PromptTemplateSchema.pick({
+    name: true,
+    parent: true,
+    description: true,
+    test_data: true,
+    script: true,
+    tags: true,
+    last_published_at: true,
+    role: true,
+    content: true,
+    content_type: true,
+    inputSchema: true,
 }).meta({ id: 'PromptTemplateCreatePayload' });
 
 export const PromptTemplateUpdatePayloadSchema = PromptTemplateSchema.omit(SERVER_OWNED_PROMPT_FIELD_KEYS)

--- a/packages/common/src/api-schemas/prompt.ts
+++ b/packages/common/src/api-schemas/prompt.ts
@@ -9,6 +9,13 @@ import { FacetSpecSchema, PromptTemplateRefSchema } from './interaction.js';
 // is picked up by the OpenAPI scanner and published as that component's `description`, which would
 // double up with the `description` stated in `.meta()`.
 
+export const RenderPromptPayloadSchema = z
+    .record(z.string(), z.unknown())
+    // Preserve the explicit free-form spelling OpenAPI Generator needs to emit a request-body
+    // setter. An empty additionalProperties schema is validator-equivalent but generates a
+    // different Go API, and the adapter intentionally normalizes component roots conservatively.
+    .meta({ id: 'RenderPromptPayload', additionalProperties: true });
+
 export const RenderPromptResponseSchema = z
     .strictObject({
         id: z.string(),

--- a/packages/common/src/api-schemas/registry.ts
+++ b/packages/common/src/api-schemas/registry.ts
@@ -643,6 +643,7 @@ import {
     PromptTemplateInteractionUsageSchema,
     PromptTemplateInteractionVersionSchema,
     PromptTemplateRefArraySchema,
+    RenderPromptPayloadSchema,
     RenderPromptResponseSchema,
 } from './prompt.js';
 import { QuotaStandingResponseSchema, QuotaTierResponseSchema } from './quota.js';
@@ -1769,6 +1770,7 @@ const PROMPT_AUTHORING_SCHEMAS = {
     // The prompt-authoring endpoints: fork, render, search and the interaction usages a prompt
     // reports. `PromptTemplate` itself and its write payloads live with the interactions, which is
     // where the prompt tree they reference is defined.
+    RenderPromptPayload: RenderPromptPayloadSchema,
     RenderPromptResponse: RenderPromptResponseSchema,
     PromptTemplateInteractionVersion: PromptTemplateInteractionVersionSchema,
     PromptTemplateForkPayload: PromptTemplateForkPayloadSchema,
@@ -2046,7 +2048,6 @@ const APP_MANIFEST_SCHEMAS = {
     AppWidgetInfoMap: AppRuntimeSchemas.AppWidgetInfoMapSchema,
     PromoteAppVersionResponse: AppRuntimeSchemas.PromoteAppVersionResponseSchema,
     AppPackage: AppRuntimeSchemas.AppPackageSchema,
-    RenderPromptPayload: AppRuntimeSchemas.RenderPromptPayloadSchema,
     ProjectPluginArray: AppRuntimeSchemas.ProjectPluginArraySchema,
 } as const satisfies Record<string, z.ZodType>;
 

--- a/packages/common/src/prompt.ts
+++ b/packages/common/src/prompt.ts
@@ -11,6 +11,7 @@ import type {
     PromptTemplateInteractionsResponseSchema,
     PromptTemplateInteractionUsageSchema,
     PromptTemplateInteractionVersionSchema,
+    RenderPromptPayloadSchema,
     RenderPromptResponseSchema,
 } from './api-schemas/prompt.js';
 
@@ -81,6 +82,8 @@ export type PromptTemplateInteractionVersion = z.infer<typeof PromptTemplateInte
 export type PromptTemplateInteractionUsage = z.infer<typeof PromptTemplateInteractionUsageSchema>;
 
 export type PromptTemplateInteractionsResponse = z.infer<typeof PromptTemplateInteractionsResponseSchema>;
+
+export type RenderPromptPayload = z.infer<typeof RenderPromptPayloadSchema>;
 
 /**
  * What `POST /prompts/:id/render` answers with: the segment identity plus the rendered body.


### PR DESCRIPTION
## Summary
- preserve the published prompt-create property order through an explicit ordered Zod projection
- model prompt-render variables as a canonical free-form prompt schema and export its inferred type
- carry the named render payload type through the TypeScript client

## Test Plan
- [x] `pnpm --dir packages/common lint`
- [x] `pnpm --dir packages/common build`
- [x] `pnpm --dir packages/common typecheck:test`
- [x] `pnpm --dir packages/common test` (596 tests)
- [x] `pnpm --dir packages/client lint`
- [x] `pnpm --dir packages/client build`
- [x] `pnpm --dir packages/client typecheck:test`
- [x] `pnpm --dir packages/client test` (90 tests)