### PR TITLE
feat: MCP collection API key auth, and a single source for the API version

### DIFF
--- a/packages/client/src/AppsApi.ts
+++ b/packages/client/src/AppsApi.ts
@@ -1,5 +1,6 @@
 import { ApiTopic, type ClientBase, type ServerError } from '@vertesia/api-fetch-client';
 import type {
+    AppApiKeyCollectionParams,
     AppBuildProgress,
     AppDeleteSummary,
     AppDevelopmentTaskDetails,
@@ -26,9 +27,11 @@ import type {
     CountResult,
     CreateAppRepoBranchRequest,
     DeleteAppVersionResponse,
+    McpApiKeyStatus,
     ProjectRef,
     PromoteAppVersionResponse,
     RequireAtLeastOne,
+    SetMcpApiKeyRequest,
     StartAppBuildRequest,
     StartAppBuildResponse,
     StartAppScaffoldRequest,
@@ -62,6 +65,27 @@ export default class AppsApi extends ApiTopic {
      */
     previewDelete(id: string): Promise<AppDeleteSummary> {
         return this.del(`/${id}`);
+    }
+
+    /**
+     * Store the API key of an MCP tool collection declared with `auth: 'api_key'`.
+     * The key is write-only: it is encrypted server-side and never returned by any endpoint,
+     * so the response carries only the configured flag and a masked hint.
+     */
+    setMcpCollectionApiKey(appId: string, collectionId: string, apiKey: string): Promise<McpApiKeyStatus> {
+        return this.put(`/${encodeURIComponent(appId)}/collections/${encodeURIComponent(collectionId)}/api-key`, {
+            payload: { api_key: apiKey } satisfies SetMcpApiKeyRequest,
+        });
+    }
+
+    /** Whether an MCP tool collection has an API key stored, with a masked hint for display. */
+    getMcpCollectionApiKeyStatus(appId: string, collectionId: string): Promise<McpApiKeyStatus> {
+        return this.get(`/${encodeURIComponent(appId)}/collections/${encodeURIComponent(collectionId)}/api-key`);
+    }
+
+    /** Remove the stored API key of an MCP tool collection. */
+    deleteMcpCollectionApiKey(appId: string, collectionId: string): Promise<McpApiKeyStatus> {
+        return this.del(`/${encodeURIComponent(appId)}/collections/${encodeURIComponent(collectionId)}/api-key`);
     }
 
     /**
@@ -288,6 +312,7 @@ export default class AppsApi extends ApiTopic {
         settings?: Record<string, unknown>,
         oauthParams?: Record<string, { client_id?: string; client_secret?: string; scopes?: string[] }>,
         oauthProviderParams?: Record<string, { client_id?: string; client_secret?: string; scopes?: string[] }>,
+        apiKeyParams?: AppApiKeyCollectionParams,
     ): Promise<AppInstallation> {
         return this.post(`/install`, {
             payload: {
@@ -295,6 +320,7 @@ export default class AppsApi extends ApiTopic {
                 settings,
                 oauth_params: oauthParams,
                 oauth_provider_params: oauthProviderParams,
+                api_key_params: apiKeyParams,
             } satisfies AppInstallationPayload,
         });
     }

--- a/packages/client/src/store/version.ts
+++ b/packages/client/src/store/version.ts
@@ -1,4 +1,7 @@
-export const VERSION = '20260319'; // YYYYMMDD, client versioning for API endpoints. Increment manually for breaking changes
-// Re-exported, not redeclared: the servers read the same constant when deciding how strictly to
-// hold a request to its schema, so a name only this side knew could not stay a negotiation.
-export { APP_VERSION_HEADER, VERSION_HEADER } from '@vertesia/common';
+// Preserve the public client export while sourcing its value from the same module as the servers
+// and OpenAPI generator.
+export {
+    APP_VERSION_HEADER,
+    CURRENT_API_VERSION_HEADER_VALUE as VERSION,
+    VERSION_HEADER,
+} from '@vertesia/common';

--- a/packages/common/src/api-schemas/app-delete-summary.contract.test.ts
+++ b/packages/common/src/api-schemas/app-delete-summary.contract.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import type { AppDeleteSummary } from '../apps.js';
+import { AppDeleteSummarySchema } from './app-lifecycle.js';
+import { validateApiResponse } from './registry.js';
+
+/** Exact type identity — `extends` in both directions is too weak (any/unknown slip through). */
+type Equals<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+function assertType<T extends true>(_ok: T): void {}
+
+/**
+ * `DeleteApp` published `CountResult` while returning this shape. Response validation therefore
+ * reported a missing `count` and every field below as unexpected — and where the check fails closed
+ * (local development) that surfaced as a 500 raised AFTER the app had already been deleted, which is
+ * the worst possible moment for it. These assertions pin the component to what the handler builds.
+ */
+const REAL_SUMMARY: AppDeleteSummary = {
+    confirmed: true,
+    app_id: '68b1779130afe5403a1589bc',
+    app_name: 'acme-app',
+    versions: 2,
+    installations: 1,
+    storage_prefix: 'apps/acme-app',
+    deleted: true,
+    warnings: [],
+};
+
+describe('AppDeleteSummary — as the DeleteApp response is validated', () => {
+    it('accepts what the handler returns after a confirmed delete', () => {
+        expect(validateApiResponse('AppDeleteSummary', REAL_SUMMARY).valid).toBe(true);
+    });
+
+    it('accepts the dry-run preview, which is the same shape with deleted: false', () => {
+        const preview = { ...REAL_SUMMARY, confirmed: false, deleted: false };
+        expect(validateApiResponse('AppDeleteSummary', preview).valid).toBe(true);
+    });
+
+    it('accepts a git-backed app, whose summary carries the repo URL', () => {
+        const withRepo = { ...REAL_SUMMARY, git_repo_url: 'https://git.example.com/acme/acme-app.git' };
+        expect(validateApiResponse('AppDeleteSummary', withRepo).valid).toBe(true);
+    });
+
+    it('accepts the warnings a partially-degraded cascade collects', () => {
+        const warned = {
+            ...REAL_SUMMARY,
+            warnings: ['git repo delete failed: 502', 'version cleanup failed: timeout'],
+        };
+        expect(validateApiResponse('AppDeleteSummary', warned).valid).toBe(true);
+    });
+
+    it('is NOT interchangeable with CountResult, the component this endpoint used to publish', () => {
+        // The regression in one line: neither validates as the other, so the mismatch was total.
+        expect(validateApiResponse('CountResult', REAL_SUMMARY).valid).toBe(false);
+        expect(validateApiResponse('AppDeleteSummary', { count: 1 }).valid).toBe(false);
+    });
+
+    it('rejects an undeclared field, so the component cannot silently drift from the handler', () => {
+        expect(validateApiResponse('AppDeleteSummary', { ...REAL_SUMMARY, secrets_purged: 3 }).valid).toBe(false);
+    });
+
+    it('keeps the public type derived from the schema rather than hand-written beside it', () => {
+        assertType<Equals<AppDeleteSummary, ReturnType<typeof AppDeleteSummarySchema.parse>>>(true);
+        // Every field the handler always sets is required; only git_repo_url is optional.
+        expect(AppDeleteSummarySchema.safeParse({ ...REAL_SUMMARY, warnings: undefined }).success).toBe(false);
+        const { git_repo_url: _omitted, ...withoutRepo } = { ...REAL_SUMMARY, git_repo_url: 'https://x' };
+        expect(AppDeleteSummarySchema.safeParse(withoutRepo).success).toBe(true);
+    });
+});

--- a/packages/common/src/api-schemas/app-lifecycle.ts
+++ b/packages/common/src/api-schemas/app-lifecycle.ts
@@ -324,6 +324,35 @@ export const DeleteAppVersionResponseSchema = z
     })
     .meta({ id: 'DeleteAppVersionResponse' });
 
+export const AppDeleteSummarySchema = z
+    .strictObject({
+        confirmed: z.boolean().meta({
+            description:
+                'Whether `?confirm=true` was sent. Without it the endpoint reports what WOULD be removed and ' +
+                'deletes nothing — `deleted` stays false.',
+        }),
+        app_id: z.string(),
+        app_name: z.string(),
+        versions: z.number().meta({ description: 'AppVersion records the cascade covers.' }),
+        installations: z.number().meta({ description: 'AppInstallation records the cascade covers.' }),
+        storage_prefix: z.string(),
+        git_repo_url: z.string().optional(),
+        deleted: z.boolean().meta({
+            description: 'Whether the app record itself was removed. False for a dry run.',
+        }),
+        warnings: z.array(z.string()).meta({
+            description:
+                'Cascade steps that failed without aborting the deletion. Credential cleanup is NOT among them — ' +
+                'a failed API key purge fails the request outright and keeps the app row.',
+        }),
+    })
+    .meta({
+        id: 'AppDeleteSummary',
+        description:
+            'Result of `DELETE /apps/:id`. Doubles as the dry-run preview: without `?confirm=true` the same ' +
+            'shape comes back with `deleted: false` describing what the cascade would remove.',
+    });
+
 export const AppRepoBranchSchema = z
     .strictObject({
         name: z.string(),
@@ -468,6 +497,28 @@ export const OAuthClientCredentialsMapSchema = z
     .meta({ id: 'OAuthClientCredentialsMap' });
 
 export const AppOAuthCollectionParamsSchema = OAuthClientCredentialsMapSchema.meta({ id: 'AppOAuthCollectionParams' });
+
+export const McpApiKeyCredentialSchema = z
+    .strictObject({
+        // Matches SetMcpApiKeyRequest, including the `\S` pattern — see the note there on why the
+        // trim alone does not survive into the AJV-enforced JSON Schema.
+        api_key: z
+            .string()
+            .trim()
+            .min(1)
+            .regex(/\S/, 'API key must not be blank')
+            .meta({
+                description:
+                    'The key the installer holds for this collection. Surrounding whitespace is stripped. Stored ' +
+                    'encrypted in the installing project and never returned.',
+            }),
+    })
+    .meta({ id: 'McpApiKeyCredential' });
+
+export const AppApiKeyCollectionParamsSchema = z
+    .object({})
+    .catchall(McpApiKeyCredentialSchema)
+    .meta({ id: 'AppApiKeyCollectionParams' });
 
 export const AppInspectionIssueSchema = z
     .strictObject({
@@ -774,6 +825,12 @@ export const AppInstallationPayloadSchema = z
         oauth_provider_params: AppOAuthProviderParamsSchema.meta({
             description:
                 'OAuth credentials for named providers, keyed by the provider key from oauth_providers. Collected from the user at install time for providers with required_at_install. Separate from oauth_params to avoid key collisions between provider keys and collection ids.',
+        }).optional(),
+        api_key_params: AppApiKeyCollectionParamsSchema.meta({
+            description:
+                "API keys for auth: 'api_key' collections, keyed by collection.id. Collected from the user at " +
+                'install time for collections with api_key_config.required_at_install. Each key is stored in the ' +
+                "installing project's encrypted secret store, replacing any key already held for that collection.",
         }).optional(),
     })
     .meta({ id: 'AppInstallationPayload' });

--- a/packages/common/src/api-schemas/apps.ts
+++ b/packages/common/src/api-schemas/apps.ts
@@ -112,9 +112,13 @@ export const AppUIConfigSchema = z
     })
     .meta({ id: 'AppUIConfig' });
 
-export const ToolCollectionAuthTypeSchema = z
-    .enum(['oauth', 'other'])
-    .meta({ id: 'ToolCollectionAuthType', description: 'Authentication type for tool collections' });
+export const ToolCollectionAuthTypeSchema = z.enum(['oauth', 'api_key', 'other']).meta({
+    id: 'ToolCollectionAuthType',
+    description:
+        "Authentication type for tool collections.\n- 'oauth': the runtime resolves a per-user or per-project " +
+        "OAuth access token\n- 'api_key': a static key held in the project's secret store is sent as the RFC 6750 " +
+        'bearer token (`Authorization: Bearer <key>`)',
+});
 
 export const MCPOAuthConfigSchema = z
     .strictObject({
@@ -160,6 +164,33 @@ export const MCPOAuthConfigSchema = z
             'Install-time OAuth provisioning blueprint for an MCP collection. Defines how to auto-create an ' +
             'OAuth provider when the app is installed. Does NOT affect runtime behaviour — the runtime uses ' +
             'oauth_bindings on AppInstallation.',
+    });
+
+export const MCPApiKeyConfigSchema = z
+    .strictObject({
+        required_at_install: z
+            .boolean()
+            .optional()
+            .meta({
+                description:
+                    'When true, the installer must supply the key in the install dialog. Use this for a manifest ' +
+                    'published to projects that each hold their own key. Leave unset when the key was already ' +
+                    'stored by whoever registered the server.',
+            }),
+        instructions: z
+            .string()
+            .optional()
+            .meta({
+                description:
+                    'Shown in the install dialog above the key field — typically where to generate the key on the ' +
+                    'remote service.',
+            }),
+    })
+    .meta({
+        id: 'MCPApiKeyConfig',
+        description:
+            "Install-time provisioning blueprint for an `auth: 'api_key'` MCP collection. Declares whether the " +
+            'installer is prompted for the key. Never holds the key itself — manifests are shareable documents.',
     });
 
 /**
@@ -210,6 +241,11 @@ export const MCPToolCollectionObjectSchema = z
                 'OAuth provider at install time using these values merged with any user-supplied ' +
                 'required_at_install params. The created app is recorded in AppInstallation.oauth_bindings. ' +
                 'Mutually exclusive with oauth_provider.',
+        }),
+        api_key_config: MCPApiKeyConfigSchema.optional().meta({
+            description:
+                "Install-time provisioning blueprint for auth: 'api_key' collections. Only meaningful alongside " +
+                "auth: 'api_key'; ignored otherwise.",
         }),
         oauth_provider: z
             .string()
@@ -370,6 +406,39 @@ export const McpOAuthTokenRequestSchema = z
         mcp_server_url: z.string().optional(),
     })
     .meta({ id: 'McpOAuthTokenRequest' });
+
+export const SetMcpApiKeyRequestSchema = z
+    .strictObject({
+        // `.regex(/\S/)` rather than `.trim().min(1)` alone: request bodies are validated by AJV
+        // against the EMITTED JSON Schema, where a Zod transform like `.trim()` leaves no trace —
+        // `minLength: 1` on its own happily accepts "   ". The pattern emits and is enforced, so a
+        // whitespace-only key is rejected at the boundary instead of becoming an encrypted empty
+        // key that still reports `configured: true`. The trim still normalizes for Zod consumers.
+        api_key: z
+            .string()
+            .trim()
+            .min(1)
+            .regex(/\S/, 'API key must not be blank')
+            .meta({
+                description:
+                    'The static key issued by the remote MCP server. Surrounding whitespace is stripped. Stored ' +
+                    'encrypted in the project secret store and sent as the RFC 6750 bearer token on every request ' +
+                    'to the collection URL. Never returned by the API.',
+            }),
+    })
+    .meta({ id: 'SetMcpApiKeyRequest' });
+
+export const McpApiKeyStatusSchema = z
+    .strictObject({
+        configured: z.boolean().meta({ description: 'Whether a key is stored for this collection.' }),
+        // Always present — null when unset, never absent. `.nullable()` rather than `.nullish()`
+        // so the published contract says so and generated clients do not treat it as optional.
+        hint: z
+            .string()
+            .nullable()
+            .meta({ description: 'Last few characters of the stored key, for display only. Null when unset.' }),
+    })
+    .meta({ id: 'McpApiKeyStatus', description: 'Whether an API key is configured for an MCP tool collection' });
 
 export const OAuthAuthStatusSchema = z
     .strictObject({

--- a/packages/common/src/api-schemas/mcp-api-key.contract.test.ts
+++ b/packages/common/src/api-schemas/mcp-api-key.contract.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import type { McpApiKeyStatus } from '../apps.js';
+import { AppInstallationPayloadSchema } from './app-lifecycle.js';
+import { McpApiKeyStatusSchema, SetMcpApiKeyRequestSchema } from './apps.js';
+import { validateApiRequest } from './registry.js';
+
+/** Exact type identity — `extends` in both directions is too weak (any/unknown slip through). */
+type Equals<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+function assertType<T extends true>(_ok: T): void {}
+
+/**
+ * Request bodies are enforced by AJV against the EMITTED JSON Schema, not by parsing with Zod. A
+ * Zod-only assertion would pass on transforms (`.trim()`) that leave no trace in the emission and
+ * therefore never run at the endpoint — so the blank-key cases below go through `validateApiRequest`,
+ * which is the path `validatedBody` actually takes.
+ */
+describe('SetMcpApiKeyRequest — as enforced at the endpoint (AJV)', () => {
+    it('accepts a real key', () => {
+        expect(validateApiRequest('SetMcpApiKeyRequest', { api_key: 'sk-live-abcdef' }).valid).toBe(true);
+    });
+
+    it('rejects a whitespace-only key', () => {
+        expect(validateApiRequest('SetMcpApiKeyRequest', { api_key: '   ' }).valid).toBe(false);
+    });
+
+    it('rejects a tab/newline-only key', () => {
+        expect(validateApiRequest('SetMcpApiKeyRequest', { api_key: '\t\n ' }).valid).toBe(false);
+    });
+
+    it('rejects an empty key', () => {
+        expect(validateApiRequest('SetMcpApiKeyRequest', { api_key: '' }).valid).toBe(false);
+    });
+
+    it('rejects a missing key', () => {
+        expect(validateApiRequest('SetMcpApiKeyRequest', {}).valid).toBe(false);
+    });
+
+    it('rejects unknown properties', () => {
+        expect(validateApiRequest('SetMcpApiKeyRequest', { api_key: 'sk-live', collection_id: 'x' }).valid).toBe(false);
+    });
+
+    it('still normalizes surrounding whitespace for Zod consumers', () => {
+        expect(SetMcpApiKeyRequestSchema.parse({ api_key: '  sk-live-abcdef  ' }).api_key).toBe('sk-live-abcdef');
+    });
+});
+
+describe('AppInstallationPayload.api_key_params — as enforced at the endpoint (AJV)', () => {
+    const APP_ID = '68b1779130afe5403a1589bc';
+
+    it('accepts a key per collection', () => {
+        const result = validateApiRequest('AppInstallationPayload', {
+            app_id: APP_ID,
+            api_key_params: { acme_mcp: { api_key: 'sk-install-abcdef' } },
+        });
+        expect(result.valid).toBe(true);
+    });
+
+    it('rejects a whitespace-only key on the install path too', () => {
+        const result = validateApiRequest('AppInstallationPayload', {
+            app_id: APP_ID,
+            api_key_params: { acme_mcp: { api_key: '  ' } },
+        });
+        expect(result.valid).toBe(false);
+    });
+
+    it('stays optional — installs with no api_key collections send nothing', () => {
+        expect(validateApiRequest('AppInstallationPayload', { app_id: APP_ID }).valid).toBe(true);
+        expect(AppInstallationPayloadSchema.parse({ app_id: APP_ID }).api_key_params).toBeUndefined();
+    });
+});
+
+describe('McpApiKeyStatus', () => {
+    it('publishes hint as required-but-nullable, not optional', () => {
+        // Every response sets `hint`, so the field must not be optional in the generated clients.
+        assertType<Equals<McpApiKeyStatus, { configured: boolean; hint: string | null }>>(true);
+        expect(McpApiKeyStatusSchema.safeParse({ configured: false }).success).toBe(false);
+        expect(McpApiKeyStatusSchema.safeParse({ configured: false, hint: null }).success).toBe(true);
+        expect(McpApiKeyStatusSchema.safeParse({ configured: true, hint: 'sk-l...3456' }).success).toBe(true);
+    });
+
+    it('never carries the key itself', () => {
+        expect(McpApiKeyStatusSchema.safeParse({ configured: true, hint: null, api_key: 'sk-live' }).success).toBe(
+            false,
+        );
+    });
+});

--- a/packages/common/src/api-schemas/registry.ts
+++ b/packages/common/src/api-schemas/registry.ts
@@ -109,9 +109,11 @@ import {
     AgentRunTypeSchema,
     AgentToolApprovalClassSchema,
     AgentToolDefinitionSchema,
+    AppApiKeyCollectionParamsSchema,
     AppBuildProgressSchema,
     AppBuildProgressStatusSchema,
     AppBuildTriggerSchema,
+    AppDeleteSummarySchema,
     AppDevelopmentTaskDetailsSchema,
     AppDevelopmentTaskListSchema,
     AppDevelopmentTaskSchema,
@@ -155,6 +157,7 @@ import {
     EventRefSchema,
     Extract_AppVersionGitRefType_branch_tag_commitSchema,
     InCodeTypeRefSchema,
+    McpApiKeyCredentialSchema,
     OAuthClientCredentialsMapSchema,
     OAuthClientCredentialsSchema,
     RunKindSchema,
@@ -178,6 +181,7 @@ import {
     AppSourceConfigSchema,
     AppUIConfigSchema,
     MCPToolAnnotationsSchema,
+    McpApiKeyStatusSchema,
     McpOAuthConnectResponseSchema,
     McpOAuthDisconnectResponseSchema,
     McpOAuthTokenRequestSchema,
@@ -186,6 +190,7 @@ import {
     OAuthAuthStatusArraySchema,
     OAuthAuthStatusSchema,
     OAuthMetadataResponseSchema,
+    SetMcpApiKeyRequestSchema,
     ToolCollectionObjectSchema,
 } from './apps.js';
 import {
@@ -1806,6 +1811,10 @@ const REMOTE_MCP_SCHEMAS = {
     McpOAuthConnectResponse: McpOAuthConnectResponseSchema,
     OAuthAuthorizeResponse: OAuthAuthorizeResponseSchema,
     OAuthAuthStatusArray: OAuthAuthStatusArraySchema,
+    // The static-key alternative to that handshake: the key itself is write-only, so only the
+    // setter payload and the configured/hint projection are published.
+    SetMcpApiKeyRequest: SetMcpApiKeyRequestSchema,
+    McpApiKeyStatus: McpApiKeyStatusSchema,
 } as const satisfies Record<string, z.ZodType>;
 
 const AUDIT_TRAIL_SCHEMAS = {
@@ -1919,6 +1928,7 @@ const APP_LIFECYCLE_SCHEMAS = {
     RunType: RunTypeSchema,
     AppBuildProgressStatus: AppBuildProgressStatusSchema,
     DeleteAppVersionResponse: DeleteAppVersionResponseSchema,
+    AppDeleteSummary: AppDeleteSummarySchema,
     AppRepoBranch: AppRepoBranchSchema,
     AppRepoDocumentCommit: AppRepoDocumentCommitSchema,
     AppVersionGitSource: AppVersionGitSourceSchema,
@@ -1928,6 +1938,8 @@ const APP_LIFECYCLE_SCHEMAS = {
     AppDevelopmentTaskList: AppDevelopmentTaskListSchema,
     OAuthClientCredentialsMap: OAuthClientCredentialsMapSchema,
     AppOAuthCollectionParams: AppOAuthCollectionParamsSchema,
+    McpApiKeyCredential: McpApiKeyCredentialSchema,
+    AppApiKeyCollectionParams: AppApiKeyCollectionParamsSchema,
     AppInspectionIssue: AppInspectionIssueSchema,
     AppScaffoldProgress: AppScaffoldProgressSchema,
     AppRepoTree: AppRepoTreeSchema,
@@ -2371,6 +2383,7 @@ const STRICT_COMPONENTS: ReadonlySet<string> = new Set<string>([
     'AppUIConfig',
     'AppUINavItem',
     'MCPOAuthConfig',
+    'MCPApiKeyConfig',
     'MCPToolCollectionObject',
     'VertesiaSDKToolCollectionObject',
     // File, task, content-type and command components. Every one is published closed
@@ -2929,6 +2942,8 @@ const STRICT_COMPONENTS: ReadonlySet<string> = new Set<string>([
     'McpOAuthDisconnectResponse',
     'McpOAuthConnectResponse',
     'OAuthAuthorizeResponse',
+    'SetMcpApiKeyRequest',
+    'McpApiKeyStatus',
     'AuditMeter',
     'AuditAggregationDimensionMap',
     'AuditAggregationRow',
@@ -2982,6 +2997,7 @@ const STRICT_COMPONENTS: ReadonlySet<string> = new Set<string>([
     'AppInstallationProviderBinding',
     'AppInstallationOAuthBinding',
     'OAuthClientCredentials',
+    'McpApiKeyCredential',
     'AppInspectionCapabilityReport',
     'AppRepoTreeEntry',
     'AppRepoRef',
@@ -2990,6 +3006,7 @@ const STRICT_COMPONENTS: ReadonlySet<string> = new Set<string>([
     'InCodeTypeRef',
     'StoredTypeRef',
     'DeleteAppVersionResponse',
+    'AppDeleteSummary',
     'AppRepoBranch',
     'AppRepoDocumentCommit',
     'AppVersionGitSource',

--- a/packages/common/src/apps.ts
+++ b/packages/common/src/apps.ts
@@ -2,9 +2,11 @@ import type { z } from 'zod';
 import type {
     AgentToolApprovalClassSchema,
     AgentToolDefinitionSchema,
+    AppApiKeyCollectionParamsSchema,
     AppBuildProgressSchema,
     AppBuildProgressStatusSchema,
     AppBuildTriggerSchema,
+    AppDeleteSummarySchema,
     AppDevelopmentTaskDetailsSchema,
     AppDevelopmentTaskListSchema,
     AppDevelopmentTaskSchema,
@@ -40,6 +42,7 @@ import type {
     AppVersionTargetSchema,
     AppVersionUrlsSchema,
     DeleteAppVersionResponseSchema,
+    McpApiKeyCredentialSchema,
     OAuthClientCredentialsSchema,
     StartAppBuildRequestSchema,
     StartAppBuildResponseSchema,
@@ -86,9 +89,11 @@ import type {
     AppManifestSourceSchema,
     AppSourceConfigSchema,
     AppUIConfigSchema,
+    MCPApiKeyConfigSchema,
     MCPOAuthConfigSchema,
     MCPToolAnnotationsSchema,
     MCPToolCollectionObjectSchema,
+    McpApiKeyStatusSchema,
     McpOAuthConnectResponseSchema,
     McpOAuthDisconnectResponseSchema,
     McpOAuthTokenRequestSchema,
@@ -96,6 +101,7 @@ import type {
     OAuthAuthorizeResponseSchema,
     OAuthAuthStatusSchema,
     OAuthMetadataResponseSchema,
+    SetMcpApiKeyRequestSchema,
     ToolCollectionAuthTypeSchema,
     ToolCollectionObjectSchema,
     VertesiaSDKToolCollectionObjectSchema,
@@ -161,6 +167,9 @@ export type ToolCollectionAuthType = z.infer<typeof ToolCollectionAuthTypeSchema
 export type ToolCollectionType = 'mcp' | 'vertesia_sdk';
 
 export type MCPOAuthConfig = z.infer<typeof MCPOAuthConfigSchema>;
+
+/** Install-time provisioning blueprint for an `auth: 'api_key'` MCP collection. Never holds the key. */
+export type MCPApiKeyConfig = z.infer<typeof MCPApiKeyConfigSchema>;
 
 export type MCPToolCollectionObject = z.infer<typeof MCPToolCollectionObjectSchema>;
 
@@ -663,6 +672,12 @@ export interface OrphanedAppInstallation extends Omit<AppInstallation, 'manifest
 export type OAuthClientCredentials = z.infer<typeof OAuthClientCredentialsSchema>;
 
 export type AppOAuthCollectionParams = z.infer<typeof AppOAuthCollectionParamsSchema>;
+
+/** One installer-supplied MCP API key. */
+export type McpApiKeyCredential = z.infer<typeof McpApiKeyCredentialSchema>;
+
+/** Installer-supplied MCP API keys, keyed by collection id. */
+export type AppApiKeyCollectionParams = z.infer<typeof AppApiKeyCollectionParamsSchema>;
 export type AppOAuthProviderParams = z.infer<typeof AppOAuthProviderParamsSchema>;
 
 export type AppInstallationPayload = z.infer<typeof AppInstallationPayloadSchema>;
@@ -696,6 +711,15 @@ export interface McpOAuthCollectionRef {
     app_install_id: string;
     collection_id: string;
 }
+
+/**
+ * Payload for storing the static bearer token of an `auth: 'api_key'` MCP collection.
+ * The key is write-only — it is never echoed back by any endpoint.
+ */
+export type SetMcpApiKeyRequest = z.infer<typeof SetMcpApiKeyRequestSchema>;
+
+/** Whether an `auth: 'api_key'` MCP collection has a key stored, plus a display-only hint. */
+export type McpApiKeyStatus = z.infer<typeof McpApiKeyStatusSchema>;
 
 export type McpOAuthTokenRequest = z.infer<typeof McpOAuthTokenRequestSchema>;
 
@@ -873,15 +897,11 @@ export type ValidateUrlResponse = z.infer<typeof ValidateUrlResponseSchema>;
  * Result of DELETE /api/v1/apps/:id. With `?confirm=true` the cascade runs and
  * `deleted: true` is set; without it the endpoint returns a dry-run summary so
  * the UI can show what would be removed.
+ *
+ * Inferred from the published component rather than hand-written: the endpoint
+ * had been declaring `CountResult`, so response validation reported a missing
+ * `count` and every field here as unexpected — and in local development, where
+ * the check fails closed, that surfaced as a 500 raised AFTER the app was
+ * already deleted. Deriving the type is what keeps the two from drifting again.
  */
-export interface AppDeleteSummary {
-    confirmed: boolean;
-    app_id: string;
-    app_name: string;
-    versions: number;
-    installations: number;
-    storage_prefix: string;
-    git_repo_url?: string;
-    deleted: boolean;
-    warnings: string[];
-}
+export type AppDeleteSummary = z.infer<typeof AppDeleteSummarySchema>;

--- a/packages/common/src/versions.test.ts
+++ b/packages/common/src/versions.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { ApiVersions, CURRENT_API_VERSION, CURRENT_API_VERSION_HEADER_VALUE } from './versions.js';
+
+describe('API versions', () => {
+    it('keeps the current API version aligned with the latest milestone', () => {
+        const milestones = Object.values(ApiVersions).filter(
+            (version): version is number => typeof version === 'number',
+        );
+
+        expect(CURRENT_API_VERSION).toBe(Math.max(...milestones));
+        expect(CURRENT_API_VERSION_HEADER_VALUE).toBe(String(CURRENT_API_VERSION));
+    });
+});

--- a/packages/common/src/versions.ts
+++ b/packages/common/src/versions.ts
@@ -27,3 +27,15 @@ export enum ApiVersions {
      */
     REQUEST_CONTRACT_ENFORCEMENT_V1 = 20260803,
 }
+
+/**
+ * The API version used by current clients and published as the current OpenAPI shape.
+ *
+ * Keep this explicit rather than deriving it at runtime: promoting a milestone to the client
+ * default is a deliberate compatibility decision. The versions test ensures this alias is
+ * reconsidered whenever a newer milestone is added.
+ */
+export const CURRENT_API_VERSION = ApiVersions.REQUEST_CONTRACT_ENFORCEMENT_V1;
+
+/** The current API version formatted for the {@link VERSION_HEADER} wire value. */
+export const CURRENT_API_VERSION_HEADER_VALUE = String(CURRENT_API_VERSION);


### PR DESCRIPTION
## Summary

Adds static-key authentication for remote MCP tool collections, alongside the existing OAuth path. A collection may declare `auth: 'api_key'`; the key itself never enters the manifest — a shareable document — and is sent by the runtime as the RFC 6750 bearer token (`Authorization: Bearer <key>`). MCP has no API-key standard, but RFC 6750 is explicitly format- and issuer-agnostic, so a static key is a conformant bearer token.

### Wire schemas and inferred types

- `ToolCollectionAuthType` gains `api_key`.
- `MCPApiKeyConfig` — install-time provisioning blueprint (`required_at_install`, `instructions`). Never holds the key.
- `SetMcpApiKeyRequest` / `McpApiKeyStatus` — the rotation endpoints. The status carries only `configured` and a masked hint; the key is never echoed.
- `McpApiKeyCredential` / `AppApiKeyCollectionParams` — `api_key_params` on `AppInstallationPayload`, so an installer can supply the key at install time the way OAuth params already work.

The blank-key guard is spelled `.regex(/\S/)` rather than `.trim().min(1)` alone. Request bodies are validated by AJV against the **emitted JSON Schema**, where a Zod `.trim()` transform leaves no trace — `minLength: 1` on its own happily accepts `"   "`. The regex emits `pattern: "\\S"` and is enforced; the contract tests go through `validateApiRequest` rather than parsing with Zod, so they exercise the path the endpoint actually takes.

### `AppDeleteSummary` becomes a published component

`DeleteApp` had been declaring `CountResult` while returning this shape. Response validation therefore reported a missing `count` and every summary field as unexpected — and where the check fails closed (local development) that surfaced as a 500 raised *after* the app had already been deleted. The public type is now inferred from the schema rather than hand-written beside it, so the two cannot drift again.

### Client

`setMcpCollectionApiKey`, `getMcpCollectionApiKeyStatus`, `deleteMcpCollectionApiKey`, and a fifth `apiKeyParams` argument on `install`.

### Single source for the API version

`CURRENT_API_VERSION` / `CURRENT_API_VERSION_HEADER_VALUE` are introduced in `versions.ts` as the one place the API version is declared. The client's `VERSION` export is re-exported from it rather than redeclared, and a test pins the alias to the newest milestone in `ApiVersions` so adding a milestone forces the promotion to be reconsidered.

> Note for reviewers: this moves the client default from `20260319` to `20260803` (`REQUEST_CONTRACT_ENFORCEMENT_V1`), so the JS client now opts **in** to strict request-contract enforcement rather than sitting below the milestone.

## Test Plan

- [x] `packages/common`: `pnpm test` — 616 passed / 44 files (includes 12 new MCP API-key contract tests, 7 new `AppDeleteSummary` contract tests, and the versions alias test)
- [x] `packages/common`: `pnpm build` (`tsc` + rolldown)
- [x] `packages/client`: `pnpm build`
- [x] `biome check` clean across `packages/common/src` and `packages/client/src`
- [x] Generated-client gates run against the regenerated spec: Java `BUILD SUCCESS` (22 tests), Go `ok github.com/vertesia/vertesia-client-go/openapi`