### PR TITLE
fix(client): sanitize file download errors

### DIFF
--- a/packages/client/src/store/FilesApi.test.ts
+++ b/packages/client/src/store/FilesApi.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ZenoClient } from './client.js';
 
 describe('FilesApi', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+    });
+
     it('retries signed upload URL creation after a transient connection failure', async () => {
         let attempts = 0;
         const fetchSignedUploadUrl = async (): Promise<Response> => {
@@ -65,5 +70,36 @@ describe('FilesApi', () => {
 
         expect(result).toEqual({ id: 'file-1', path: 'agents/run/conversation.json', url: 'https://signed' });
         expect(attempts).toBe(2);
+    });
+
+    it('does not expose a signed URL when a file download returns 404', async () => {
+        const signedUrl =
+            'https://storage.googleapis.com/test-bucket/agents/run/files/missing.png?X-Goog-Credential=secret&X-Goog-Signature=do-not-log';
+        const fetchDownloadUrl = (): Promise<Response> =>
+            Promise.resolve(
+                new Response(JSON.stringify({ url: signedUrl }), {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' },
+                }),
+            );
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 404, statusText: 'Not Found' })));
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        const client = new ZenoClient({
+            serverUrl: 'https://store.test',
+            apikey: 'token',
+            fetch: fetchDownloadUrl,
+        });
+
+        const error = await client.files.downloadFile('agents/run/files/missing.png').catch((cause: unknown) => cause);
+
+        expect(error).toMatchObject({
+            name: 'FileDownloadError',
+            status: 404,
+            message: 'File download not found: agents/run/files/missing.png',
+        });
+        expect(String(error)).not.toContain('X-Goog-Credential');
+        expect(String(error)).not.toContain('X-Goog-Signature');
+        expect(String(error)).not.toContain('do-not-log');
+        expect(consoleError).not.toHaveBeenCalled();
     });
 });

--- a/packages/client/src/store/FilesApi.ts
+++ b/packages/client/src/store/FilesApi.ts
@@ -28,6 +28,44 @@ const FILE_SIGNING_RETRY_POLICY: IRequestRetryPolicy = {
     statuses: [502, 503, 504],
 };
 
+function fileLocationForError(location: string): string {
+    try {
+        const url = new URL(location);
+        return `${url.protocol}//${url.host}${url.pathname}`;
+    } catch {
+        return location.split(/[?#]/, 1)[0] || 'unknown file';
+    }
+}
+
+function sanitizedErrorCause(error: unknown): Error | undefined {
+    if (!(error instanceof Error)) {
+        return undefined;
+    }
+    const message = error.message.replace(/https?:\/\/[^\s)\]}>"']+/g, (url) => fileLocationForError(url));
+    const cause = new Error(message);
+    cause.name = error.name;
+    return cause;
+}
+
+function fileDownloadFailureReason(status?: number, statusText?: string): string {
+    if (status === 404) return 'not found';
+    if (status === 403) return 'forbidden';
+    if (status) return `failed with status ${status}${statusText ? ` ${statusText}` : ''}`;
+    return 'failed';
+}
+
+export class FileDownloadError extends Error {
+    readonly status?: number;
+
+    constructor(location: string, status?: number, statusText?: string, cause?: unknown) {
+        const safeLocation = fileLocationForError(location);
+        const reason = fileDownloadFailureReason(status, statusText);
+        super(`File download ${reason}: ${safeLocation}`, { cause: sanitizedErrorCause(cause) });
+        this.name = 'FileDownloadError';
+        this.status = status;
+    }
+}
+
 export function getMemoryFilePath(name: string) {
     const nameWithExt = name.endsWith('.tar.gz') ? name : `${name}.tar.gz`;
     return `${MEMORIES_PREFIX}/${nameWithExt}`;
@@ -229,28 +267,19 @@ export class FilesApi extends ApiTopic {
         const needSign = !location.startsWith('https:');
         const { url } = needSign ? await this.getDownloadUrl(location) : { url: location };
 
-        const res = await fetchSignedUrl(url, {
-            method: 'GET',
-        })
-            .then((res: Response) => {
-                if (res.ok) {
-                    return res;
-                } else if (res.status === 404) {
-                    throw new Error(`File at ${url} not found`); //TODO: type fetch error better with a fetch error class
-                } else if (res.status === 403) {
-                    throw new Error(`File at ${url} is forbidden`);
-                } else {
-                    console.log(res);
-                    throw new Error(`Failed to download file ${location}: ${res.statusText}`);
-                }
-            })
-            .catch((err) => {
-                console.error(`Failed to download file ${location}.`, err);
-                throw err;
-            });
+        let res: Response;
+        try {
+            res = await fetchSignedUrl(url, { method: 'GET' });
+        } catch (error: unknown) {
+            throw new FileDownloadError(location, undefined, undefined, error);
+        }
+
+        if (!res.ok) {
+            throw new FileDownloadError(location, res.status, res.statusText);
+        }
 
         if (!res.body) {
-            throw new Error(`No body in response while downloading file ${location}`);
+            throw new FileDownloadError(location);
         }
 
         return res.body;


### PR DESCRIPTION
Summary:
- return a typed, status-bearing FileDownloadError for signed storage download failures
- remove console output and strip signed query credentials from propagated errors
- retain safe storage locations so callers can distinguish not-found failures

Verification:
- pnpm lint
- pnpm typecheck:test
- pnpm test
- pnpm build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side error handling only; reduces credential leakage and improves caller ergonomics without changing successful download behavior.
> 
> **Overview**
> **`FilesApi.downloadFile`** now fails with a typed **`FileDownloadError`** (optional HTTP **`status`**) instead of generic errors that embedded the full signed download URL.
> 
> Error messages and nested **`cause`** values are **sanitized**: signed query parameters are stripped from URLs (paths or origin+pathname only), and **`console.log` / `console.error`** on download failure are removed so credentials are not logged.
> 
> A test asserts that a **404** on the signed fetch yields a not-found **`FileDownloadError`** for the logical path, with no signed URL material in the stringified error and no **`console.error`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8235a3047504297fcfe7b03a0cdef3a643155b0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->