### PR TITLE
fix: propagate app version to Store client

### DIFF
--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1,3 +1,4 @@
+import { APP_VERSION_HEADER } from '@vertesia/common';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { isTokenExpired, VertesiaClient } from './client.js';
 
@@ -144,6 +145,21 @@ describe('Test Vertesia Client', () => {
         expect(client).toBeDefined();
         expect(client.baseUrl).toBe('https://studio-server-production.api.becomposable.com');
         expect(client.storeUrl).toBe('https://zeno-server-production.api.becomposable.com');
+    });
+
+    test('withAppVersion keeps Studio and Store requests pinned together', () => {
+        const client = new VertesiaClient({
+            serverUrl: 'https://studio-server-production.api.becomposable.com',
+            storeUrl: 'https://zeno-server-production.api.becomposable.com',
+        });
+
+        expect(client.withAppVersion('candidate-v1')).toBe(client);
+        expect(client.headers[APP_VERSION_HEADER]).toBe('candidate-v1');
+        expect(client.store.headers[APP_VERSION_HEADER]).toBe('candidate-v1');
+
+        client.withAppVersion(null);
+        expect(client.headers[APP_VERSION_HEADER]).toBeUndefined();
+        expect(client.store.headers[APP_VERSION_HEADER]).toBeUndefined();
     });
 });
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -248,6 +248,7 @@ export class VertesiaClient extends AbstractFetchClient<VertesiaClient> {
      * exact built version instead of the promoted version. Pass null/empty to clear (→ promoted).
      */
     withAppVersion(version: string | null | undefined) {
+        this.store.withAppVersion(version);
         if (!version) {
             delete this.headers[APP_VERSION_HEADER];
         } else {


### PR DESCRIPTION
## Summary
- propagate `VertesiaClient.withAppVersion()` to the embedded Store client as well as the Studio client
- keep setting and clearing the version target synchronized across both clients
- add a regression test covering both header stores

## Why
A caller using the root client could pin Studio requests to an immutable app version while `client.objects` and other Store APIs silently omitted `x-vertesia-app-version`. Store-side app capability resolution then fell back to the promoted package instead of the requested candidate.

## Test Plan
- [x] `pnpm --filter @vertesia/client... build`
- [x] `pnpm --prefix packages/client lint`
- [x] `pnpm --prefix packages/client build`
- [x] `pnpm --prefix packages/client test` — 15 files, 92 tests
- [x] `pnpm --prefix packages/client typecheck:test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small SDK header-propagation fix with no auth or server changes; behavior aligns Store with existing Studio pinning.
> 
> **Overview**
> **`VertesiaClient.withAppVersion()`** now forwards the pin to the embedded **Store** (`ZenoClient`) client, matching how auth, retry, and timeout are already kept in sync.
> 
> Previously only Studio requests carried **`x-vertesia-app-version`**; Store calls via `client.objects` and other store APIs could resolve app refs against the promoted version instead of the requested candidate. Setting and clearing the version updates both clients’ headers.
> 
> A regression test asserts Studio and Store headers stay aligned when pinning and when clearing with `null`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea3b9b7305fd791596fcc0d975af44ec6b880e9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->