### PR TITLE
chore(deps): keep typescript-legacy on the TypeScript 6 line

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -274,7 +274,26 @@
       "allowedVersions": "<25",
       "rangeStrategy": "bump"
     },
-        {
+    {
+      // `typescript-legacy` is the pnpm catalog alias for the last TypeScript major that still
+      // ships the JavaScript compiler API (`typescript@6`). TypeScript 7 is the native port and
+      // does not expose it, so `packages/cli`'s ts-loader, which imports `typescript-legacy` for
+      // AST work, breaks on v7 — that is the whole reason the alias exists next to the
+      // `typescript` catalog entry, which does track the current major. Matched by depName
+      // because the catalog key, not the aliased package name (`typescript`), is what Renovate
+      // reports for `npm:` aliases; matching the package name here would also freeze the real
+      // `typescript` entry.
+      "description": "Keep the typescript-legacy catalog alias on the TypeScript 6 line (JS compiler API)",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchDepNames": [
+        "typescript-legacy"
+      ],
+      "allowedVersions": "<7",
+      "rangeStrategy": "bump"
+    },
+    {
       // The undici Agent is passed as a dispatcher to Node's built-in global
       // fetch (see core/src/http-agent.ts). undici v8 renamed the dispatch
       // handler interface (onRequestStart), so a v8 Agent is rejected by the


### PR DESCRIPTION
## Summary

The `typescript-legacy` entry in the pnpm catalog aliases `typescript@6` — the last major that
still ships the JavaScript compiler API. TypeScript 7 is the native port and does not expose it,
so `packages/cli`'s `ts-loader` (which does `import * as ts from 'typescript-legacy'` for AST
work) breaks on v7. That is the entire reason the alias exists next to the `typescript` catalog
entry, which *does* track the current major.

Nothing in the Renovate config expressed that, so Renovate proposed bumping the alias to v7. This
adds a package rule capping it at `<7`:

```json5
"matchManagers": ["npm"],
"matchDepNames": ["typescript-legacy"],
"allowedVersions": "<7"
```

Two deliberate choices:

- **`allowedVersions: "<7"` rather than `enabled: false`** — it matches how `node` (`<25`),
  `undici` (`<8`) and `google-auth-library` (`<10`) are already pinned in this file, and it keeps
  6.x patch/minor releases flowing so the alias stays maintained rather than frozen.
- **`matchDepNames`, not `matchPackageNames`** — for an `npm:` alias Renovate reports depName as
  the catalog key (`typescript-legacy`) and packageName as `typescript`. Matching on the package
  name would have silently frozen the real `typescript` catalog entry alongside it.

Also normalizes the stray indentation on the `undici` rule that immediately follows the insertion
point.

## Test Plan

- [x] `npx --package renovate -- renovate-config-validator .renovaterc.json5` → "Config validated
      successfully against 1 file(s)". Confirmed this check is meaningful by re-running it against
      a copy with `matchDepNames` deliberately typo'd, which fails with
      `Invalid configuration option: packageRules[N].matchDepNamez`.
- [x] No lint/format command applies: `biome.json` scopes `files.includes` to `**/package.json`
      and `**/*.{js,cjs,mjs,jsx,ts,tsx,css,html}`, so `.renovaterc.json5` is outside it.
- [x] No build or test run — the diff touches only the Renovate config; no package source,
      `package.json`, or lockfile is affected.
