### PR TITLE
feat: expose skill routing metadata

### DIFF
--- a/packages/build-tools/tests/skill.test.ts
+++ b/packages/build-tools/tests/skill.test.ts
@@ -43,6 +43,24 @@ Content here`;
         });
     });
 
+    it('should map flat keywords frontmatter into context_triggers', async () => {
+        const content = `---
+name: test
+title: Test
+description: Test description
+keywords: [sql, data analysis]
+---
+Content here`;
+
+        const result = await skillTransformer.transform(content, 'test.md');
+
+        expect((result.data as { context_triggers: { keywords: string[] } }).context_triggers).toEqual({
+            keywords: ['sql', 'data analysis'],
+            tool_names: undefined,
+            data_patterns: undefined,
+        });
+    });
+
     it('should include tools from frontmatter', async () => {
         const content = `---
 name: test

--- a/packages/common/src/api-schemas/agent-runs.contract.test.ts
+++ b/packages/common/src/api-schemas/agent-runs.contract.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { AgentEventType, LlmCallType } from '../workflow-analytics.js';
+import { AgentEventSchema } from './agent-runs.js';
+
+describe('AgentEventSchema', () => {
+    it('round-trips shadow skill-ranking events', () => {
+        const event = {
+            eventType: AgentEventType.ShadowSkillRanking,
+            timestamp: '2026-08-06T00:00:00.000Z',
+            runId: 'run-1',
+            agentRunId: 'agent-run-1',
+            model: 'model-1',
+            environmentId: 'environment-1',
+            environmentType: 'test',
+            interactionId: 'interaction-1',
+            callType: LlmCallType.ResumeUser,
+            iteration: 4,
+            attemptNumber: 1,
+            scorerVersion: 2,
+            userMessageTokenCount: 3,
+            scope: 'universe',
+            rankings: [{ skill: 'learn_data_analysis', score: 24, active: true }],
+        } as const;
+
+        expect(AgentEventSchema.parse(event)).toEqual(event);
+    });
+
+    it('continues to reject unknown event types', () => {
+        expect(() => AgentEventSchema.parse({ eventType: 'unknown' })).toThrow();
+    });
+
+    it('rejects shadow rankings above the telemetry cap', () => {
+        const event = {
+            eventType: AgentEventType.ShadowSkillRanking,
+            timestamp: '2026-08-06T00:00:00.000Z',
+            runId: 'run-1',
+            model: 'model-1',
+            environmentId: 'environment-1',
+            environmentType: 'test',
+            interactionId: 'interaction-1',
+            callType: LlmCallType.Start,
+            iteration: 0,
+            attemptNumber: 1,
+            scorerVersion: 2,
+            userMessageTokenCount: 1,
+            scope: 'universe',
+            rankings: Array.from({ length: 21 }, (_, index) => ({
+                skill: `learn_skill_${index}`,
+                score: 0,
+                active: false,
+            })),
+        } as const;
+
+        expect(() => AgentEventSchema.parse(event)).toThrow();
+    });
+});

--- a/packages/common/src/api-schemas/agent-runs.ts
+++ b/packages/common/src/api-schemas/agent-runs.ts
@@ -124,12 +124,33 @@ const ToolCallEventSchema = z.strictObject({
     spawnedChildWorkflow: z.boolean().optional(),
 });
 
+const ShadowSkillRankingEventSchema = z.strictObject({
+    ...agentEventBase,
+    eventType: z.literal(AgentEventType.ShadowSkillRanking),
+    callType: z.union([z.literal(LlmCallType.Start), z.literal(LlmCallType.ResumeUser)]),
+    iteration: z.number(),
+    attemptNumber: z.number(),
+    scorerVersion: z.number(),
+    userMessageTokenCount: z.number(),
+    scope: z.enum(['universe', 'active_only']),
+    rankings: z
+        .array(
+            z.strictObject({
+                skill: z.string(),
+                score: z.number(),
+                active: z.boolean(),
+            }),
+        )
+        .max(20),
+});
+
 export const AgentEventSchema: z.ZodType<AgentEvent> = z
     .discriminatedUnion('eventType', [
         AgentRunStartedEventSchema,
         AgentRunCompletedEventSchema,
         LlmCallEventSchema,
         ToolCallEventSchema,
+        ShadowSkillRankingEventSchema,
     ])
     .meta({ id: 'AgentEvent' });
 

--- a/packages/common/src/api-schemas/app-lifecycle.ts
+++ b/packages/common/src/api-schemas/app-lifecycle.ts
@@ -462,6 +462,13 @@ export const AgentToolDefinitionSchema = z
                     'For skill tools (`learn_*`): the tool names this skill enables when called. Matches the `tools:` key used in SKILL.md frontmatter and built-in skill definitions — one name across the whole stack.',
             })
             .optional(),
+        keywords: z
+            .array(z.string())
+            .meta({
+                description:
+                    'For skill tools (`learn_*`): context-trigger keywords from SKILL.md frontmatter. Not included in primary-agent tool definitions; available to discovery and routing components.',
+            })
+            .optional(),
         annotations: MCPToolAnnotationsSchema.meta({
             description: 'MCP tool annotations providing hints about tool behavior and safety.',
         }).optional(),

--- a/packages/common/src/store/conversation-state.ts
+++ b/packages/common/src/store/conversation-state.ts
@@ -269,6 +269,9 @@ export interface ConversationCatalogState {
      */
     skill_tool_map?: Record<string, string[]>;
 
+    /** Routing keywords keyed by bare skill name (without the learn_ prefix). */
+    skill_keywords?: Record<string, string[]>;
+
     /** All available skills from registered tool collections (for upfront hydration in sandbox) */
     available_skills?: AvailableSkill[];
 
@@ -284,7 +287,10 @@ export interface ConversationCatalogState {
  * (catalog.json, next to conversation.json and tools.json). Activation metadata is
  * runtime bookkeeping and is deliberately not part of the stored catalog.
  */
-export type StoredConversationCatalog = Pick<ConversationCatalogState, 'skill_tool_map' | 'available_skills'>;
+export type StoredConversationCatalog = Pick<
+    ConversationCatalogState,
+    'skill_tool_map' | 'skill_keywords' | 'available_skills'
+>;
 
 /** Artifact key of the stored conversation catalog, relative to the agent storage root. */
 export const CONVERSATION_CATALOG_ARTIFACT_KEY = 'catalog.json';

--- a/packages/common/src/workflow-analytics.ts
+++ b/packages/common/src/workflow-analytics.ts
@@ -16,6 +16,7 @@ export enum AgentEventType {
     AgentRunCompleted = 'agent_run_completed',
     LlmCall = 'llm_call',
     ToolCall = 'tool_call',
+    ShadowSkillRanking = 'shadow_skill_ranking',
 }
 
 /**
@@ -210,6 +211,21 @@ export interface ToolCallEvent extends BaseAgentEvent {
     spawnedChildWorkflow?: boolean;
 }
 
+/** Shadow-only lexical skill ranking emitted without changing the active catalog. */
+export interface ShadowSkillRankingEvent extends BaseAgentEvent {
+    eventType: AgentEventType.ShadowSkillRanking;
+    callType: LlmCallType.Start | LlmCallType.ResumeUser;
+    /** Workflow model iteration used to join subsequent tool calls. */
+    iteration: number;
+    /** Activity attempt used to deduplicate retries. */
+    attemptNumber: number;
+    scorerVersion: number;
+    /** Lexical token count only; user text and token strings are never emitted. */
+    userMessageTokenCount: number;
+    scope: 'universe' | 'active_only';
+    rankings: Array<{ skill: string; score: number; active: boolean }>;
+}
+
 // ============================================================================
 // Checkpoint Events
 // ============================================================================
@@ -253,7 +269,12 @@ export interface NestedInteractionEvent extends LlmCallEvent {
 /**
  * @discriminator eventType
  */
-export type AgentEvent = AgentRunStartedEvent | AgentRunCompletedEvent | LlmCallEvent | ToolCallEvent;
+export type AgentEvent =
+    | AgentRunStartedEvent
+    | AgentRunCompletedEvent
+    | LlmCallEvent
+    | ToolCallEvent
+    | ShadowSkillRankingEvent;
 
 /**
  * Workflow Analytics Types

--- a/packages/tools-sdk/src/SkillCollection.test.ts
+++ b/packages/tools-sdk/src/SkillCollection.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { SkillCollection } from './SkillCollection.js';
+
+describe('SkillCollection.getToolDefinitions', () => {
+    it('emits context-trigger keywords for skill routing', () => {
+        const collection = new SkillCollection({
+            name: 'data-analysis',
+            skills: [
+                {
+                    name: 'analyze_data',
+                    description: 'Analyze structured data.',
+                    instructions: 'Use SQL.',
+                    content_type: 'md',
+                    context_triggers: { keywords: ['sql', 'data analysis'] },
+                },
+            ],
+        });
+
+        expect(collection.getToolDefinitions()[0]).toMatchObject({
+            name: 'learn_analyze_data',
+            keywords: ['sql', 'data analysis'],
+        });
+    });
+
+    it('omits keywords when a skill has none', () => {
+        const collection = new SkillCollection({
+            name: 'plain',
+            skills: [
+                {
+                    name: 'plain_skill',
+                    description: 'Plain skill.',
+                    instructions: 'Do the task.',
+                    content_type: 'md',
+                },
+            ],
+        });
+
+        expect(collection.getToolDefinitions()[0]).not.toHaveProperty('keywords');
+    });
+});

--- a/packages/tools-sdk/src/SkillCollection.ts
+++ b/packages/tools-sdk/src/SkillCollection.ts
@@ -119,6 +119,7 @@ export class SkillCollection implements ICollection<SkillDefinition> {
                 description,
                 input_schema: skill.input_schema || defaultSchema,
                 tools: skill.tools,
+                ...(skill.context_triggers?.keywords?.length ? { keywords: skill.context_triggers.keywords } : {}),
                 category: this.name,
             };
         });


### PR DESCRIPTION
## Problem
Skill authors can declare context-trigger keywords, but those signals are not exposed by the public skill tool contract. There is also no typed event for evaluating how candidate skills rank against a user turn before changing runtime activation behavior.

## Goal
- Preserve skill keywords in AgentToolDefinition and SkillCollection output for learn_* skills.
- Persist keyword metadata in the stored conversation catalog sidecar.
- Define and strictly validate a privacy-safe shadow_skill_ranking event, capped at 20 candidates.
- Keep the additions optional and backward compatible.

## Benefits
- Routing consumers can use author-curated intent signals to distinguish similar skills.
- Ranking quality can be measured before reducing the upfront skill catalog.
- Telemetry records scores and token counts without storing user text or lexical tokens.
- Existing integrations without keyword metadata continue to work unchanged.

## Test Plan
- [x] cd packages/common && pnpm build && pnpm lint && pnpm test && pnpm typecheck:test
- [x] cd packages/build-tools && pnpm build && pnpm lint && pnpm test && pnpm typecheck:test
- [x] cd packages/tools-sdk && pnpm build && pnpm lint && pnpm test && pnpm typecheck:test