### PR TITLE
fix: hand off start-staged file delivery to the workflow

### DIFF
--- a/packages/common/src/store/agent-run.ts
+++ b/packages/common/src/store/agent-run.ts
@@ -30,6 +30,7 @@ import type {
     AgentMessage,
     CompactMessage,
     ConversationActivityState,
+    ConversationFileBatchRef,
     ConversationFileRef,
     ConversationFileRemovedRef,
     WorkflowRunEvent,
@@ -472,6 +473,7 @@ export type SignalAgentPayload =
     | StopSignal
     | ConversationFileRef
     | ConversationFileRemovedRef
+    | ConversationFileBatchRef
     | Record<string, unknown>;
 
 /**

--- a/packages/common/src/store/workflow.ts
+++ b/packages/common/src/store/workflow.ts
@@ -1180,11 +1180,6 @@ export interface ConversationFile {
      * accessible to tools via its artifact_path/md_path.
      */
     consumed_at?: number;
-    /**
-     * Carried over from the FileUploaded signal: the workflow owes a "[Files Ready]" user turn
-     * once every flagged file of the batch has settled. See ConversationFileRef.deliver_when_ready.
-     */
-    deliver_when_ready?: boolean;
 }
 
 /**
@@ -1229,13 +1224,24 @@ export interface ConversationFileRef {
     reference: string;
     /** Artifact path without prefix (e.g., "files/document.pdf") */
     artifact_path: string;
+}
+
+/**
+ * Manifest closing a staged-upload batch (the FileBatchClosed signal). Sent by clients that
+ * stage files before the run exists (the agent start screen) after every upload attempt has
+ * finished: those clients cannot wait for text extraction themselves, so the workflow owns the
+ * "[Files Ready]" user turn. The manifest is the batch's authoritative membership — the
+ * workflow delivers once, and only once, every listed file has settled, so a fast first file
+ * can never trigger delivery while later files are still uploading.
+ */
+export interface ConversationFileBatchRef {
+    /** Client-generated batch id. */
+    batch_id: string;
     /**
-     * When true, the workflow delivers a "[Files Ready]" user turn itself once every flagged
-     * file of the batch has finished processing. Set by clients that stage files before the
-     * run exists (the agent start screen) and therefore cannot wait for readiness themselves —
-     * delivery must not depend on the client staying alive during text extraction.
+     * Ids (ConversationFileRef.id) of the files successfully uploaded and signaled for this
+     * batch. Files whose upload failed client-side are omitted; empty when every upload failed.
      */
-    deliver_when_ready?: boolean;
+    file_ids: string[];
 }
 
 /**

--- a/packages/common/src/store/workflow.ts
+++ b/packages/common/src/store/workflow.ts
@@ -1180,6 +1180,11 @@ export interface ConversationFile {
      * accessible to tools via its artifact_path/md_path.
      */
     consumed_at?: number;
+    /**
+     * Carried over from the FileUploaded signal: the workflow owes a "[Files Ready]" user turn
+     * once every flagged file of the batch has settled. See ConversationFileRef.deliver_when_ready.
+     */
+    deliver_when_ready?: boolean;
 }
 
 /**
@@ -1224,6 +1229,13 @@ export interface ConversationFileRef {
     reference: string;
     /** Artifact path without prefix (e.g., "files/document.pdf") */
     artifact_path: string;
+    /**
+     * When true, the workflow delivers a "[Files Ready]" user turn itself once every flagged
+     * file of the batch has finished processing. Set by clients that stage files before the
+     * run exists (the agent start screen) and therefore cannot wait for readiness themselves —
+     * delivery must not depend on the client staying alive during text extraction.
+     */
+    deliver_when_ready?: boolean;
 }
 
 /**

--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.test.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.test.tsx
@@ -341,7 +341,7 @@ describe('ModernAgentConversation send handling', () => {
         // view: consumers like StudioAssistantPanel feed the new agentRunId straight back as a
         // prop, which unmounts StartWorkflowView (and any handoff state) the moment the run
         // starts. Regression coverage for the flow where staged files silently vanished.
-        it('uploads staged files flagged deliver_when_ready and sends no follow-up message', async () => {
+        it('uploads staged files, closes the batch with a manifest, and sends no follow-up message', async () => {
             const startWorkflow = vi.fn().mockResolvedValue({ agent_run_id: 'agent-run-2' });
             mockStreamState({
                 messages: [],
@@ -372,13 +372,32 @@ describe('ModernAgentConversation send handling', () => {
                     expect.objectContaining({
                         name: 'report.pdf',
                         artifact_path: 'files/report.pdf',
-                        deliver_when_ready: true,
                     }),
                 );
             });
 
-            // The workflow owns the "[Files Ready]" turn (deliver_when_ready): the client must
-            // not send a UserInput of its own — it would race the workflow's delivery.
+            // The closing manifest defines the batch's membership: the workflow delivers only
+            // when every listed file has settled, so a fast first file can never trigger a
+            // partial delivery.
+            await waitFor(() => {
+                expect(mocks.sendSignal).toHaveBeenCalledWith(
+                    'agent-run-2',
+                    'FileBatchClosed',
+                    expect.objectContaining({
+                        batch_id: expect.stringMatching(/^batch-/),
+                        file_ids: [
+                            (
+                                mocks.sendSignal.mock.calls.find((call) => call[1] === 'FileUploaded')?.[2] as {
+                                    id: string;
+                                }
+                            ).id,
+                        ],
+                    }),
+                );
+            });
+
+            // The workflow owns the "[Files Ready]" turn: the client must not send a UserInput
+            // of its own — it would race the workflow's delivery.
             const userInputCalls = mocks.sendSignal.mock.calls.filter((call) => call[1] === 'UserInput');
             expect(userInputCalls).toHaveLength(0);
 

--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.test.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.test.tsx
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
     reconnect: vi.fn(),
     restart: vi.fn(),
     sendSignal: vi.fn(),
+    uploadArtifact: vi.fn(),
     headerProps: vi.fn(),
     allMessagesMixedProps: vi.fn(),
     messageInputProps: vi.fn(),
@@ -30,6 +31,7 @@ vi.mock('@vertesia/ui/session', () => ({
             agents: {
                 restart: mocks.restart,
                 sendSignal: mocks.sendSignal,
+                uploadArtifact: mocks.uploadArtifact,
                 getActiveWorkstreams: mocks.getActiveWorkstreams,
                 retrieve: mocks.retrieve,
             },
@@ -218,6 +220,7 @@ describe('ModernAgentConversation send handling', () => {
         vi.clearAllMocks();
         mocks.restart.mockResolvedValue({ id: 'agent-run-1' });
         mocks.sendSignal.mockResolvedValue({});
+        mocks.uploadArtifact.mockResolvedValue({});
         mocks.getActiveWorkstreams.mockResolvedValue({ running: [] });
         mocks.retrieve.mockResolvedValue({ disabled_mcp_collections: undefined });
         mocks.useAgentPlans.mockReturnValue({
@@ -330,6 +333,60 @@ describe('ModernAgentConversation send handling', () => {
         );
         await waitFor(() => {
             expect(clearProcessingFiles).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('files staged before the run existed', () => {
+        // Staging must upload inline in StartWorkflowView, not via a handoff to the conversation
+        // view: consumers like StudioAssistantPanel feed the new agentRunId straight back as a
+        // prop, which unmounts StartWorkflowView (and any handoff state) the moment the run
+        // starts. Regression coverage for the flow where staged files silently vanished.
+        it('uploads staged files flagged deliver_when_ready and sends no follow-up message', async () => {
+            const startWorkflow = vi.fn().mockResolvedValue({ agent_run_id: 'agent-run-2' });
+            mockStreamState({
+                messages: [],
+                isCompleted: false,
+                initialHistoryStatus: 'empty',
+                agentRunStatus: 'RUNNING',
+            });
+
+            const { container } = renderWithProviders(
+                <ModernAgentConversation startWorkflow={startWorkflow} hideHeader initialMessage="" />,
+            );
+
+            const file = new File(['pdf'], 'report.pdf', { type: 'application/pdf' });
+            const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+            expect(fileInput).not.toBeNull();
+            fireEvent.change(fileInput, { target: { files: [file] } });
+
+            fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Look at these files' } });
+            fireEvent.click(screen.getByRole('button', { name: 'Start Agent' }));
+
+            await waitFor(() => {
+                expect(mocks.uploadArtifact).toHaveBeenCalledWith('agent-run-2', 'files/report.pdf', file);
+            });
+            await waitFor(() => {
+                expect(mocks.sendSignal).toHaveBeenCalledWith(
+                    'agent-run-2',
+                    'FileUploaded',
+                    expect.objectContaining({
+                        name: 'report.pdf',
+                        artifact_path: 'files/report.pdf',
+                        deliver_when_ready: true,
+                    }),
+                );
+            });
+
+            // The workflow owns the "[Files Ready]" turn (deliver_when_ready): the client must
+            // not send a UserInput of its own — it would race the workflow's delivery.
+            const userInputCalls = mocks.sendSignal.mock.calls.filter((call) => call[1] === 'UserInput');
+            expect(userInputCalls).toHaveLength(0);
+
+            // The staged note still rides on the initial message so the agent knows to wait.
+            expect(startWorkflow).toHaveBeenCalledWith(
+                expect.stringContaining('1 file(s) are being uploaded'),
+                expect.anything(),
+            );
         });
     });
 

--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
@@ -6,6 +6,7 @@ import {
     type AgentToolApprovalMode,
     type CompletedWorkstreamEntry,
     type ConversationFile,
+    type ConversationFileBatchRef,
     type ConversationFileRef,
     FileProcessingStatus,
     type McpConnectUxConfig,
@@ -937,26 +938,41 @@ function StartWorkflowView({
                 // StudioAssistantPanel feed the new agentRunId straight back as a prop, which
                 // switches ModernAgentConversation to its agentRunId branch and unmounts this
                 // view — any state handoff dies with it. Inline client calls survive regardless
-                // of what renders next. deliver_when_ready makes the workflow itself deliver the
-                // "[Files Ready]" turn once processing settles, so no follow-up signal is sent
-                // here and delivery does not depend on this client staying alive.
+                // of what renders next. The closing FileBatchClosed manifest names the batch's
+                // exact membership, so the workflow delivers the "[Files Ready]" turn itself
+                // once — and only once — every listed file has settled, even when a small file
+                // finishes processing while a larger one is still uploading. Delivery does not
+                // depend on this client staying alive.
                 if (canStageFiles && stagedFiles.length > 0) {
+                    const batchId = `batch-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+                    const uploadedFileIds: string[] = [];
                     for (const file of stagedFiles) {
                         try {
                             const artifactPath = `files/${file.name}`;
                             await client.agents.uploadArtifact(agentId, artifactPath, file);
+                            const fileId = `file-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
                             await client.agents.sendSignal(agentId, 'FileUploaded', {
-                                id: `file-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+                                id: fileId,
                                 name: file.name,
                                 content_type: file.type || 'application/octet-stream',
                                 reference: `artifact:${artifactPath}`,
                                 artifact_path: artifactPath,
-                                deliver_when_ready: true,
                             } as ConversationFileRef);
+                            uploadedFileIds.push(fileId);
                         } catch (uploadErr) {
                             console.error(`Failed to upload staged file ${file.name}:`, uploadErr);
                             // Continue with other files
                         }
+                    }
+                    try {
+                        // Close the batch even when every upload failed — the workflow then
+                        // tells the agent to stop waiting instead of leaving the run parked.
+                        await client.agents.sendSignal(agentId, 'FileBatchClosed', {
+                            batch_id: batchId,
+                            file_ids: uploadedFileIds,
+                        } as ConversationFileBatchRef);
+                    } catch (batchErr) {
+                        console.error('Failed to close staged file batch:', batchErr);
                     }
                     setStagedFiles([]);
                 }

--- a/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentConversation.tsx
@@ -933,44 +933,31 @@ function StartWorkflowView({
             if (newRun) {
                 const agentId = newRun.agent_run_id;
 
-                // Upload staged files to the new run's artifact space and signal agent
-                const uploadedFiles: string[] = [];
+                // Upload the staged files inline, NOT via the conversation view: consumers like
+                // StudioAssistantPanel feed the new agentRunId straight back as a prop, which
+                // switches ModernAgentConversation to its agentRunId branch and unmounts this
+                // view — any state handoff dies with it. Inline client calls survive regardless
+                // of what renders next. deliver_when_ready makes the workflow itself deliver the
+                // "[Files Ready]" turn once processing settles, so no follow-up signal is sent
+                // here and delivery does not depend on this client staying alive.
                 if (canStageFiles && stagedFiles.length > 0) {
                     for (const file of stagedFiles) {
                         try {
                             const artifactPath = `files/${file.name}`;
                             await client.agents.uploadArtifact(agentId, artifactPath, file);
-
-                            // Signal agent that file was uploaded
                             await client.agents.sendSignal(agentId, 'FileUploaded', {
                                 id: `file-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
                                 name: file.name,
                                 content_type: file.type || 'application/octet-stream',
                                 reference: `artifact:${artifactPath}`,
                                 artifact_path: artifactPath,
+                                deliver_when_ready: true,
                             } as ConversationFileRef);
-                            uploadedFiles.push(file.name);
                         } catch (uploadErr) {
                             console.error(`Failed to upload staged file ${file.name}:`, uploadErr);
                             // Continue with other files
                         }
                     }
-
-                    // Send a follow-up message to notify the agent that all files are ready
-                    if (uploadedFiles.length > 0) {
-                        try {
-                            await client.agents.sendSignal(agentId, 'UserInput', {
-                                message: `[Files Ready] All ${uploadedFiles.length} file(s) have been uploaded and are now available: ${uploadedFiles.join(', ')}. You can now process them.`,
-                                metadata: {
-                                    type: 'files_ready',
-                                    files: uploadedFiles,
-                                },
-                            } as UserInputSignal);
-                        } catch (signalErr) {
-                            console.error('Failed to send files ready signal:', signalErr);
-                        }
-                    }
-
                     setStagedFiles([]);
                 }
 

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/AttachmentPreview.test.ts
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/AttachmentPreview.test.ts
@@ -1,6 +1,6 @@
 import { type AgentMessage, AgentMessageType } from '@vertesia/common';
 import { describe, expect, it } from 'vitest';
-import { collectDeliveredArtifactRefs } from './AttachmentPreview';
+import { collectDeliveredArtifactRefs, parseUserMessageAttachments } from './AttachmentPreview';
 
 function question(message: string, details?: AgentMessage['details']): AgentMessage {
     return {
@@ -13,7 +13,68 @@ function question(message: string, details?: AgentMessage['details']): AgentMess
     };
 }
 
+describe('parseUserMessageAttachments', () => {
+    // Filenames with parentheses (browser download suffixes like "report (6).json") flow
+    // verbatim into artifact hrefs. A first-closing-paren href capture made these lines fail
+    // to parse: the file rendered as raw text and its chip outlived delivery because the
+    // reference never reached collectDeliveredArtifactRefs.
+    it('parses hrefs containing parentheses', () => {
+        const parsed = parseUserMessageAttachments(
+            'Look at this.\n\nUploaded artifacts:\n[report (6).json](artifact:files/report (6).json)',
+        );
+
+        expect(parsed.body).toBe('Look at this.');
+        expect(parsed.attachments).toHaveLength(1);
+        expect(parsed.attachments[0].name).toBe('report (6).json');
+        expect(parsed.attachments[0].href).toBe('artifact:files/report (6).json');
+        expect(parsed.attachments[0].artifactPath).toBe('files/report (6).json');
+    });
+
+    it('splits href from trailing note even when both contain parentheses', () => {
+        const parsed = parseUserMessageAttachments(
+            [
+                'Attachments:',
+                '- [scan (2).png](artifact:files/scan (2).png) (image - use view_image tool with path "files/scan (2).png" to see it)',
+                '- [notes (v2).pdf](artifact:files/notes (v2).pdf) (text extracted to files/notes (v2).pdf.md)',
+            ].join('\n'),
+        );
+
+        expect(parsed.attachments).toHaveLength(2);
+        expect(parsed.attachments[0].href).toBe('artifact:files/scan (2).png');
+        // The note still drives the image content-type heuristic.
+        expect(parsed.attachments[0].contentType).toBe('image/*');
+        expect(parsed.attachments[1].href).toBe('artifact:files/notes (v2).pdf');
+        expect(parsed.attachments[1].contentType).toBeUndefined();
+    });
+
+    it('keeps parsing plain links and note-suffixed links without parentheses', () => {
+        const parsed = parseUserMessageAttachments(
+            [
+                'Uploaded artifacts:',
+                '[report.pdf](artifact:files/report.pdf)',
+                '- [photo.png](artifact:files/photo.png) (image - use view_image tool with path "files/photo.png" to see it)',
+            ].join('\n'),
+        );
+
+        expect(parsed.attachments.map((a) => a.href)).toEqual([
+            'artifact:files/report.pdf',
+            'artifact:files/photo.png',
+        ]);
+        expect(parsed.attachments[1].contentType).toBe('image/*');
+    });
+});
+
 describe('collectDeliveredArtifactRefs', () => {
+    it('collects references for filenames containing parentheses', () => {
+        const refs = collectDeliveredArtifactRefs([
+            question(
+                '[Files Ready] All 1 file(s)...\n\nUploaded artifacts:\n[filaments-bundle (6).json](artifact:files/filaments-bundle (6).json)',
+            ),
+        ]);
+
+        expect(refs).toEqual(new Set(['artifact:files/filaments-bundle (6).json', 'files/filaments-bundle (6).json']));
+    });
+
     it('collects attachment references from persisted user messages', () => {
         const refs = collectDeliveredArtifactRefs([
             question('Review this.\n\nUploaded artifacts:\n[report.pdf](artifact:files/report.pdf)'),

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/AttachmentPreview.test.ts
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/AttachmentPreview.test.ts
@@ -47,6 +47,20 @@ describe('parseUserMessageAttachments', () => {
         expect(parsed.attachments[1].contentType).toBeUndefined();
     });
 
+    // The previous regex pair backtracked polynomially on lines packed with ") (" sequences
+    // (CodeQL js/polynomial-redos). The scanner must stay linear and still pick the rightmost
+    // note split — the same split the greedy regex produced.
+    it('handles pathological paren-dense lines in linear time with the rightmost note split', () => {
+        const hostile = `[a](${') ('.repeat(20_000)}x) (note)`;
+        const started = performance.now();
+        const parsed = parseUserMessageAttachments(`Uploaded artifacts:\n${hostile}`);
+        expect(performance.now() - started).toBeLessThan(200);
+
+        expect(parsed.attachments).toHaveLength(1);
+        expect(parsed.attachments[0].href).toBe(`${') ('.repeat(20_000)}x`);
+        expect(parsed.attachments[0].contentType).toBeUndefined();
+    });
+
     it('keeps parsing plain links and note-suffixed links without parentheses', () => {
         const parsed = parseUserMessageAttachments(
             [

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/AttachmentPreview.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/AttachmentPreview.tsx
@@ -379,14 +379,47 @@ export function AttachmentPreviewList({
 }
 
 const ATTACHMENT_SECTION_RE = /^\s*(?:\*\*)?(attachments|uploaded artifacts):(?:\*\*)?\s*$/i;
-// Hrefs mirror user filenames, so they can contain parentheses and spaces
-// ("artifact:files/report (6).json"). A [^)]-style href capture truncates at the first ")",
-// making the whole line fail to parse — the file then renders as plain text and its reference
-// escapes collectDeliveredArtifactRefs. Match the note-suffixed form first (workflow-composed
-// lines end with "(image - ...)" / "(text extracted to ...)"), then fall back to
-// greedy-to-last-paren for plain links.
-const ATTACHMENT_LINK_WITH_NOTE_RE = /^\s*(?:[-*]\s*)?\[([^\]]+)]\((.+)\)\s+\((.*)\)\s*$/;
-const ATTACHMENT_LINK_RE = /^\s*(?:[-*]\s*)?\[([^\]]+)]\((.+)\)\s*$/;
+
+const SINGLE_WHITESPACE_RE = /\s/;
+
+interface AttachmentLineParts {
+    name: string;
+    href: string;
+    note?: string;
+}
+
+/**
+ * Parse one attachment line of the form `- [label](href)` or `- [label](href) (note)`.
+ *
+ * Hrefs mirror user filenames, so they can contain parentheses and spaces
+ * ("artifact:files/report (6).json"), and workflow-composed lines append a parenthesized note
+ * ("(image - ...)", "(text extracted to ...)") that can itself contain parentheses. A regex for
+ * that shape needs overlapping greedy captures, which backtrack polynomially on message content
+ * (CodeQL js/polynomial-redos) — so the line is split with a linear scan instead: the label runs
+ * to the first "]", and the note starts at the rightmost "(" preceded by whitespace and a ")",
+ * which is the same split the greedy href capture would have produced.
+ */
+function parseAttachmentLine(trimmed: string): AttachmentLineParts | null {
+    let text = trimmed;
+    if (text.startsWith('-') || text.startsWith('*')) {
+        text = text.slice(1).trimStart();
+    }
+    if (!text.startsWith('[') || !text.endsWith(')')) return null;
+    const labelEnd = text.indexOf(']');
+    if (labelEnd < 2 || text[labelEnd + 1] !== '(') return null;
+    const name = text.slice(1, labelEnd);
+    // Everything between "](" and the final ")": either the whole href, or "href) (note".
+    const body = text.slice(labelEnd + 2, -1);
+    for (let open = body.lastIndexOf('('); open > 0; open = body.lastIndexOf('(', open - 1)) {
+        let wsStart = open;
+        while (wsStart > 0 && SINGLE_WHITESPACE_RE.test(body[wsStart - 1])) {
+            wsStart--;
+        }
+        if (wsStart === open || wsStart < 2 || body[wsStart - 1] !== ')') continue;
+        return { name, href: body.slice(0, wsStart - 1), note: body.slice(open + 1) };
+    }
+    return body ? { name, href: body } : null;
+}
 
 export function parseUserMessageAttachments(content: string): ParsedUserAttachments {
     const lines = content.split(/\r?\n/);
@@ -411,14 +444,14 @@ export function parseUserMessageAttachments(content: string): ParsedUserAttachme
             continue;
         }
 
-        const match = ATTACHMENT_LINK_WITH_NOTE_RE.exec(trimmed) ?? ATTACHMENT_LINK_RE.exec(trimmed);
-        if (!match) {
+        const parsed = parseAttachmentLine(trimmed);
+        if (!parsed) {
             inAttachmentSection = false;
             bodyLines.push(line);
             continue;
         }
 
-        const [, name, href, note] = match;
+        const { name, href, note } = parsed;
         const artifactPath = href.startsWith('artifact:') ? href.slice('artifact:'.length) : undefined;
         attachments.push({
             id: `${href}-${attachments.length}`,

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/AttachmentPreview.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/AttachmentPreview.tsx
@@ -379,7 +379,14 @@ export function AttachmentPreviewList({
 }
 
 const ATTACHMENT_SECTION_RE = /^\s*(?:\*\*)?(attachments|uploaded artifacts):(?:\*\*)?\s*$/i;
-const ATTACHMENT_LINK_RE = /^\s*(?:[-*]\s*)?\[([^\]]+)]\(([^)]+)\)(?:\s+\((.*)\))?\s*$/;
+// Hrefs mirror user filenames, so they can contain parentheses and spaces
+// ("artifact:files/report (6).json"). A [^)]-style href capture truncates at the first ")",
+// making the whole line fail to parse — the file then renders as plain text and its reference
+// escapes collectDeliveredArtifactRefs. Match the note-suffixed form first (workflow-composed
+// lines end with "(image - ...)" / "(text extracted to ...)"), then fall back to
+// greedy-to-last-paren for plain links.
+const ATTACHMENT_LINK_WITH_NOTE_RE = /^\s*(?:[-*]\s*)?\[([^\]]+)]\((.+)\)\s+\((.*)\)\s*$/;
+const ATTACHMENT_LINK_RE = /^\s*(?:[-*]\s*)?\[([^\]]+)]\((.+)\)\s*$/;
 
 export function parseUserMessageAttachments(content: string): ParsedUserAttachments {
     const lines = content.split(/\r?\n/);
@@ -404,7 +411,7 @@ export function parseUserMessageAttachments(content: string): ParsedUserAttachme
             continue;
         }
 
-        const match = ATTACHMENT_LINK_RE.exec(trimmed);
+        const match = ATTACHMENT_LINK_WITH_NOTE_RE.exec(trimmed) ?? ATTACHMENT_LINK_RE.exec(trimmed);
         if (!match) {
             inAttachmentSection = false;
             bodyLines.push(line);

--- a/packages/ui/src/features/agent/chat/hooks/useFileProcessing.test.tsx
+++ b/packages/ui/src/features/agent/chat/hooks/useFileProcessing.test.tsx
@@ -232,4 +232,42 @@ describe('useFileProcessing', () => {
 
         expect(result.current.processingFiles.has('file-1')).toBe(false);
     });
+
+    it('drops a staged local entry when the server marks that file consumed', async () => {
+        const client = createClient();
+        const toast = vi.fn();
+        const { result, rerender } = renderHook(
+            ({ updates }) => useFileProcessing(client, 'agent-run-1', updates, toast),
+            { initialProps: { updates: new Map<string, ConversationFile>() } },
+        );
+
+        const file = new File(['pdf'], 'report.pdf', { type: 'application/pdf' });
+        await act(async () => {
+            await result.current.handleFileUpload([file]);
+        });
+        const [fileId] = Array.from(result.current.processingFiles.entries())[0];
+        expect(result.current.processingFiles.has(fileId)).toBe(true);
+
+        // The turn was consumed elsewhere (another tab, or an agent-initiated turn), so
+        // clearProcessingFiles() never ran here and the optimistic entry is still staged.
+        // Merging local first means skipping the server update is not enough to hide it.
+        rerender({
+            updates: new Map<string, ConversationFile>([
+                [
+                    fileId,
+                    {
+                        id: fileId,
+                        name: 'report.pdf',
+                        content_type: 'application/pdf',
+                        size: 0,
+                        status: FileProcessingStatus.READY,
+                        started_at: 1_000,
+                        consumed_at: 1_100,
+                    },
+                ],
+            ]),
+        });
+
+        expect(result.current.processingFiles.has(fileId)).toBe(false);
+    });
 });

--- a/packages/ui/src/features/agent/chat/hooks/useFileProcessing.ts
+++ b/packages/ui/src/features/agent/chat/hooks/useFileProcessing.ts
@@ -113,7 +113,15 @@ export function useFileProcessing(
             // consumed_at is the workflow's authoritative delivered marker. Filter it here in
             // addition to message-history refs: older runs may lack the marker, while some
             // server-originated messages may not preserve the rendered attachment block.
-            if (!removedFileIds.has(id) && !file.consumed_at) {
+            if (file.consumed_at) {
+                // Drop any optimistic local entry as well. clearProcessingFiles() normally
+                // retires it when this client sends the message, but a turn consumed
+                // elsewhere (another tab, or an agent-initiated turn) leaves this session's
+                // chip staged. Skipping the server update alone would keep it visible.
+                merged.delete(id);
+                return;
+            }
+            if (!removedFileIds.has(id)) {
                 // Server updates are authoritative for status, but may omit fields the local
                 // optimistic entry already knows: preview_url is never sent by the server, and
                 // artifact_path/reference can be absent on some updates. Backfill them from local


### PR DESCRIPTION
## Summary
- Files staged before a conversation exists were announced with a client-sent "[Files Ready]" message fired right after upload — before text extraction finished — so the delivering turn attached an empty artifact list and real delivery slipped to the user's next reply. Delivery also depended on the client surviving the whole extraction.
- New `ConversationFileBatchRef` type + `FileBatchClosed` signal: the start screen uploads inline, then closes the batch with a manifest naming the successfully registered file ids. The conversation workflow (implemented alongside this change) delivers the "[Files Ready]" turn itself once every listed file settles — the manifest is the batch's authoritative membership, so a fast first file can never trigger delivery while later files are still uploading, and an all-failed upload still closes the batch so the agent is told to stop waiting.
- Ports the `consumed_at` local-chip drop into `useFileProcessing` so composer chips clear when a turn this client did not send consumes the files.
- Replaces the attachment-link regex parser with a linear scanner: hrefs mirror filenames and can contain parentheses (`report (6).json`), and the regex form needed overlapping greedy captures with polynomial backtracking (CodeQL js/polynomial-redos). The scanner produces the identical split.

## Verification
- `packages/ui`: vitest green (incl. staged-upload manifest, chip-drop, paren-filename, and ReDoS-input parser tests), `tsc -p tsconfig.test.json`, biome clean
- `pnpm build` (rollup) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtpMmWKtYinfeSzCvAhLEM