### PR TITLE
chore(deps, security): fix audit findings

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -42,12 +42,29 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-          cache: pnpm
+          package-manager-cache: false
+      - name: Locate pnpm store
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "${GITHUB_OUTPUT}"
+      - name: Restore pnpm store cache
+        id: pnpm-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: pnpm-store-${{ runner.os }}-${{ runner.arch }}-
       - name: Validate Renovate config
         run: pnpm run ci:renovate
       - name: Install workspace dependencies
         timeout-minutes: 5
         run: pnpm install --frozen-lockfile
+      - name: Save pnpm store cache
+        if: github.event_name == 'push' && steps.pnpm-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ steps.pnpm-cache.outputs.cache-primary-key }}
       - name: Check codebase
         timeout-minutes: 5
         run: pnpm check

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -44,7 +44,18 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-          cache: "pnpm"
+          package-manager-cache: false
+      - name: Locate pnpm store
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "${GITHUB_OUTPUT}"
+      - name: Restore pnpm store cache
+        id: pnpm-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: pnpm-store-${{ runner.os }}-${{ runner.arch }}-
       - name: Install pandoc
         uses: pandoc/actions/setup@86321b6dd4675f5014c611e05088e10d4939e09e # v1.1.1
       - name: Install native test dependencies
@@ -55,6 +66,12 @@ jobs:
       - name: Install workspace dependencies
         timeout-minutes: 5
         run: pnpm install
+      - name: Save pnpm store cache
+        if: github.event_name == 'push' && steps.pnpm-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ steps.pnpm-cache.outputs.cache-primary-key }}
       - name: Build workspace
         timeout-minutes: 10
         run: pnpm build
@@ -80,10 +97,27 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-          cache: "pnpm"
+          package-manager-cache: false
+      - name: Locate pnpm store
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "${GITHUB_OUTPUT}"
+      - name: Restore pnpm store cache
+        id: pnpm-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: pnpm-store-${{ runner.os }}-${{ runner.arch }}-
       - name: Install workspace dependencies
         timeout-minutes: 5
         run: pnpm install
+      - name: Save pnpm store cache
+        if: github.event_name == 'push' && steps.pnpm-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ steps.pnpm-cache.outputs.cache-primary-key }}
       - name: Build workspace
         timeout-minutes: 10
         run: pnpm build

--- a/.github/workflows/publish-koa.yaml
+++ b/.github/workflows/publish-koa.yaml
@@ -68,9 +68,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 
-      # Ensure npm 11.5.1 or later is installed
-      - name: Update npm
-        run: npm install -g npm@latest
+      # Node.js 24 ships with npm 11.5.1 or later, as required for trusted publishing.
       - name: Verify npm version
         run: npm --version
 

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -68,9 +68,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 
-      # Ensure npm 11.5.1 or later is installed
-      - name: Update npm
-        run: npm install -g npm@latest
+      # Node.js 24 ships with npm 11.5.1 or later, as required for trusted publishing.
       - name: Verify npm version
         run: npm --version
 

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Run zizmor
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: uvx zizmor@1.24.1 --no-exit-codes --persona=auditor --format=sarif .github llumiverse/.github > results.sarif
+        run: uvx zizmor@1.29.0 --no-exit-codes --persona=auditor --format=sarif .github llumiverse/.github > results.sarif
 
       - name: Upload SARIF
         if: ${{ !cancelled() }}

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -33,6 +33,17 @@
   ],
   "prConcurrentLimit": 40,
   "labels": ["dependencies"],
+  "customManagers": [
+    {
+      "description": "Update the zizmor version pinned in its GitHub Actions workflow",
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/zizmor\\.ya?ml$/"],
+      "matchStrings": ["uvx\\s+zizmor@(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)"],
+      "depNameTemplate": "zizmor",
+      "datasourceTemplate": "pypi",
+      "versioningTemplate": "pep440"
+    }
+  ],
   "npm": {
     // Extend Renovate's default npm manager configuration to include .template files.
     "managerFilePatterns": [

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -76,7 +76,7 @@
         "katex": "^0.18.1",
         "lodash-es": "^4.18.1",
         "lucide-react": "^1.27.0",
-        "mermaid": "^11.16.0",
+        "mermaid": "^11.16.1",
         "monaco-editor": "^0.56.0",
         "motion": "^12.42.2",
         "papaparse": "^5.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ overrides:
   '@grpc/grpc-js@>=1.14.0 <1.14.4': ~1.14.4
   form-data@>=4.0.0 <4.0.6: ^4.0.6
   postcss@<8.5.23: 8.5.23
-  js-yaml@>=4.0.0 <4.3.0: 4.3.0
+  js-yaml@>=4.0.0 <4.3.1: 4.3.1
   js-yaml@>=5.0.0 <5.2.2: 5.2.2
   protobufjs@<=7.6.4: 7.6.5
   serialize-javascript@<=7.0.2: ^7.0.3
@@ -941,8 +941,8 @@ importers:
         specifier: ^1.27.0
         version: 1.28.0(react@19.2.7)
       mermaid:
-        specifier: ^11.16.0
-        version: 11.16.0
+        specifier: ^11.16.1
+        version: 11.16.1
       monaco-editor:
         specifier: ^0.56.0
         version: 0.56.0
@@ -5473,8 +5473,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   js-yaml@5.2.2:
@@ -5811,8 +5811,8 @@ packages:
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
-  mermaid@11.16.0:
-    resolution: {integrity: sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==}
+  mermaid@11.16.1:
+    resolution: {integrity: sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==}
 
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -11577,7 +11577,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -12046,7 +12046,7 @@ snapshots:
 
   merge-stream@2.0.0: {}
 
-  mermaid@11.16.0:
+  mermaid@11.16.1:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
       '@iconify/utils': 3.1.0
@@ -12359,7 +12359,7 @@ snapshots:
       glob: 10.5.0
       he: 1.2.0
       is-path-inside: 3.0.3
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       log-symbols: 4.1.0
       minimatch: 9.0.9
       ms: 2.1.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,6 +21,8 @@ minimumReleaseAgeExclude:
   - "@llumiverse/*"
   # Renovate security update: js-yaml@5.2.2
   - js-yaml@5.2.2
+  - js-yaml@4.3.1
+  - mermaid@11.16.1
   # GHSA-mh99-v99m-4gvg backport to the 2.x line, published 2026-07-30. Version-scoped exception
   # so we take the fix now rather than waiting out the 3-day cooldown.
   - brace-expansion@2.1.4
@@ -82,7 +84,7 @@ overrides:
   # GHSA-fxqj-rqcc-2cmp: incomplete fix of GHSA-6g55-p6wh-862q (attacker-controlled
   # sourceMappingURL reads arbitrary .map files when `from` is unset).
   postcss@<8.5.23: 8.5.23
-  js-yaml@>=4.0.0 <4.3.0: 4.3.0
+  "js-yaml@>=4.0.0 <4.3.1": 4.3.1
   # GHSA-pm4m-ph32-ghv5 (5.x line, reached via packages/build-tools). This lockfile already
   # resolves 5.2.2; the floor pins that in place so a future resolution cannot drop back to a
   # vulnerable 5.x. Major-scoped on purpose — a bare `js-yaml@<5.2.2` would drag the 4.x


### PR DESCRIPTION
## Summary
- update Mermaid and js-yaml to patched versions and refresh the lockfile
- upgrade zizmor to 1.29.0 and configure Renovate to track future PyPI releases
- keep pnpm caching fast while restricting cache writes to trusted push events
- remove ad-hoc global npm upgrades from publishing workflows
- include llumiverse security workflow updates from https://github.com/vertesia/llumiverse/pull/577

## Test Plan
- [x] `pnpm audit`
- [x] `pnpm lint:actions`
- [x] `pnpm run ci:renovate`
- [x] `uvx zizmor@1.29.0 --persona=auditor .github`
- [x] `pnpm --filter @vertesia/ui lint`
- [x] `pnpm --filter @vertesia/ui build`
- [x] `pnpm --filter @vertesia/ui typecheck:test`
- [x] `pnpm --filter @vertesia/ui test`
