### PR TITLE
fix: route and create overflow tab shared component

### DIFF
--- a/packages/ui/src/core/components/shadcn/index.ts
+++ b/packages/ui/src/core/components/shadcn/index.ts
@@ -14,6 +14,7 @@ export * from './LanguageSwitcher';
 export * from './label';
 export * from './MessageBox';
 export * from './modal';
+export * from './overflowTabs';
 export * from './Panel';
 export * from './popover';
 export * from './radioGroup';

--- a/packages/ui/src/core/components/shadcn/overflowTabs.tsx
+++ b/packages/ui/src/core/components/shadcn/overflowTabs.tsx
@@ -1,0 +1,320 @@
+import { useUITranslation } from '@vertesia/ui/i18n';
+import { ChevronDownIcon } from 'lucide-react';
+import { type ReactNode, useEffect, useLayoutEffect, useRef, useState } from 'react';
+
+import { cn } from '../libs/utils';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from './dropdown';
+
+/** Gap between tab items, in px — must match the `gap-1` used by the rendered rows. */
+export const OVERFLOW_TAB_GAP_PX = 4;
+
+export type OverflowTabsVariant = 'tabs' | 'pills';
+
+/** Tab-item styling, matching the corresponding `TabsTrigger` variants. */
+const VARIANT_CLASSES: Record<OverflowTabsVariant, { base: string; active: string; inactive: string; icon: string }> = {
+    tabs: {
+        base: 'flex items-center border-b-2 px-2 py-1.5 text-sm font-medium whitespace-nowrap cursor-pointer shrink-0',
+        inactive: 'border-transparent text-muted-foreground hover:border-border hover:text-foreground',
+        active: 'border-primary text-primary',
+        icon: 'ms-1 size-4',
+    },
+    pills: {
+        base: 'flex items-center rounded-md px-2 py-1 text-xs font-medium whitespace-nowrap cursor-pointer shrink-0',
+        inactive: 'text-muted-foreground hover:bg-muted/60',
+        active: 'bg-muted text-foreground',
+        icon: 'ms-0.5 size-3.5',
+    },
+};
+
+export interface OverflowTabsLayout<T> {
+    /** Attach to the element whose width bounds the row; its `clientWidth` is what tabs are fitted into. */
+    containerRef: React.RefObject<HTMLDivElement | null>;
+    /** Ref callback for the i-th item of the hidden measurement row. */
+    setItemRef: (index: number) => (el: HTMLElement | null) => void;
+    /** Ref callback for the "More" button of the hidden measurement row. */
+    setMoreRef: (el: HTMLElement | null) => void;
+    /** Items that fit; when the active item overflowed it is promoted into the last slot. */
+    visible: T[];
+    /** Items that did not fit and belong in the "More" menu. */
+    overflow: T[];
+    /** Whether the active item ended up in `overflow` (used to highlight the "More" trigger). */
+    activeInOverflow: boolean;
+}
+
+/**
+ * Splits `items` into a visible row and an overflow list, measured from a hidden row that renders
+ * every item at its natural width (see {@link OverflowTabsBar} for the expected markup). The active
+ * item is promoted into the last visible slot when it would otherwise be hidden in the menu.
+ *
+ * Callers own the rendering, so the hidden row must use the same classes and content as the visible
+ * one — otherwise the measured widths don't describe what is actually laid out.
+ */
+export function useOverflowTabs<T>(
+    items: T[],
+    isActive: (item: T) => boolean,
+    gap = OVERFLOW_TAB_GAP_PX,
+): OverflowTabsLayout<T> {
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    const itemRefs = useRef<Array<HTMLElement | null>>([]);
+    const moreRef = useRef<HTMLElement | null>(null);
+    // `count` leading items are shown. When `promote` is set, the active item is pulled
+    // into the last slot (before More) and `count` counts the items shown before it.
+    const [layout, setLayout] = useState<{ count: number; promote: boolean }>({
+        count: items.length,
+        promote: false,
+    });
+
+    const recompute = () => {
+        const container = containerRef.current;
+        if (!container) return;
+        const containerWidth = container.clientWidth;
+        const widths = items.map((_, i) => itemRefs.current[i]?.offsetWidth ?? 0);
+        const totalAll = widths.reduce((sum, w) => sum + w, 0) + gap * Math.max(0, items.length - 1);
+
+        // How many items (in order, optionally skipping one) fit within `available`.
+        const fitCount = (available: number, skipIndex: number) => {
+            let used = 0;
+            let fitted = 0;
+            for (let i = 0; i < items.length; i++) {
+                if (i === skipIndex) continue;
+                const cand = used + (fitted > 0 ? gap : 0) + widths[i];
+                if (cand > available) break;
+                used = cand;
+                fitted += 1;
+            }
+            return fitted;
+        };
+
+        let next: { count: number; promote: boolean };
+        if (totalAll <= containerWidth) {
+            next = { count: items.length, promote: false };
+        } else {
+            const moreWidth = moreRef.current?.offsetWidth ?? 0;
+            const naturalCount = Math.max(1, fitCount(containerWidth - moreWidth - gap, -1));
+            const activeIndex = items.findIndex(isActive);
+            if (activeIndex < 0 || activeIndex < naturalCount) {
+                next = { count: naturalCount, promote: false };
+            } else {
+                // Active item overflowed: reserve its slot at the end, fit leading items before it.
+                const leadAvailable = containerWidth - moreWidth - widths[activeIndex] - gap * 2;
+                next = { count: fitCount(leadAvailable, activeIndex), promote: true };
+            }
+        }
+        setLayout((prev) => (prev.count === next.count && prev.promote === next.promote ? prev : next));
+    };
+
+    // Re-measure after every render (item/label changes) and on container resize.
+    const recomputeRef = useRef(recompute);
+    recomputeRef.current = recompute;
+    useLayoutEffect(() => {
+        recomputeRef.current();
+    });
+    useEffect(() => {
+        const container = containerRef.current;
+        if (!container || typeof ResizeObserver === 'undefined') return;
+        const observer = new ResizeObserver(() => recomputeRef.current());
+        observer.observe(container);
+        return () => observer.disconnect();
+    }, []);
+
+    const activeIndex = items.findIndex(isActive);
+    let visible: T[];
+    let overflow: T[];
+    if (layout.promote && activeIndex >= 0) {
+        // Pull the active item into the last visible slot; the item it displaces overflows.
+        const others = items.filter((_, i) => i !== activeIndex);
+        visible = [...others.slice(0, layout.count), items[activeIndex]];
+        overflow = others.slice(layout.count);
+    } else {
+        visible = items.slice(0, layout.count);
+        overflow = items.slice(layout.count);
+    }
+
+    return {
+        containerRef,
+        setItemRef: (index: number) => (el: HTMLElement | null) => {
+            itemRefs.current[index] = el;
+        },
+        setMoreRef: (el: HTMLElement | null) => {
+            moreRef.current = el;
+        },
+        visible,
+        overflow,
+        activeInOverflow: overflow.some(isActive),
+    };
+}
+
+export interface OverflowMoreMenuProps {
+    label: ReactNode;
+    /** Classes for the trigger button — pass the same tab-item classes the row uses. */
+    triggerClassName?: string;
+    /** Icon after the label; the hidden measurement row must render the same one. */
+    icon?: ReactNode;
+    /** The menu entries, normally `DropdownMenuItem`s rendered by the caller. */
+    children: ReactNode;
+}
+
+/** Trailing "More" dropdown of overflowed tabs; opens on hover, click, or keyboard. */
+export function OverflowMoreMenu({ label, triggerClassName, icon, children }: OverflowMoreMenuProps) {
+    const [open, setOpen] = useState(false);
+    const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const openedByHover = useRef(false);
+
+    const cancelClose = () => {
+        if (closeTimer.current) {
+            clearTimeout(closeTimer.current);
+            closeTimer.current = null;
+        }
+    };
+    const openOnHover = () => {
+        cancelClose();
+        openedByHover.current = true;
+        setOpen(true);
+    };
+    // Delay the close so the pointer can travel across the gap onto the menu.
+    const closeAfterDelay = () => {
+        cancelClose();
+        closeTimer.current = setTimeout(() => setOpen(false), 150);
+    };
+
+    // Clear any pending close timer on unmount.
+    useEffect(() => () => clearTimeout(closeTimer.current ?? undefined), []);
+
+    return (
+        // Non-modal: a modal menu sets body `pointer-events: none` while open, which makes
+        // the hover open/close flap. It still closes on outside-click / Escape.
+        <DropdownMenu
+            modal={false}
+            open={open}
+            onOpenChange={(next) => {
+                // Fired by click / keyboard / dismiss (not by hover); keep our state in sync.
+                cancelClose();
+                if (next) openedByHover.current = false;
+                setOpen(next);
+            }}
+        >
+            <DropdownMenuTrigger asChild>
+                {/* Tab-bar primitive: raw button is the menu trigger (asChild). */}
+                <button
+                    type="button"
+                    onMouseEnter={openOnHover}
+                    onMouseLeave={closeAfterDelay}
+                    className={triggerClassName}
+                >
+                    {label}
+                    {icon ?? <ChevronDownIcon className="ms-1 size-4" />}
+                </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+                align="end"
+                className="w-max"
+                onMouseEnter={cancelClose}
+                onMouseLeave={closeAfterDelay}
+                onCloseAutoFocus={(e) => {
+                    // Keep hover-opens from returning the focus ring to the trigger.
+                    if (openedByHover.current) e.preventDefault();
+                }}
+            >
+                {children}
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+}
+
+/** Minimal tab shape the bar needs; the richer core `Tab` satisfies it as-is. */
+export interface OverflowTab {
+    name: string;
+    label: ReactNode;
+    disabled?: boolean;
+}
+
+export interface OverflowTabsBarProps {
+    tabs: OverflowTab[];
+    current: string;
+    onTabChange: (name: string) => void;
+    /** `tabs` draws the underline bar (default), `pills` the compact rounded row. */
+    variant?: OverflowTabsVariant;
+    className?: string;
+}
+
+/**
+ * Tabs as a horizontal row; any that don't fit collapse into a trailing "More" dropdown. Unlike
+ * `TabsBar` this is a bar only — it does not own the panels — so it suits tab rows whose content is
+ * rendered by the caller. The visible/overflow split is measured from a hidden full-width row.
+ */
+export function OverflowTabsBar({ tabs, current, onTabChange, variant = 'tabs', className }: OverflowTabsBarProps) {
+    const { t } = useUITranslation();
+    const styles = VARIANT_CLASSES[variant];
+    const { containerRef, setItemRef, setMoreRef, visible, overflow, activeInOverflow } = useOverflowTabs(
+        tabs,
+        (tab) => tab.name === current,
+    );
+    const moreLabel = t('agent.moreTabs');
+
+    return (
+        <div ref={containerRef} className={cn('relative', className)}>
+            {/* Hidden measurement row: all tabs + More at natural width, kept separate
+                from the visible row so measuring can't feed back into the layout. */}
+            <div aria-hidden className="pointer-events-none invisible absolute start-0 top-0 flex w-max gap-1">
+                {tabs.map((tab, i) => (
+                    <button
+                        type="button"
+                        key={tab.name}
+                        tabIndex={-1}
+                        ref={setItemRef(i)}
+                        className={cn(styles.base, styles.inactive)}
+                    >
+                        {tab.label}
+                    </button>
+                ))}
+                <button type="button" tabIndex={-1} ref={setMoreRef} className={cn(styles.base, styles.inactive)}>
+                    {moreLabel}
+                    <ChevronDownIcon className={styles.icon} />
+                </button>
+            </div>
+
+            {/* Visible row */}
+            <div className={cn('flex gap-1 overflow-hidden', variant === 'tabs' && '-mb-px border-b')}>
+                {visible.map((tab) => {
+                    const isActive = tab.name === current;
+                    return (
+                        // Tab-bar primitive: raw button mirrors core TabsTrigger styling.
+                        <button
+                            type="button"
+                            key={tab.name}
+                            aria-current={isActive ? 'page' : undefined}
+                            disabled={tab.disabled}
+                            onClick={() => onTabChange(tab.name)}
+                            className={cn(
+                                styles.base,
+                                isActive ? styles.active : styles.inactive,
+                                'disabled:pointer-events-none disabled:opacity-50',
+                            )}
+                        >
+                            {tab.label}
+                        </button>
+                    );
+                })}
+
+                {overflow.length > 0 && (
+                    <OverflowMoreMenu
+                        label={moreLabel}
+                        triggerClassName={cn(styles.base, activeInOverflow ? styles.active : styles.inactive)}
+                        icon={<ChevronDownIcon className={styles.icon} />}
+                    >
+                        {overflow.map((tab) => (
+                            <DropdownMenuItem
+                                key={tab.name}
+                                disabled={tab.disabled}
+                                onClick={() => onTabChange(tab.name)}
+                                className={cn(tab.name === current && 'text-primary')}
+                            >
+                                {tab.label}
+                            </DropdownMenuItem>
+                        ))}
+                    </OverflowMoreMenu>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/packages/ui/src/features/agent/chat/AgentRightPanel.tsx
+++ b/packages/ui/src/features/agent/chat/AgentRightPanel.tsx
@@ -5,10 +5,7 @@ import {
     Button,
     Center,
     cn,
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
+    OverflowTabsBar,
     type Tab as TabDefinition,
     Tabs,
     TabsPanel,
@@ -18,7 +15,6 @@ import { useUITranslation } from '@vertesia/ui/i18n';
 import { useUserSession } from '@vertesia/ui/session';
 import {
     CheckCircleIcon,
-    ChevronDownIcon,
     ClipboardCopyIcon,
     DownloadCloudIcon,
     FileTextIcon,
@@ -27,7 +23,7 @@ import {
     XCircleIcon,
     XIcon,
 } from 'lucide-react';
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { ArtifactsTab } from './ArtifactsTab.js';
 import { BrowserUseWidget, getLatestBrowserUseByWorkstream } from './BrowserUseWidget.js';
 import { DocumentPanel } from './DocumentPanel.js';
@@ -342,252 +338,6 @@ function WorkstreamsTab({ workstreams, messages, runId }: WorkstreamsTabProps) {
                         </RightPanelErrorBoundary>
                     );
                 })}
-            </div>
-        </div>
-    );
-}
-
-// ---------------------------------------------------------------------------
-// Overflow tab bar
-// ---------------------------------------------------------------------------
-
-// Tab-item styling, matching core's TabsTrigger underline tabs.
-const TAB_ITEM_BASE =
-    'flex items-center border-b-2 px-2 py-1.5 text-sm font-medium whitespace-nowrap cursor-pointer shrink-0';
-const TAB_ITEM_INACTIVE = 'border-transparent text-muted-foreground hover:border-border hover:text-foreground';
-const TAB_ITEM_ACTIVE = 'border-primary text-primary';
-const TAB_GAP_PX = 4; // matches the `gap-1` between tab items
-
-interface OverflowMoreMenuProps {
-    /** The overflowed tabs to list inside the menu. */
-    tabs: TabDefinition[];
-    current: string;
-    onTabChange: (name: string) => void;
-    label: string;
-    /** Whether the active tab is one of the overflowed tabs. */
-    active: boolean;
-}
-
-/** Trailing "More" dropdown of overflowed tabs; opens on hover, click, or keyboard. */
-function OverflowMoreMenu({ tabs, current, onTabChange, label, active }: OverflowMoreMenuProps) {
-    const [open, setOpen] = useState(false);
-    const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const openedByHover = useRef(false);
-
-    const cancelClose = () => {
-        if (closeTimer.current) {
-            clearTimeout(closeTimer.current);
-            closeTimer.current = null;
-        }
-    };
-    const openOnHover = () => {
-        cancelClose();
-        openedByHover.current = true;
-        setOpen(true);
-    };
-    // Delay the close so the pointer can travel across the gap onto the menu.
-    const closeAfterDelay = () => {
-        cancelClose();
-        closeTimer.current = setTimeout(() => setOpen(false), 150);
-    };
-
-    // Clear any pending close timer on unmount.
-    useEffect(() => () => clearTimeout(closeTimer.current ?? undefined), []);
-
-    return (
-        // Non-modal: a modal menu sets body `pointer-events: none` while open, which makes
-        // the hover open/close flap. It still closes on outside-click / Escape.
-        <DropdownMenu
-            modal={false}
-            open={open}
-            onOpenChange={(next) => {
-                // Fired by click / keyboard / dismiss (not by hover); keep our state in sync.
-                cancelClose();
-                if (next) openedByHover.current = false;
-                setOpen(next);
-            }}
-        >
-            <DropdownMenuTrigger asChild>
-                {/* Tab-bar primitive: raw button is the menu trigger (asChild). */}
-                <button
-                    type="button"
-                    onMouseEnter={openOnHover}
-                    onMouseLeave={closeAfterDelay}
-                    className={cn(TAB_ITEM_BASE, active ? TAB_ITEM_ACTIVE : TAB_ITEM_INACTIVE)}
-                >
-                    {label}
-                    <ChevronDownIcon className="ms-1 size-4" />
-                </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-                align="end"
-                className="w-max"
-                onMouseEnter={cancelClose}
-                onMouseLeave={closeAfterDelay}
-                onCloseAutoFocus={(e) => {
-                    // Keep hover-opens from returning the focus ring to the trigger.
-                    if (openedByHover.current) e.preventDefault();
-                }}
-            >
-                {tabs.map((tab) => (
-                    <DropdownMenuItem
-                        key={tab.name}
-                        disabled={tab.disabled}
-                        onClick={() => onTabChange(tab.name)}
-                        className={cn(tab.name === current && 'text-primary')}
-                    >
-                        {tab.label}
-                    </DropdownMenuItem>
-                ))}
-            </DropdownMenuContent>
-        </DropdownMenu>
-    );
-}
-
-interface OverflowTabsBarProps {
-    tabs: TabDefinition[];
-    current: string;
-    onTabChange: (name: string) => void;
-    className?: string;
-}
-
-/**
- * Tabs as a horizontal row; any that don't fit collapse into a trailing "More"
- * dropdown. The visible/overflow split is measured from a hidden full-width row.
- */
-function OverflowTabsBar({ tabs, current, onTabChange, className }: OverflowTabsBarProps) {
-    const { t } = useUITranslation();
-    const containerRef = useRef<HTMLDivElement | null>(null);
-    const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
-    const moreRef = useRef<HTMLButtonElement | null>(null);
-    // `count` leading tabs are shown. When `promote` is set, the active tab is pulled
-    // into the last slot (before More) and `count` counts the tabs shown before it.
-    const [layout, setLayout] = useState<{ count: number; promote: boolean }>({ count: tabs.length, promote: false });
-
-    const recompute = () => {
-        const container = containerRef.current;
-        if (!container) return;
-        const containerWidth = container.clientWidth;
-        const widths = tabs.map((_, i) => itemRefs.current[i]?.offsetWidth ?? 0);
-        const totalAll = widths.reduce((sum, w) => sum + w, 0) + TAB_GAP_PX * Math.max(0, tabs.length - 1);
-
-        // How many tabs (in order, optionally skipping one) fit within `available`.
-        const fitCount = (available: number, skipIndex: number) => {
-            let used = 0;
-            let count = 0;
-            for (let i = 0; i < tabs.length; i++) {
-                if (i === skipIndex) continue;
-                const cand = used + (count > 0 ? TAB_GAP_PX : 0) + widths[i];
-                if (cand > available) break;
-                used = cand;
-                count += 1;
-            }
-            return count;
-        };
-
-        let next: { count: number; promote: boolean };
-        if (totalAll <= containerWidth) {
-            next = { count: tabs.length, promote: false };
-        } else {
-            const moreWidth = moreRef.current?.offsetWidth ?? 0;
-            const naturalCount = Math.max(1, fitCount(containerWidth - moreWidth - TAB_GAP_PX, -1));
-            const activeIndex = tabs.findIndex((tab) => tab.name === current);
-            if (activeIndex < 0 || activeIndex < naturalCount) {
-                next = { count: naturalCount, promote: false };
-            } else {
-                // Active tab overflowed: reserve its slot at the end, fit leading tabs before it.
-                const leadAvailable = containerWidth - moreWidth - widths[activeIndex] - TAB_GAP_PX * 2;
-                next = { count: fitCount(leadAvailable, activeIndex), promote: true };
-            }
-        }
-        setLayout((prev) => (prev.count === next.count && prev.promote === next.promote ? prev : next));
-    };
-
-    // Re-measure after every render (tab/label changes) and on container resize.
-    const recomputeRef = useRef(recompute);
-    recomputeRef.current = recompute;
-    useLayoutEffect(() => {
-        recomputeRef.current();
-    });
-    useEffect(() => {
-        const container = containerRef.current;
-        if (!container || typeof ResizeObserver === 'undefined') return;
-        const observer = new ResizeObserver(() => recomputeRef.current());
-        observer.observe(container);
-        return () => observer.disconnect();
-    }, []);
-
-    const activeIndex = tabs.findIndex((tab) => tab.name === current);
-    let visible: TabDefinition[];
-    let overflow: TabDefinition[];
-    if (layout.promote && activeIndex >= 0) {
-        // Pull the active tab into the last visible slot; the tab it displaces overflows.
-        const others = tabs.filter((_, i) => i !== activeIndex);
-        visible = [...others.slice(0, layout.count), tabs[activeIndex]];
-        overflow = others.slice(layout.count);
-    } else {
-        visible = tabs.slice(0, layout.count);
-        overflow = tabs.slice(layout.count);
-    }
-    const activeInOverflow = overflow.some((tab) => tab.name === current);
-    const moreLabel = t('agent.moreTabs');
-
-    return (
-        <div ref={containerRef} className={cn('relative', className)}>
-            {/* Hidden measurement row: all tabs + More at natural width, kept separate
-                from the visible row so measuring can't feed back into the layout. */}
-            <div aria-hidden className="pointer-events-none invisible absolute start-0 top-0 flex w-max gap-1">
-                {tabs.map((tab, i) => (
-                    <button
-                        type="button"
-                        key={tab.name}
-                        tabIndex={-1}
-                        ref={(el) => {
-                            itemRefs.current[i] = el;
-                        }}
-                        className={cn(TAB_ITEM_BASE, TAB_ITEM_INACTIVE)}
-                    >
-                        {tab.label}
-                    </button>
-                ))}
-                <button type="button" tabIndex={-1} ref={moreRef} className={cn(TAB_ITEM_BASE, TAB_ITEM_INACTIVE)}>
-                    {moreLabel}
-                    <ChevronDownIcon className="ms-1 size-4" />
-                </button>
-            </div>
-
-            {/* Visible row */}
-            <div className="-mb-px flex gap-1 overflow-hidden border-b">
-                {visible.map((tab) => {
-                    const isActive = tab.name === current;
-                    return (
-                        // Tab-bar primitive: raw button mirrors core TabsTrigger underline styling.
-                        <button
-                            type="button"
-                            key={tab.name}
-                            aria-current={isActive ? 'page' : undefined}
-                            disabled={tab.disabled}
-                            onClick={() => onTabChange(tab.name)}
-                            className={cn(
-                                TAB_ITEM_BASE,
-                                isActive ? TAB_ITEM_ACTIVE : TAB_ITEM_INACTIVE,
-                                'disabled:pointer-events-none disabled:opacity-50',
-                            )}
-                        >
-                            {tab.label}
-                        </button>
-                    );
-                })}
-
-                {overflow.length > 0 && (
-                    <OverflowMoreMenu
-                        tabs={overflow}
-                        current={current}
-                        onTabChange={onTabChange}
-                        label={moreLabel}
-                        active={activeInOverflow}
-                    />
-                )}
             </div>
         </div>
     );

--- a/packages/ui/src/features/agent/chat/ModernAgentOutput/WorkstreamTabs.tsx
+++ b/packages/ui/src/features/agent/chat/ModernAgentOutput/WorkstreamTabs.tsx
@@ -1,8 +1,7 @@
 import type { AgentMessage } from '@vertesia/common';
-import { cn, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@vertesia/ui/core';
+import { cn, DropdownMenuItem, OverflowMoreMenu, useOverflowTabs } from '@vertesia/ui/core';
 import { i18nInstance, NAMESPACE, useUITranslation } from '@vertesia/ui/i18n';
 import { CheckCircle, ChevronDown, Clock } from 'lucide-react';
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { getWorkstreamId } from './utils';
 
 interface WorkstreamTabsProps {
@@ -19,7 +18,6 @@ const TAB_ITEM_BASE =
     'flex items-center gap-1.5 px-2 py-1 text-xs font-medium whitespace-nowrap transition-colors border-b-2 shrink-0 cursor-pointer';
 const TAB_ITEM_INACTIVE = 'border-transparent text-muted hover:bg-muted';
 const TAB_ITEM_ACTIVE = 'border-info bg-info text-info';
-const TAB_GAP_PX = 4; // matches the `gap-1` between tab items
 
 // Shorten long workstream names for the tab row.
 function truncateName(name: string) {
@@ -50,93 +48,39 @@ function WorkstreamMoreMenu({
     count,
     completionStatus,
 }: WorkstreamMoreMenuProps) {
-    const [open, setOpen] = useState(false);
-    const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const openedByHover = useRef(false);
-
-    const cancelClose = () => {
-        if (closeTimer.current) {
-            clearTimeout(closeTimer.current);
-            closeTimer.current = null;
-        }
-    };
-    const openOnHover = () => {
-        cancelClose();
-        openedByHover.current = true;
-        setOpen(true);
-    };
-    // Delay the close so the pointer can travel across the gap onto the menu.
-    const closeAfterDelay = () => {
-        cancelClose();
-        closeTimer.current = setTimeout(() => setOpen(false), 150);
-    };
-
-    // Clear any pending close timer on unmount.
-    useEffect(() => () => clearTimeout(closeTimer.current ?? undefined), []);
-
     return (
-        // Non-modal: a modal menu sets body `pointer-events: none` while open, which makes
-        // the hover open/close flap. It still closes on outside-click / Escape.
-        <DropdownMenu
-            modal={false}
-            open={open}
-            onOpenChange={(next) => {
-                // Fired by click / keyboard / dismiss (not by hover); keep our state in sync.
-                cancelClose();
-                if (next) openedByHover.current = false;
-                setOpen(next);
-            }}
+        <OverflowMoreMenu
+            label={label}
+            triggerClassName={cn(TAB_ITEM_BASE, active ? TAB_ITEM_ACTIVE : TAB_ITEM_INACTIVE)}
+            icon={<ChevronDown className="ms-0.5 size-3.5" />}
         >
-            <DropdownMenuTrigger asChild>
-                {/* Tab-bar primitive: raw button is the menu trigger (asChild). */}
-                <button
-                    type="button"
-                    onMouseEnter={openOnHover}
-                    onMouseLeave={closeAfterDelay}
-                    className={cn(TAB_ITEM_BASE, active ? TAB_ITEM_ACTIVE : TAB_ITEM_INACTIVE)}
-                >
-                    {label}
-                    <ChevronDown className="ms-0.5 size-3.5" />
-                </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-                align="end"
-                className="w-max"
-                onMouseEnter={cancelClose}
-                onMouseLeave={closeAfterDelay}
-                onCloseAutoFocus={(e) => {
-                    // Keep hover-opens from returning the focus ring to the trigger.
-                    if (openedByHover.current) e.preventDefault();
-                }}
-            >
-                {items.map(([id, name]) => {
-                    const showCount = (count?.get(id) ?? 0) > 0;
-                    return (
-                        <DropdownMenuItem
-                            key={id}
-                            onClick={() => onSelect(id)}
-                            className={cn('flex items-center gap-2', id === current && 'text-info')}
-                        >
-                            <span className="truncate">{name}</span>
-                            {showCount && (
-                                <span className="ms-auto inline-flex items-center gap-1">
-                                    <span className="inline-flex items-center justify-center rounded-full bg-muted px-1.5 text-[10px] text-muted">
-                                        {count?.get(id)}
-                                    </span>
-                                    {completionStatus &&
-                                        id !== 'all' &&
-                                        (completionStatus.get(id) ? (
-                                            <CheckCircle className="size-3 text-success" />
-                                        ) : (
-                                            <Clock className="size-3 text-attention" />
-                                        ))}
+            {items.map(([id, name]) => {
+                const showCount = (count?.get(id) ?? 0) > 0;
+                return (
+                    <DropdownMenuItem
+                        key={id}
+                        onClick={() => onSelect(id)}
+                        className={cn('flex items-center gap-2', id === current && 'text-info')}
+                    >
+                        <span className="truncate">{name}</span>
+                        {showCount && (
+                            <span className="ms-auto inline-flex items-center gap-1">
+                                <span className="inline-flex items-center justify-center rounded-full bg-muted px-1.5 text-[10px] text-muted">
+                                    {count?.get(id)}
                                 </span>
-                            )}
-                        </DropdownMenuItem>
-                    );
-                })}
-            </DropdownMenuContent>
-        </DropdownMenu>
+                                {completionStatus &&
+                                    id !== 'all' &&
+                                    (completionStatus.get(id) ? (
+                                        <CheckCircle className="size-3 text-success" />
+                                    ) : (
+                                        <Clock className="size-3 text-attention" />
+                                    ))}
+                            </span>
+                        )}
+                    </DropdownMenuItem>
+                );
+            })}
+        </OverflowMoreMenu>
     );
 }
 
@@ -161,82 +105,10 @@ function WorkstreamOverflowBar({
     completionStatus,
 }: WorkstreamOverflowBarProps) {
     const { t } = useUITranslation();
-    const containerRef = useRef<HTMLDivElement | null>(null);
-    const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
-    const moreRef = useRef<HTMLButtonElement | null>(null);
-    // `count` leading tabs are shown. When `promote` is set, the active tab is pulled
-    // into the last slot (before More) and `count` counts the tabs shown before it.
-    const [layout, setLayout] = useState<{ count: number; promote: boolean }>({
-        count: entries.length,
-        promote: false,
-    });
-
-    const recompute = () => {
-        const container = containerRef.current;
-        if (!container) return;
-        const containerWidth = container.clientWidth;
-        const widths = entries.map((_, i) => itemRefs.current[i]?.offsetWidth ?? 0);
-        const totalAll = widths.reduce((sum, w) => sum + w, 0) + TAB_GAP_PX * Math.max(0, entries.length - 1);
-
-        // How many tabs (in order, optionally skipping one) fit within `available`.
-        const fitCount = (available: number, skipIndex: number) => {
-            let used = 0;
-            let fitted = 0;
-            for (let i = 0; i < entries.length; i++) {
-                if (i === skipIndex) continue;
-                const cand = used + (fitted > 0 ? TAB_GAP_PX : 0) + widths[i];
-                if (cand > available) break;
-                used = cand;
-                fitted += 1;
-            }
-            return fitted;
-        };
-
-        let next: { count: number; promote: boolean };
-        if (totalAll <= containerWidth) {
-            next = { count: entries.length, promote: false };
-        } else {
-            const moreWidth = moreRef.current?.offsetWidth ?? 0;
-            const naturalCount = Math.max(1, fitCount(containerWidth - moreWidth - TAB_GAP_PX, -1));
-            const activeIndex = entries.findIndex(([id]) => id === activeWorkstream);
-            if (activeIndex < 0 || activeIndex < naturalCount) {
-                next = { count: naturalCount, promote: false };
-            } else {
-                // Active tab overflowed: reserve its slot at the end, fit leading tabs before it.
-                const leadAvailable = containerWidth - moreWidth - widths[activeIndex] - TAB_GAP_PX * 2;
-                next = { count: fitCount(leadAvailable, activeIndex), promote: true };
-            }
-        }
-        setLayout((prev) => (prev.count === next.count && prev.promote === next.promote ? prev : next));
-    };
-
-    // Re-measure after every render (tab/label changes) and on container resize.
-    const recomputeRef = useRef(recompute);
-    recomputeRef.current = recompute;
-    useLayoutEffect(() => {
-        recomputeRef.current();
-    });
-    useEffect(() => {
-        const container = containerRef.current;
-        if (!container || typeof ResizeObserver === 'undefined') return;
-        const observer = new ResizeObserver(() => recomputeRef.current());
-        observer.observe(container);
-        return () => observer.disconnect();
-    }, []);
-
-    const activeIndex = entries.findIndex(([id]) => id === activeWorkstream);
-    let visible: WorkstreamEntry[];
-    let overflow: WorkstreamEntry[];
-    if (layout.promote && activeIndex >= 0) {
-        // Pull the active tab into the last visible slot; the tab it displaces overflows.
-        const others = entries.filter((_, i) => i !== activeIndex);
-        visible = [...others.slice(0, layout.count), entries[activeIndex]];
-        overflow = others.slice(layout.count);
-    } else {
-        visible = entries.slice(0, layout.count);
-        overflow = entries.slice(layout.count);
-    }
-    const activeInOverflow = overflow.some(([id]) => id === activeWorkstream);
+    const { containerRef, setItemRef, setMoreRef, visible, overflow, activeInOverflow } = useOverflowTabs(
+        entries,
+        ([id]) => id === activeWorkstream,
+    );
     const moreLabel = t('agent.moreTabs');
 
     // Inner tab content (name + count badge + completion icon), shared by the hidden
@@ -280,15 +152,13 @@ function WorkstreamOverflowBar({
                         type="button"
                         key={id}
                         tabIndex={-1}
-                        ref={(el) => {
-                            itemRefs.current[i] = el;
-                        }}
+                        ref={setItemRef(i)}
                         className={cn(TAB_ITEM_BASE, TAB_ITEM_INACTIVE)}
                     >
                         {renderTabInner(id, name, false)}
                     </button>
                 ))}
-                <button type="button" tabIndex={-1} ref={moreRef} className={cn(TAB_ITEM_BASE, TAB_ITEM_INACTIVE)}>
+                <button type="button" tabIndex={-1} ref={setMoreRef} className={cn(TAB_ITEM_BASE, TAB_ITEM_INACTIVE)}>
                     {moreLabel}
                     <ChevronDown className="ms-0.5 size-3.5" />
                 </button>

--- a/packages/ui/src/features/facets/AgentRunnerFacetsNav.tsx
+++ b/packages/ui/src/features/facets/AgentRunnerFacetsNav.tsx
@@ -21,6 +21,8 @@ interface AgentRunnerFacetsNavProps {
         statuses?: FacetBucket[];
         initiated_by?: FacetBucket[];
         interactions?: EnrichedFacetBucket[];
+        /** `run_kind` buckets — `agent` (autonomous runs) and `process` (process runs). */
+        kinds?: FacetBucket[];
     };
     search: SearchInterface;
     actions?: React.ReactNode[];
@@ -46,6 +48,14 @@ export function useAgentRunnerFilterGroups(facets: AgentRunnerFacetsNavProps['fa
         type: 'text',
         multiple: false,
     });
+
+    customFilterGroups.push(
+        VStringFacet({
+            buckets: facets.kinds || [],
+            name: 'run_kind',
+            placeholder: 'Kind',
+        }),
+    );
 
     customFilterGroups.push(
         VInteractionFacet({
@@ -154,7 +164,7 @@ export function AgentRunnerFacetsNav({
                         {!selectionCount && (
                             <div className="flex items-center justify-between px-2 py-1">
                                 <div className="text-sm text-muted-foreground">
-                                    {search.initialized ? `${search.totalCount} agent runs` : 'Loading agent runs...'}
+                                    {search.initialized ? `${search.totalCount} runs` : 'Loading runs...'}
                                 </div>
                             </div>
                         )}

--- a/packages/ui/src/features/layout/GenericPageNavHeader.tsx
+++ b/packages/ui/src/features/layout/GenericPageNavHeader.tsx
@@ -17,10 +17,6 @@ interface GenericPageNavHeaderProps {
     /**
      * Parent page linked from the breadcrumbs when there is no history chain to walk (the user
      * landed on this URL directly). Give it as an absolute app path, including the module mount.
-     *
-     * Without it the parent is inferred as the current path minus its id segment, which is wrong
-     * whenever the collection page lives elsewhere — e.g. `/store/process-runs/:id`, whose list
-     * page is `/store/processes` (`/store/process-runs` is not a route).
      */
     parentPath?: string;
     /** Label for {@link parentPath}; defaults to its last segment, title-cased. */
@@ -109,7 +105,7 @@ export function GenericPageNavHeader({
                 items.push({
                     label: parentLabel ?? buildBreadcrumbLabel({ href: parentPath }),
                     href: parentPath,
-                    onClick: () => navigate(parentPath, { isBasePathNested: false }),
+                    onClick: () => navigate(parentPath, { isBasePathNested: false, replace: true }),
                 });
             } else {
                 // Infer parents from URL when navigating directly to a detail page

--- a/packages/ui/src/features/layout/GenericPageNavHeader.tsx
+++ b/packages/ui/src/features/layout/GenericPageNavHeader.tsx
@@ -14,6 +14,17 @@ interface GenericPageNavHeaderProps {
     children?: ReactNode;
     className?: string;
     useDynamicBreadcrumbs?: boolean;
+    /**
+     * Parent page linked from the breadcrumbs when there is no history chain to walk (the user
+     * landed on this URL directly). Give it as an absolute app path, including the module mount.
+     *
+     * Without it the parent is inferred as the current path minus its id segment, which is wrong
+     * whenever the collection page lives elsewhere — e.g. `/store/process-runs/:id`, whose list
+     * page is `/store/processes` (`/store/process-runs` is not a route).
+     */
+    parentPath?: string;
+    /** Label for {@link parentPath}; defaults to its last segment, title-cased. */
+    parentLabel?: string;
 }
 
 interface BreadcrumbElementProps {
@@ -43,6 +54,8 @@ export function GenericPageNavHeader({
     actions,
     breadcrumbs,
     useDynamicBreadcrumbs = true,
+    parentPath,
+    parentLabel,
 }: GenericPageNavHeaderProps) {
     const navigate = useNavigate();
 
@@ -90,6 +103,13 @@ export function GenericPageNavHeader({
                         href: entry.href,
                         onClick: () => navigate(entry.href, { stepsBack: stepsBack }),
                     });
+                });
+            } else if (parentPath) {
+                // Caller knows where this page belongs; skip the URL inference below.
+                items.push({
+                    label: parentLabel ?? buildBreadcrumbLabel({ href: parentPath }),
+                    href: parentPath,
+                    onClick: () => navigate(parentPath, { isBasePathNested: false }),
                 });
             } else {
                 // Infer parents from URL when navigating directly to a detail page


### PR DESCRIPTION
## Description

- Made the overflow tab a shared component
  <img width="400" height="512" alt="Screenshot 2026-08-07 at 12 11 02" src="https://github.com/user-attachments/assets/e72d75ae-ffd0-4963-b9b8-71f51c045163" />

---

> When user lands to a page with the link, the breadcrumbs always use the parents path, which might cause some mismatch
- pass a `parent path` parameter, which will override the route 