### PR TITLE
fix: align ABAC condition evaluation

### DIFF
--- a/packages/studio-utils/src/conditions/index.ts
+++ b/packages/studio-utils/src/conditions/index.ts
@@ -1,1 +1,1 @@
-export { matchConditions, matchLike, resolvePath } from './match.js';
+export { matchConditions, matchLike, resolveConditions, resolvePath } from './match.js';

--- a/packages/studio-utils/src/conditions/match.test.ts
+++ b/packages/studio-utils/src/conditions/match.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { installStudioUtilsLogger, type StudioUtilsLogger } from '../logger.js';
-import { matchConditions, matchLike, resolvePath } from './index.js';
+import { matchConditions, matchLike, resolveConditions, resolvePath } from './index.js';
 
 describe('resolvePath', () => {
     it('resolves top-level fields and one-level properties fields', () => {
@@ -58,6 +58,23 @@ describe('matchConditions', () => {
         expect(matchConditions({ code: { $gt: 'a' } }, { code: 'b' })).toBe(true);
     });
 
+    it('matches set operators against scalar and array-valued object fields', () => {
+        expect(
+            matchConditions({ compartments: { $in: ['finance', 'legal'] } }, { compartments: ['hr', 'finance'] }),
+        ).toBe(true);
+        expect(matchConditions({ compartments: { $in: ['finance'] } }, { compartments: ['hr'] })).toBe(false);
+        expect(matchConditions({ compartments: { $nin: ['finance'] } }, { compartments: ['hr'] })).toBe(true);
+        expect(matchConditions({ compartments: { $nin: ['finance'] } }, { compartments: ['hr', 'finance'] })).toBe(
+            false,
+        );
+    });
+
+    it('uses Mongo-compatible equality for scalar conditions on array-valued fields', () => {
+        expect(matchConditions({ tags: 'finance' }, { tags: ['audit', 'finance'] })).toBe(true);
+        expect(matchConditions({ tags: { $eq: 'finance' } }, { tags: ['audit', 'finance'] })).toBe(true);
+        expect(matchConditions({ tags: { $ne: 'finance' } }, { tags: ['audit', 'finance'] })).toBe(false);
+    });
+
     it('treats unknown operators as non-matches', () => {
         const logger: StudioUtilsLogger = {
             warn: vi.fn(),
@@ -71,5 +88,47 @@ describe('matchConditions', () => {
         );
 
         installStudioUtilsLogger(previousLogger);
+    });
+});
+
+describe('resolveConditions', () => {
+    it('resolves scalar and array principal references', () => {
+        expect(
+            resolveConditions(
+                {
+                    sensitivity: { $lte: '$principal.clearance' },
+                    compartments: { $in: '$principal.compartments' },
+                    'properties.department': '$principal.properties.department',
+                },
+                {
+                    clearance: 3,
+                    compartments: ['finance'],
+                    properties: { department: 'finance' },
+                },
+            ),
+        ).toEqual({
+            sensitivity: { $lte: 3 },
+            compartments: { $in: ['finance'] },
+            'properties.department': 'finance',
+        });
+    });
+
+    it('uses deterministic defaults for missing principal fields', () => {
+        expect(
+            resolveConditions(
+                {
+                    sensitivity: { $lte: '$principal.clearance' },
+                    compartments: { $in: '$principal.compartments' },
+                    active: { $exists: '$principal.active' },
+                    department: '$principal.properties.department',
+                },
+                {},
+            ),
+        ).toEqual({
+            sensitivity: { $lte: 0 },
+            compartments: { $in: [] },
+            active: { $exists: false },
+            department: '',
+        });
     });
 });

--- a/packages/studio-utils/src/conditions/match.ts
+++ b/packages/studio-utils/src/conditions/match.ts
@@ -56,6 +56,20 @@ function compareOrdered(value: unknown, expected: unknown, op: '$gt' | '$gte' | 
     }
 }
 
+function matchesEquality(value: unknown, expected: unknown): boolean {
+    if (Array.isArray(value) && !Array.isArray(expected)) {
+        return value.includes(expected);
+    }
+    if (Array.isArray(value) && Array.isArray(expected)) {
+        return value.length === expected.length && value.every((entry, index) => entry === expected[index]);
+    }
+    return value === expected;
+}
+
+function matchesAny(value: unknown, expected: unknown[]): boolean {
+    return Array.isArray(value) ? value.some((entry) => expected.includes(entry)) : expected.includes(value);
+}
+
 /**
  * Evaluate a PropertyConditions object against a set of properties (JS-side, in-memory).
  *
@@ -80,9 +94,8 @@ function compareOrdered(value: unknown, expected: unknown, op: '$gt' | '$gte' | 
  * Unknown operators emit a warning via the studio-utils logger and return false — surfacing
  * misconfiguration loudly without breaking the surrounding token mint or permission check.
  *
- * `$principal.X` substitutions in conditions are expected to have already been resolved at
- * JWT-mint time by `resolveConditions` in token-server; values reaching this function are
- * concrete.
+ * `$principal.X` substitutions in conditions are expected to have already been resolved by
+ * {@link resolveConditions}; values reaching this function are concrete.
  */
 export function matchConditions(conditions: PropertyConditions, properties: Record<string, unknown>): boolean {
     for (const [key, condition] of Object.entries(conditions)) {
@@ -90,17 +103,17 @@ export function matchConditions(conditions: PropertyConditions, properties: Reco
 
         if (condition === null || condition === undefined || typeof condition !== 'object') {
             // Direct value match
-            if (value !== condition) return false;
+            if (!matchesEquality(value, condition)) return false;
         } else {
             // Operator object
             const ops = condition as Record<string, unknown>;
             for (const [op, expected] of Object.entries(ops)) {
                 switch (op) {
                     case '$eq':
-                        if (value !== expected) return false;
+                        if (!matchesEquality(value, expected)) return false;
                         break;
                     case '$ne':
-                        if (value === expected) return false;
+                        if (matchesEquality(value, expected)) return false;
                         break;
                     case '$gt':
                         if (!compareOrdered(value, expected, '$gt')) return false;
@@ -115,10 +128,10 @@ export function matchConditions(conditions: PropertyConditions, properties: Reco
                         if (!compareOrdered(value, expected, '$lte')) return false;
                         break;
                     case '$in':
-                        if (!Array.isArray(expected) || !expected.includes(value)) return false;
+                        if (!Array.isArray(expected) || !matchesAny(value, expected)) return false;
                         break;
                     case '$nin':
-                        if (Array.isArray(expected) && expected.includes(value)) return false;
+                        if (Array.isArray(expected) && matchesAny(value, expected)) return false;
                         break;
                     case '$exists':
                         if (typeof expected !== 'boolean' || (value !== undefined) !== expected) return false;
@@ -143,4 +156,67 @@ export function matchConditions(conditions: PropertyConditions, properties: Reco
         }
     }
     return true;
+}
+
+const PRINCIPAL_REF_PREFIX = '$principal.';
+const NUMERIC_OPS = new Set(['$gt', '$gte', '$lt', '$lte']);
+
+/**
+ * Resolve `$principal.X` references in resource conditions to concrete values.
+ *
+ * Missing properties use the same non-matching defaults as token generation:
+ * numeric comparisons receive `0`, `$in`/`$nin` receive `[]`, `$exists`
+ * receives `false`, and other contexts receive an empty string.
+ */
+export function resolveConditions(
+    conditions: PropertyConditions,
+    principalProps: Record<string, unknown>,
+): PropertyConditions {
+    const resolved: PropertyConditions = {};
+
+    for (const [key, condition] of Object.entries(conditions)) {
+        if (typeof condition === 'string' && condition.startsWith(PRINCIPAL_REF_PREFIX)) {
+            resolved[key] = resolvePrincipalRef(condition, principalProps);
+        } else if (condition !== null && typeof condition === 'object' && !Array.isArray(condition)) {
+            resolved[key] = resolveOperatorObject(condition as Record<string, unknown>, principalProps);
+        } else {
+            resolved[key] = condition;
+        }
+    }
+
+    return resolved;
+}
+
+function resolvePrincipalRef(ref: string, principalProps: Record<string, unknown>): unknown {
+    const value = resolvePath(principalProps, ref.slice(PRINCIPAL_REF_PREFIX.length));
+    return value === undefined ? '' : value;
+}
+
+function resolveOperatorObject(
+    operators: Record<string, unknown>,
+    principalProps: Record<string, unknown>,
+): Record<string, unknown> {
+    const resolved: Record<string, unknown> = {};
+
+    for (const [operator, value] of Object.entries(operators)) {
+        if (typeof value === 'string' && value.startsWith(PRINCIPAL_REF_PREFIX)) {
+            const principalValue = resolvePath(principalProps, value.slice(PRINCIPAL_REF_PREFIX.length));
+            resolved[operator] =
+                principalValue === undefined
+                    ? operator === '$in' || operator === '$nin'
+                        ? []
+                        : defaultForOperator(operator)
+                    : principalValue;
+        } else {
+            resolved[operator] = value;
+        }
+    }
+
+    return resolved;
+}
+
+function defaultForOperator(operator: string): string | number | boolean {
+    if (NUMERIC_OPS.has(operator)) return 0;
+    if (operator === '$exists') return false;
+    return '';
 }


### PR DESCRIPTION
## Summary
- Share principal-reference resolution with condition consumers through `@vertesia/studio-utils`.
- Align in-memory equality, `$in`, and `$nin` behavior with database matching for array-valued fields.
- Add regression coverage for principal references and array comparisons.

## Test Plan
- [x] `cd packages/studio-utils && pnpm lint`
- [x] `cd packages/studio-utils && pnpm test` — 74 tests passed
- [x] `cd packages/studio-utils && pnpm build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes permission/ABAC evaluation semantics for array fields and principal resolution; misalignment could grant or deny access incorrectly until consumers adopt the shared resolver.
> 
> **Overview**
> Centralizes **`$principal.*` resolution** in `@vertesia/studio-utils` via new **`resolveConditions`**, with the same missing-field defaults as token generation (numeric → `0`, `$in`/`$nin` → `[]`, `$exists` → `false`, else `''`).
> 
> **`matchConditions`** now treats array-valued document fields like Mongo: scalar equality/`$eq`/`$ne` match if the scalar is an element of the array; **`$in`** / **`$nin`** intersect when the field is an array (not only exact scalar membership). Docs point consumers at `resolveConditions` before in-memory matching.
> 
> Regression tests cover principal resolution and array/set operators.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a98a6b4d152846f999541bb6f349b43d40cd64f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->